### PR TITLE
Troubleshoot Context7 Deployment Issue

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -2,7 +2,7 @@
   "$schema": "https://context7.com/schema/context7.json",
   "projectTitle": "Pumped-FN",
   "description": "Type-safe dependency injection with graph resolution for long-lived services and short-lived operations",
-  "folders": ["docs", "docs/code"],
+  "folders": ["docs"],
   "excludeFolders": ["src", "node_modules", "dist", "tests", ".git"],
   "rules": [
     "NEVER use ctx.get() or scope.resolve() inside executors - declare dependencies explicitly in arrays",


### PR DESCRIPTION
The docs/code directory doesn't exist, causing context7 deployment to fail. Removed it from the folders array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)