### PR TITLE
docs: complete code fragment migration with VitePress imports

### DIFF
--- a/docs/code/basic-patterns.ts
+++ b/docs/code/basic-patterns.ts
@@ -77,3 +77,58 @@ describe("multiple dependencies", () => {
   })
 })
 // #endregion multiple-dependencies
+
+// #region anti-pattern-side-effects
+// [!code --:2]
+import { provide as p4 } from "@pumped-fn/core-next"
+
+// ❌ Bad: Side effects in executor factory
+const badCounter = provide(() => {
+  let count = 0
+  console.log("This runs every resolve!")
+  return { value: count++ }
+})
+
+// ✅ Good: Pure factory, side effects in usage
+const goodCounter = provide(() => {
+  return {
+    value: 0,
+    increment: () => console.log("Side effect in method")
+  }
+})
+// [!code --:7]
+
+describe("anti-pattern: side effects", () => {
+  it("shows proper pattern", () => {
+    expect(goodCounter).toBeDefined()
+  })
+})
+// #endregion anti-pattern-side-effects
+
+// #region anti-pattern-async-factory
+// [!code --:2]
+import { provide as p5 } from "@pumped-fn/core-next"
+
+// ❌ Bad: Async factory function
+// const badAsync = provide(async () => {
+//   const data = await fetch("/api")
+//   return data
+// })
+
+// ✅ Good: Sync factory, return promise
+const goodAsync = provide(() => {
+  return {
+    fetchData: async () => {
+      const data = await fetch("/api")
+      return data
+    }
+  }
+})
+// [!code --:8]
+
+describe("anti-pattern: async factory", () => {
+  it("shows correct pattern", () => {
+    expect(goodAsync).toBeDefined()
+  })
+})
+// #endregion anti-pattern-async-factory

--- a/docs/code/flow-patterns.ts
+++ b/docs/code/flow-patterns.ts
@@ -1,0 +1,83 @@
+import { flow, provide, createScope } from "@pumped-fn/core-next"
+import { describe, it, expect } from "vitest"
+import { custom } from "@pumped-fn/core-next/ssch"
+
+// #region flow-basic
+// [!code --:2]
+import { flow as f1, createScope as cs1 } from "@pumped-fn/core-next"
+
+const doubleFlow = flow((_ctx, input: number) => input * 2)
+
+const scope = createScope()
+const result = await scope.exec(doubleFlow, 5)
+console.log(result) // 10
+// [!code --:5]
+
+describe("basic flow", () => {
+  it("executes transformation", async () => {
+    expect(result).toBe(10)
+    await scope.dispose()
+  })
+})
+// #endregion flow-basic
+
+// #region flow-with-deps
+// [!code --:3]
+import { flow as f2, provide as p2, createScope as cs2 } from "@pumped-fn/core-next"
+
+const config = provide(() => ({ multiplier: 3 }))
+
+const multiplyFlow = flow(config, (cfg, _ctx, input: number) => {
+  return input * cfg.multiplier
+})
+
+const scope2 = createScope()
+const result2 = await scope2.exec(multiplyFlow, 5)
+console.log(result2) // 15
+// [!code --:6]
+
+describe("flow with dependencies", () => {
+  it("injects dependencies", async () => {
+    expect(result2).toBe(15)
+    await scope2.dispose()
+  })
+})
+// #endregion flow-with-deps
+
+// #region flow-context
+// [!code --:3]
+import { flow as f3, provide as p3, createScope as cs3 } from "@pumped-fn/core-next"
+
+const apiService = provide(() => ({
+  fetch: async (url: string) => ({ data: `from ${url}` })
+}))
+
+const fetchUser = flow(apiService, async (api, ctx, userId: number) => {
+  const response = await ctx.run("fetch-user", () =>
+    api.fetch(`/users/${userId}`)
+  )
+  return { userId, username: `user${userId}`, raw: response.data }
+})
+
+const getUserWithPosts = flow(apiService, async (api, ctx, userId: number) => {
+  const user = await ctx.exec(fetchUser, userId)
+  const posts = await ctx.run("fetch-posts", () =>
+    api.fetch(`/posts?userId=${userId}`)
+  )
+  return { ...user, postCount: 1 }
+})
+
+const scope3 = createScope()
+const result3 = await scope3.exec(getUserWithPosts, 42)
+console.log(result3) // { userId: 42, username: 'user42', raw: 'from /users/42', postCount: 1 }
+// [!code --:11]
+
+describe("flow with context", () => {
+  it("uses context for sub-flows and operations", async () => {
+    expect(result3.userId).toBe(42)
+    expect(result3.username).toBe("user42")
+    expect(result3.postCount).toBe(1)
+    await scope3.dispose()
+  })
+})
+// #endregion flow-context

--- a/docs/concepts/flows.md
+++ b/docs/concepts/flows.md
@@ -1,1 +1,89 @@
 # Flows
+
+Flows handle short-span operations within long-running scopes. While scopes manage persistent resources (databases, connections), flows process individual requests, jobs, or transactions.
+
+## Core Concepts
+
+**Scope vs Flow:**
+- **Scope**: Long-running container for shared resources
+- **Flow**: Short-lived execution with isolated context
+- **Pattern**: One scope, many flows
+
+Each flow has its own context that provides data isolation between concurrent executions. When flows spawn sub-flows, the context forks to maintain isolation.
+
+## Basic Flow
+
+A flow transforms input to output:
+
+<<< @/code/flow-patterns.ts#flow-basic{ts}
+
+**Execution:**
+- Define flow with transformation logic
+- Execute via `scope.exec(flow, input)`
+- Returns transformed output
+
+## Flow with Dependencies
+
+Inject scope-level dependencies into flows:
+
+<<< @/code/flow-patterns.ts#flow-with-deps{ts}
+
+**Dependency Injection:**
+- Dependencies resolved from scope
+- Same instance shared across flows
+- Flows remain isolated via context
+
+## Flow Context Operations
+
+Use context for journaling and sub-flow execution:
+
+<<< @/code/flow-patterns.ts#flow-context{ts}
+
+**Context Methods:**
+- `ctx.run(key, fn)`: Journaled operation, replays on retry
+- `ctx.exec(flow, input)`: Execute sub-flow with forked context
+- `ctx.get/set(accessor)`: Access flow-scoped data
+
+## Context Isolation
+
+```ts
+const requestIdAccessor = accessor("requestId", custom<string>())
+
+const logRequest = flow(async (ctx) => {
+  const id = ctx.get(requestIdAccessor)
+  console.log(`Processing: ${id}`)
+})
+
+// Concurrent executions don't interfere
+await scope.exec(logRequest, undefined, {
+  initialContext: [[requestIdAccessor, "req-1"]]
+})
+
+await scope.exec(logRequest, undefined, {
+  initialContext: [[requestIdAccessor, "req-2"]]
+})
+```
+
+## Journaling and Replay
+
+`ctx.run()` journals operations for deterministic replay:
+
+```ts
+const fetchData = flow(async (ctx) => {
+  const data = await ctx.run("fetch", () => api.call())
+  const processed = await ctx.run("process", () => transform(data))
+  return processed
+})
+
+// On failure/retry, journaled steps replay from cache
+// Only failed step re-executes
+```
+
+## When to Use Flows
+
+- **Request Handling**: HTTP requests, API calls
+- **Job Processing**: Queue workers, batch operations
+- **Transactions**: Database transactions with rollback
+- **Stateful Operations**: Multi-step processes with checkpoints
+
+Flows provide isolation, journaling, and composability for short-lived operations within persistent scopes.

--- a/docs/decisions/anti-patterns.md
+++ b/docs/decisions/anti-patterns.md
@@ -1,1 +1,87 @@
 # Anti-Patterns
+
+Common mistakes and their solutions when working with Pumped-FN.
+
+## Side Effects in Factories
+
+**Problem:** Factories should be pure functions. Side effects make executors unpredictable and hard to test.
+
+<<< @/code/basic-patterns.ts#anti-pattern-side-effects{ts}
+
+**Why it matters:**
+- Factories may be called multiple times during resolution
+- Side effects break caching assumptions
+- Makes testing and reasoning difficult
+
+**Solution:** Keep factories pure. Place side effects in methods or lifecycle hooks.
+
+## Async Factory Functions
+
+**Problem:** Factory functions must be synchronous. Async factories break the resolution model.
+
+<<< @/code/basic-patterns.ts#anti-pattern-async-factory{ts}
+
+**Why it matters:**
+- Executors resolve synchronously to values
+- Async factories create unresolved promises
+- Breaks type inference and composition
+
+**Solution:** Return an object with async methods instead of making the factory async.
+
+## Hidden Dependencies
+
+**Problem:** Accessing external state instead of declaring dependencies.
+
+```ts
+// ❌ Bad: Hidden dependency on global
+const globalConfig = { apiUrl: "https://api.example.com" }
+
+const apiClient = provide(() => ({
+  fetch: () => axios.get(globalConfig.apiUrl) // Hidden!
+}))
+
+// ✅ Good: Explicit dependency
+const config = provide(() => ({ apiUrl: "https://api.example.com" }))
+
+const apiClient = derive([config], ([cfg]) => ({
+  fetch: () => axios.get(cfg.apiUrl)
+}))
+```
+
+**Why it matters:**
+- Hidden dependencies prevent proper testing
+- Graph doesn't reflect actual dependencies
+- Can't swap implementations with presets
+
+## Mutating Resolved Values
+
+**Problem:** Mutating cached values affects other consumers.
+
+```ts
+// ❌ Bad: Mutating shared state
+const counter = provide(() => ({ count: 0 }))
+
+const incrementer = derive([counter], ([ctr]) => {
+  ctr.count++ // Mutates shared object!
+  return ctr.count
+})
+
+// ✅ Good: Return new values
+const counter = provide(() => ({ count: 0 }))
+
+const incrementer = derive([counter], ([ctr]) => {
+  return { ...ctr, count: ctr.count + 1 }
+})
+```
+
+**Why it matters:**
+- Cached values are shared across resolutions
+- Mutations create unexpected side effects
+- Breaks single-responsibility of executors
+
+## Best Practices Summary
+
+1. **Pure Factories**: No side effects, no async
+2. **Explicit Dependencies**: Declare all dependencies in arrays
+3. **Immutable Values**: Don't mutate resolved values
+4. **Clear Boundaries**: Separate scope resources from flow operations

--- a/docs/patterns/lifecycle-management.md
+++ b/docs/patterns/lifecycle-management.md
@@ -1,1 +1,54 @@
 # Lifecycle Management
+
+Executors can register cleanup handlers that run when the scope is disposed or when reactive dependencies trigger re-execution.
+
+## Basic Cleanup
+
+Register cleanup for resources that need disposal:
+
+<<< @/code/lifecycle-patterns.ts#cleanup-basic{ts}
+
+**Key Points:**
+- `controller.cleanup()` registers disposal logic
+- Cleanup runs when scope is disposed
+- Use for connections, file handles, timers
+
+## Multiple Cleanup Handlers
+
+Register multiple cleanup handlers for complex resources:
+
+<<< @/code/lifecycle-patterns.ts#cleanup-multiple{ts}
+
+**Cleanup Execution:**
+- Handlers execute in **reverse registration order** (LIFO)
+- Last registered runs first
+- Ensures proper teardown sequence
+- Async cleanup handlers are supported
+
+## Cleanup with Reactivity
+
+When reactive dependencies update, cleanup runs before re-execution:
+
+```ts
+const counter = provide(() => 0)
+
+const watcher = derive(counter.reactive, (count, controller) => {
+  controller.cleanup(() => {
+    console.log(`Cleanup for count: ${count}`)
+  })
+  return count
+})
+
+const scope = createScope()
+await scope.resolve(watcher)
+
+await scope.update(counter, 1) // Triggers cleanup then re-execution
+await scope.dispose() // Final cleanup
+```
+
+## Best Practices
+
+- **Register Early**: Add cleanup handlers during executor initialization
+- **Async Support**: Cleanup can be async, awaited during disposal
+- **Error Safety**: Errors in cleanup don't prevent other cleanups
+- **Resource Tracking**: Use arrays/sets to track multiple resources

--- a/docs/patterns/testing-strategies.md
+++ b/docs/patterns/testing-strategies.md
@@ -1,1 +1,36 @@
 # Testing Strategies
+
+Testing with Pumped-FN leverages the dependency graph to make test isolation and mocking straightforward.
+
+## Preset Mocking
+
+Use `preset` to swap executor implementations with mocks for testing.
+
+### Basic Mocking
+
+Replace a single dependency with a mock:
+
+<<< @/code/testing-patterns.ts#preset-mock-basic
+
+**Key Points:**
+- Mock replaces the real implementation
+- Downstream executors receive the mock automatically
+- Original graph structure remains intact
+
+### Multiple Dependencies
+
+Mock multiple dependencies in a single scope:
+
+<<< @/code/testing-patterns.ts#preset-multiple
+
+**Best Practices:**
+- Mock at service boundaries
+- Keep mocks simple and focused
+- Verify interactions with spy functions
+- Always dispose test scopes
+
+## When to Use Presets
+
+- **Unit Testing**: Isolate logic by mocking dependencies
+- **Integration Testing**: Mix real and mock implementations
+- **Flaky Test Debugging**: Replace unreliable services temporarily


### PR DESCRIPTION
## Summary

Completes the code fragment implementation that was partially deployed in the previous PR. This PR adds the missing documentation migrations and pattern files.

## Changes

### New Pattern Files
- ✅ `flow-patterns.ts` - Flow examples (basic, with-deps, context)
- ✅ Anti-pattern examples added to `basic-patterns.ts`

### Documentation Migrations
- ✅ `patterns/testing-strategies.md` - Uses preset mocking examples
- ✅ `patterns/lifecycle-management.md` - Uses cleanup pattern examples  
- ✅ `concepts/flows.md` - Comprehensive flow documentation
- ✅ `decisions/anti-patterns.md` - Common pitfalls and solutions

### Validation
- ✅ All pattern files include Vitest tests
- ✅ TypeScript typecheck passes
- ✅ Documentation build succeeds
- ✅ Code fragments use region markers and cut markers for clean display

## Test Results

```
✓ flow-patterns.ts (3 tests)
✓ basic-patterns.ts (5 tests)
✓ testing-patterns.ts (2 tests)
✓ VitePress build successful
```

## Related

Fixes the incomplete deployment from #71 where only `quick-start.md` and `basic-patterns.ts` were deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)