### PR TITLE
Restructure to official Claude Code plugin format

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,20 +6,19 @@
   },
   "metadata": {
     "description": "Official marketplace for pumped-fn Claude Code plugins",
-    "version": "1.0.0",
-    "pluginRoot": "claude-skill"
+    "version": "1.4.0"
   },
   "plugins": [
     {
       "name": "pumped-design",
-      "source": "./claude-skill",
+      "source": "./",
       "description": "Design, navigate, troubleshoot, and test pumped-fn backend applications using strict organizational patterns - provides phased design process, catalog-based navigation, and layer-specific testing strategies",
       "version": "1.4.0",
       "author": {
         "name": "lagz0ne",
         "email": "duke@silentium.io"
       },
-      "homepage": "https://github.com/pumped-fn/pumped-fn/tree/main/.claude/skills/pumped-design",
+      "homepage": "https://github.com/pumped-fn/pumped-fn/tree/main/skills/pumped-design",
       "repository": "https://github.com/pumped-fn/pumped-fn",
       "license": "MIT",
       "keywords": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,10 +3,10 @@
   "version": "1.4.0",
   "description": "Design, navigate, troubleshoot, and test pumped-fn backend applications using strict organizational patterns - provides phased design process, catalog-based navigation, and layer-specific testing strategies",
   "author": "lagz0ne",
-  "repository": "https://github.com/lagz0ne/pumped-fn",
-  "homepage": "https://github.com/lagz0ne/pumped-fn/tree/main/.claude/skills/pumped-design",
+  "repository": "https://github.com/pumped-fn/pumped-fn",
+  "homepage": "https://github.com/pumped-fn/pumped-fn/tree/main/skills/pumped-design",
   "skills": [
-    ".claude/skills/pumped-design"
+    "skills/pumped-design"
   ],
   "tags": [
     "typescript",

--- a/README-plugin.md
+++ b/README-plugin.md
@@ -104,8 +104,7 @@ The skill focuses on the three hardest concepts:
 
 For more details:
 - [Pumped-fn Documentation](https://github.com/lagz0ne/pumped-fn/tree/main/docs)
-- [Skill README](../.claude/skills/pumped-fn-typescript/README.md)
-- [Pattern Reference](../.claude/skills/pumped-fn-typescript/pattern-reference.md)
+- [Skill Reference](skills/pumped-design/references/README.md)
 
 ## Version
 

--- a/skills/pumped-design/SKILL.md
+++ b/skills/pumped-design/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: pumped-design
+description: Design, navigate, troubleshoot, and test pumped-fn backend applications using strict organizational patterns - provides phased design process, catalog-based navigation, and layer-specific testing strategies
+activate_when:
+  - file_pattern: "package.json"
+    contains: "@pumped-fn"
+  - file_pattern: "**/entrypoint.*.ts"
+  - file_pattern: "**/resource.*.ts"
+  - file_pattern: "**/flow.*.ts"
+  - directory_exists: "docs/catalog"
+---
+
+# Pumped-fn Application Design Skill
+
+## Overview
+
+Structured approach for building maintainable pumped-fn backend applications with strict organization, regression discoverability, and clear testing strategy.
+
+**Announce at start:** "I'm using the pumped-design skill to [design/navigate/troubleshoot/test] your pumped-fn application."
+
+## When to Use
+
+**Auto-activates when:**
+- package.json contains "@pumped-fn"
+- Files matching entrypoint.*.ts, resource.*.ts, flow.*.ts exist
+- docs/catalog/ directory exists
+
+| Scenario | Use This Skill |
+|----------|---------------|
+| Migrating app to pumped-fn | Yes - Apply organizational patterns |
+| Designing new backend app | Yes - Follow phased design process |
+| Adding features | Yes - Navigate catalog, identify affected flows |
+| Troubleshooting flows | Yes - Use catalog mermaid diagrams |
+| Organizing tests | Yes - Layer-specific testing strategy |
+| Code reviews | Yes - Enforce naming conventions |
+
+**Scope:**
+- Backend applications using @pumped-fn
+- Server-side patterns (HTTP, CLI, cron, Lambda)
+- Resource management, flow orchestration
+- Testing backend workflows
+
+## Sub-skill Routing
+
+**AI Workflow:**
+1. User asks question → 2. Scan routing table → 3. Read sub-skill frontmatter → 4. Load if relevant → 5. Apply patterns
+
+**MANDATORY: Load `coding-standards.md` before writing any code.**
+
+### Routing Table
+
+| Sub-skill | Tags | Load When | File |
+|-----------|------|-----------|------|
+| **Coding Standards** | coding, types, naming, style | Before writing code, reviewing code | references/coding-standards.md |
+| **Resource: Basic** | resource, add, config, lifecycle | Adding standalone resource | references/resource-basic.md |
+| **Resource: Derived** | resource, add, dependencies, derive | Resource with dependencies | references/resource-derived.md |
+| **Resource: Lazy** | resource, add, lazy, conditional | Lazy/conditional resources | references/resource-lazy.md |
+| **Flow: Sub-flows** | flow, add, reuse, orchestration | Flow calling flows | references/flow-subflows.md |
+| **Flow: Context** | flow, modify, ctx.run, ctx.exec | Context operations | references/flow-context.md |
+| **Integration: Hono** | integration, add, hono, http | Hono server setup | references/integration-hono.md |
+| **Integration: Next.js** | integration, add, nextjs, ssr | Next.js integration | references/integration-nextjs.md |
+| **Integration: TanStack** | integration, add, tanstack, router | TanStack Start | references/integration-tanstack.md |
+| **Testing: Utilities** | testing, util, unit, preset | Unit testing utilities | references/testing-utilities.md |
+| **Testing: Flows** | testing, flow, integration, branches | Integration testing flows | references/testing-flows.md |
+| **Testing: Integration** | testing, integration, e2e | E2E testing | references/testing-integration.md |
+| **Extension: Basics** | extension, add, cross-cutting, wrap | Creating extensions | references/extension-basics.md |
+| **Entrypoint: Patterns** | entrypoint, add, scope, lifecycle | Entrypoint structure | references/entrypoint-patterns.md |
+
+**Examples:**
+- "Add database resource" → `resource-basic.md`
+- "Flow cleanup issue" → `flow-context.md`, `resource-basic.md`
+- "Integrate Hono" → `coding-standards.md`, `integration-hono.md`
+- "Test my flow" → `coding-standards.md`, `testing-flows.md`
+
+## Quick Reference
+
+**File Naming:**
+- `entrypoint.*.ts` - Scope creation, env initialization
+- `resource.*.ts` - DB, logger, cache (provide/derive)
+- `flow.*.ts` - Business workflows (flow())
+- `util.*.ts` - Pure functions or executor wrappers
+
+**Testing:**
+- `util.*` → Unit tests, all edges, preset() for executors
+- `flow.*` → Integration tests, ALL branches (Success + Errors)
+- `resource.*` → Rarely tested
+- `entrypoint.*` → Smoke only
+
+**Key Patterns:**
+- Sub-flows: `await ctx.exec(subFlow, input)` - NO ctx.run() wrapper
+- Operations: `await ctx.run('step-id', () => ...)`
+- Errors: Discriminated unions, type narrowing, explicit mapping
+- Types: Never `any`, prefer `unknown`, inference for internals
+
+## Design Process
+
+When designing new app:
+1. **Understanding** - Ask questions (AskUserQuestion for choices)
+2. **Exploration** - Propose 2-3 approaches
+3. **Validation** - Present design in sections
+4. **Documentation** - Write to docs/plans/ + initial catalog
+5. **Setup** - Worktree + implementation plan
+
+Use brainstorming skill phases adapted for backend architecture.
+
+## Navigation
+
+- **Find flow:** Search docs/catalog/flows.md mermaid diagrams
+- **Find dependencies:** Check Dependencies section in catalog
+- **Find affected:** Grep catalog for component name
+- **Trace execution:** Read mermaid top-to-bottom
+
+## Critical Rules
+
+**Before ANY code generation:**
+1. Load `coding-standards.md`
+2. Check relevant sub-skill (resource/flow/integration)
+3. Apply patterns exactly
+
+**Type narrowing is mandatory:**
+- Discriminated unions (success: true/false)
+- No type assertions unless absolutely required
+- Trust TypeScript after `if (!result.success)`
+
+**Flow error handling:**
+```typescript
+const validated = await ctx.exec(validateOrder, input)
+if (!validated.success) return validated
+
+const charged = await ctx.exec(chargePayment, { amount: validated.total })
+if (!charged.success) return charged
+
+return ctx.run('finalize', () => ({ success: true, orderId: charged.id }))
+```
+
+**Testing coverage:**
+- Flow with N outputs needs N tests minimum
+- Test Success + each Error variant
+- Use preset() for all dependencies
+
+## Summary
+
+Lightweight routing skill - loads detailed patterns from references/ on-demand:
+- 14 sub-skills cover construction, integration, testing
+- Frontmatter tags enable AI routing
+- Real examples from pumped-fn tests
+- Type-safe, testable, discoverable architecture

--- a/skills/pumped-design/references/README.md
+++ b/skills/pumped-design/references/README.md
@@ -1,0 +1,27 @@
+# Pumped-Design Sub-skills
+
+This directory contains sub-skills loaded on-demand by the main pumped-design skill.
+
+## Structure
+
+Each sub-skill has:
+- **YAML frontmatter** - name, tags, description (AI reads first)
+- **Content sections** - When to use, code templates, examples, troubleshooting
+
+## Usage
+
+AI loads sub-skills based on user query:
+1. Scans main SKILL.md routing table
+2. Reads sub-skill frontmatter to assess relevance
+3. Loads full content if applicable
+4. Applies patterns to user's code
+
+## Sub-skills
+
+- `coding-standards.md` - Mandatory before writing code
+- `resource-*.md` - Resource construction patterns
+- `flow-*.md` - Flow orchestration and context
+- `integration-*.md` - Framework integration
+- `testing-*.md` - Testing strategies
+- `extension-basics.md` - Cross-cutting concerns
+- `entrypoint-patterns.md` - Application entry points

--- a/skills/pumped-design/references/coding-standards.md
+++ b/skills/pumped-design/references/coding-standards.md
@@ -1,0 +1,394 @@
+---
+name: coding-standards
+tags: coding, types, naming, organization, style, readability, economy, narrowing
+description: Type safety rules, file organization, variable naming, code economy principles. Type narrowing with discriminated unions mandatory - never use any/casting, prefer unknown and inference. Flat file structure with component-type prefixes. Functional naming without suffixes. Lines of code are expensive - maximize TypeScript features without reducing readability. Destructuring to reduce verbosity.
+---
+
+# Coding Standards for Pumped-fn Applications
+
+## Type Safety Rules
+
+### Never `any` Unless Type Inference Requires It
+
+```typescript
+// ✅ Prefer unknown
+const parseInput = (raw: unknown) => {
+  if (typeof raw === 'string') {
+    return JSON.parse(raw)
+  }
+  throw new Error('Invalid input')
+}
+
+// ❌ Avoid any
+const parseInput = (raw: any) => {  // Lost type safety
+  return JSON.parse(raw)
+}
+```
+
+### Think Twice Before Type Casting
+
+```typescript
+// ✅ Let types flow naturally
+const result = await ctx.exec(validateOrder, input)
+if (!result.success) {
+  // TypeScript knows result has 'reason' property
+  return result
+}
+
+// ❌ Don't cast when narrowing works
+const result = await ctx.exec(validateOrder, input)
+if (!result.success) {
+  return result as ValidationError  // Unnecessary
+}
+```
+
+### Internal Code Uses Type Inference
+
+```typescript
+// ✅ Let TypeScript infer flow types
+export const processOrder = flow(
+  { validateOrder, chargePayment },
+  ({ validateOrder, chargePayment }) =>
+    async (ctx, input) => {  // Types inferred from usage
+      const validated = await ctx.exec(validateOrder, input)
+      return validated
+    }
+)
+
+// ❌ Don't explicitly type internals
+export const processOrder = flow(
+  { validateOrder, chargePayment },
+  ({ validateOrder, chargePayment }) =>
+    async (ctx: FlowContext, input: OrderInput): Promise<OrderResult> => {
+      // Verbose, types already known
+    }
+)
+```
+
+### Library Exports Use Explicit Interfaces
+
+```typescript
+// ✅ Export clean interface for reusable components
+export type Logger = {
+  info: (msg: string, meta?: Record<string, unknown>) => void
+  error: (msg: string, meta?: Record<string, unknown>) => void
+}
+
+export const logger = provide((controller): Logger => {
+  const pino = createPino({ ... })
+
+  controller.cleanup(() => pino.flush())
+
+  return {
+    info: (msg, meta) => pino.info(meta, msg),
+    error: (msg, meta) => pino.error(meta, msg)
+  }
+})
+
+// ❌ Don't expose library types directly
+export const logger = provide((controller): pino.Logger => {
+  // Exposes pino's complex interface
+})
+```
+
+---
+
+## Type Narrowing is Fundamental
+
+**Principle:** Design discriminated unions, use TypeScript's type narrowing. Never cast when narrowing works.
+
+### Discriminated Unions with Type Narrowing
+
+```typescript
+export namespace ProcessOrder {
+  export type Success = { success: true; orderId: string; total: number }
+  export type ValidationError = { success: false; reason: 'INVALID_ITEMS' }
+  export type PaymentError = { success: false; reason: 'PAYMENT_DECLINED'; message: string }
+
+  export type Result = Success | ValidationError | PaymentError
+}
+
+export const processOrder = flow(
+  { validateOrder, chargePayment },
+  ({ validateOrder, chargePayment }) =>
+    async (ctx, input): Promise<ProcessOrder.Result> => {
+      const validated = await ctx.exec(validateOrder, input)
+
+      // ✅ Type narrowing via discriminator
+      if (!validated.success) {
+        // TypeScript knows: validated is ValidationError here
+        // validated.reason exists
+        return validated
+      }
+
+      // ✅ After check, TypeScript knows validated.success is true
+      // TypeScript knows: validated.orderId, validated.total exist
+      const charged = await ctx.exec(chargePayment, {
+        amount: validated.total
+      })
+
+      if (!charged.success) {
+        // TypeScript knows: charged has 'reason' property
+        return charged
+      }
+
+      // TypeScript knows: charged.transactionId exists
+      return { success: true, orderId: charged.transactionId, total: charged.amount }
+    }
+)
+```
+
+### Trust Narrowing - No Optional Chaining After Checks
+
+```typescript
+// ✅ After narrowing, don't use optional chaining
+if (validated.success) {
+  const id = validated.orderId.toString()  // Correct - narrowing proves it exists
+}
+
+// ❌ Don't use optional when narrowing guarantees
+if (validated.success) {
+  const id = validated.orderId?.toString()  // Wrong - ? is redundant
+}
+```
+
+### Key Type Narrowing Patterns
+
+1. **Always use discriminated unions** - `success: true/false`, `type: 'A' | 'B'`
+2. **Let TypeScript narrow** - `if (!result.success)` eliminates error branches
+3. **Avoid type assertions** - If you need `as`, your types are wrong
+4. **Trust narrowing** - After check, TypeScript knows the exact type
+
+---
+
+## File Organization
+
+**Principle:** Flat structure with component-type prefixes for sorting and shorter imports.
+
+### Flat Structure with Prefixes
+
+```
+src/
+  entrypoint.cli.ts
+  entrypoint.web.ts
+  entrypoint.test.ts
+  flow.order.ts
+  flow.payment.ts
+  flow.user.ts
+  resource.db.ts
+  resource.logger.ts
+  resource.cache.ts
+  util.datetime.ts
+  util.validation.ts
+  util.crypto.ts
+```
+
+**Benefits:**
+- Prefix-based alphabetical sorting (all `flow.*` together)
+- Shorter import paths: `./flow.order` vs `./flows/order`
+- Clear layer membership at a glance
+- Easy globbing: `flow.*.ts`, `resource.*.ts`
+
+### Test Files Adjacent to Source
+
+```
+src/
+  flow.order.ts
+  flow.order.test.ts
+  util.datetime.ts
+  util.datetime.test.ts
+```
+
+---
+
+## Variable Naming
+
+**Principle:** Functional naming - no prefixes or suffixes.
+
+```typescript
+// ✅ Clean functional names
+const user = await findUser(id)
+const validated = validate(input)
+const dbPool = provide(...)
+const logger = provide(...)
+
+// ❌ Avoid redundant prefixes/suffixes
+const validatedUser = validate(input)     // "validated" is redundant
+const dbPoolResource = provide(...)        // "Resource" suffix is noise
+const loggerService = provide(...)         // "Service" suffix adds nothing
+```
+
+---
+
+## Code Economy
+
+**Principle:** Lines of code are expensive. Think once on meaning, think twice before adding a line. Maximize TypeScript language features without reducing readability.
+
+### Use Language Features
+
+```typescript
+// ✅ Ternary for simple branches
+const status = validated.success ? 'ok' : 'error'
+
+// ✅ Optional chaining
+const email = user?.contact?.email
+
+// ✅ Nullish coalescing
+const port = config.port ?? 3000
+
+// ✅ Combine operations when meaningful
+return validated.success
+  ? ctx.exec(chargePayment, { amount: validated.total })
+  : validated
+
+// ✅ Inline when clear
+return ctx.exec(charge, { userId: input.userId })
+```
+
+### Avoid Unnecessary Variables
+
+```typescript
+// ❌ Don't create redundant variables
+const isSuccess = validated.success
+if (isSuccess) { ... }
+
+// ✅ Use the value directly
+if (validated.success) { ... }
+
+// ❌ Don't split unnecessarily
+const userId = input.userId
+return ctx.exec(charge, { userId })
+
+// ✅ Inline when meaningful
+return ctx.exec(charge, { userId: input.userId })
+```
+
+**Balance:** Reduce lines, preserve clarity. If removing a line makes code harder to understand, keep it.
+
+---
+
+## Destructuring for Conciseness
+
+```typescript
+// ✅ Destructure dependencies
+const userRepo = derive(
+  { db: dbPool, logger },
+  ({ db, logger }) => ({
+    findById: async (id: string) => {
+      logger.info('Finding user', { id })
+      return db.query('SELECT * FROM users WHERE id = $1', [id])
+    }
+  })
+)
+
+// ✅ Destructure in flows
+const processOrder = flow(
+  { validateOrder, chargePayment },
+  ({ validateOrder, chargePayment }) =>
+    async (ctx, input) => {
+      const validated = await ctx.exec(validateOrder, input)
+      if (!validated.success) return validated
+
+      return ctx.exec(chargePayment, { amount: validated.total })
+    }
+)
+```
+
+---
+
+## Blank Lines for Readability
+
+**Principle:** Separate logical blocks with blank lines.
+
+```typescript
+// ✅ Blank lines separate logical operations
+export const processOrder = flow(
+  { validateOrder, chargePayment },
+  ({ validateOrder, chargePayment }) =>
+    async (ctx, input) => {
+      const validated = await ctx.exec(validateOrder, input)
+
+      if (!validated.success) {
+        return validated
+      }
+
+      const charged = await ctx.exec(chargePayment, {
+        userId: input.userId,
+        amount: validated.total
+      })
+
+      if (!charged.success) {
+        return charged
+      }
+
+      return ctx.run('finalize', () => ({
+        success: true,
+        orderId: charged.id
+      }))
+    }
+)
+```
+
+---
+
+## Promised Chaining Rules
+
+**Principle:** Chain `.map()`/`.mapError()` to complete logical operations, not as default style.
+
+### Chain When Completing Logical Operation
+
+```typescript
+// ✅ Chain to transform and handle errors
+const validated = await ctx.exec(validateOrder, input)
+  .map((result) => {
+    if (!result.success) throw new Error(result.reason)
+    return result
+  })
+  .mapError((err) => ({
+    success: false,
+    reason: 'VALIDATION_FAILED'
+  }))
+
+// ✅ Also OK: Separate when clearer
+const validated = await ctx.exec(validateOrder, input)
+
+if (!validated.success) {
+  return { success: false, reason: 'VALIDATION_FAILED' }
+}
+```
+
+### Don't Chain Just Because You Can
+
+```typescript
+// ❌ Meaningless chain
+const result = await ctx.exec(validate, input)
+  .map((r) => r)  // Does nothing
+
+// ✅ Only chain when transforming
+const result = await ctx.exec(validate, input)
+```
+
+**Guideline:** Use `.map()`/`.mapError()` when you need to transform or complete error handling, not by default.
+
+---
+
+## Summary
+
+**Type Safety:**
+- Never `any`, prefer `unknown`
+- No casting - use type narrowing
+- Inference for internals, explicit for exports
+- Discriminated unions mandatory
+
+**Organization:**
+- Flat files with prefixes
+- Functional naming
+- Adjacent tests
+
+**Code Quality:**
+- Lines are expensive
+- Maximize language features
+- Preserve readability
+- Blank lines separate logic
+- Destructure for conciseness
+- Chain when meaningful

--- a/skills/pumped-design/references/entrypoint-patterns.md
+++ b/skills/pumped-design/references/entrypoint-patterns.md
@@ -1,0 +1,982 @@
+---
+name: entrypoint-patterns
+tags: entrypoint, add, scope, lifecycle, initialization, shutdown, cli, http, lambda, tags, extensions
+description: Structuring application entrypoints with createScope(), tags, and extensions. Covers environment-specific patterns (CLI, HTTP, Lambda), graceful shutdown, and scope lifecycle management.
+---
+
+# Entrypoint: Patterns
+
+## When to Use
+
+Use entrypoint patterns when:
+
+- Starting application (main.ts, index.ts, app.ts)
+- Initializing servers (HTTP, WebSocket, etc.)
+- Setting up CLI commands
+- Configuring Lambda handlers
+- Establishing scope lifecycle
+
+**Core principle:** ONE scope per application lifetime (HTTP/cron) or ONE scope per invocation (CLI/Lambda)
+
+---
+
+## Code Template
+
+### HTTP Server Entrypoint
+
+```typescript
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig, apiKey } from './resources'
+import { loggingExtension, metricsExtension } from './extensions'
+import express from 'express'
+
+const app = express()
+app.use(express.json())
+
+// ONE scope for entire application
+const scope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app',
+      user: process.env.DB_USER || 'postgres',
+      password: process.env.DB_PASSWORD || 'postgres'
+    }),
+    apiKey(process.env.API_KEY || '')
+  ],
+  extensions: [loggingExtension, metricsExtension]
+})
+
+app.set('scope', scope)
+
+// Routes use scope via context
+app.post('/users', async (req, res) => {
+  const scope = req.app.get('scope')
+  const result = await scope.exec(createUser, {
+    email: req.body.email,
+    name: req.body.name
+  })
+
+  if (!result.success) {
+    return res.status(400).json({ error: result.reason })
+  }
+
+  res.status(201).json(result.user)
+})
+
+const server = app.listen(3000, () => {
+  console.log('Server listening on port 3000')
+})
+
+// Graceful shutdown
+const shutdown = async () => {
+  console.log('Shutting down gracefully...')
+
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      console.log('HTTP server closed')
+      resolve()
+    })
+  })
+
+  await scope.dispose()
+  console.log('Resources disposed')
+
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)
+```
+
+### CLI Entrypoint
+
+```typescript
+import { Command } from 'commander'
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig } from './resources'
+import { createUser } from './flows'
+
+const program = new Command()
+
+program
+  .name('app')
+  .description('Application CLI')
+  .version('1.0.0')
+
+program
+  .command('create-user')
+  .argument('<email>', 'User email')
+  .argument('<name>', 'User name')
+  .action(async (email, name) => {
+    // ONE scope per command execution
+    const scope = createScope({
+      tags: [
+        dbConfig({
+          host: process.env.DB_HOST || 'localhost',
+          port: parseInt(process.env.DB_PORT || '5432'),
+          database: process.env.DB_NAME || 'app',
+          user: process.env.DB_USER || 'postgres',
+          password: process.env.DB_PASSWORD || 'postgres'
+        })
+      ]
+    })
+
+    try {
+      const result = await scope.exec(createUser, { email, name })
+
+      if (!result.success) {
+        console.error(`Error: ${result.reason}`)
+        process.exit(1)
+      }
+
+      console.log('User created:', result.user)
+    } finally {
+      await scope.dispose()
+    }
+  })
+
+program.parse()
+```
+
+### Lambda Entrypoint
+
+```typescript
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig } from './resources'
+import { createUser } from './flows'
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  // ONE scope per invocation
+  const scope = createScope({
+    tags: [
+      dbConfig({
+        host: process.env.DB_HOST!,
+        port: parseInt(process.env.DB_PORT || '5432'),
+        database: process.env.DB_NAME!,
+        user: process.env.DB_USER!,
+        password: process.env.DB_PASSWORD!
+      })
+    ]
+  })
+
+  try {
+    if (event.httpMethod === 'POST' && event.path === '/users') {
+      const body = JSON.parse(event.body || '{}')
+
+      const result = await scope.exec(createUser, {
+        email: body.email,
+        name: body.name
+      })
+
+      if (!result.success) {
+        return {
+          statusCode: 400,
+          body: JSON.stringify({ error: result.reason })
+        }
+      }
+
+      return {
+        statusCode: 201,
+        body: JSON.stringify(result.user)
+      }
+    }
+
+    return {
+      statusCode: 404,
+      body: JSON.stringify({ error: 'Not found' })
+    }
+  } finally {
+    await scope.dispose()
+  }
+}
+```
+
+---
+
+## Scope Creation Patterns
+
+### With Tags (Configuration)
+
+```typescript
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig, apiKey, logLevel } from './resources'
+
+const scope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app'
+    }),
+    apiKey(process.env.API_KEY || ''),
+    logLevel(process.env.LOG_LEVEL || 'info')
+  ]
+})
+```
+
+### With Extensions (Observability)
+
+```typescript
+import { createScope } from '@pumped-fn/core-next'
+import { loggingExtension, metricsExtension, tracingExtension } from './extensions'
+
+const scope = createScope({
+  extensions: [
+    tracingExtension,      // First: sets trace context
+    loggingExtension,      // Second: logs with context
+    metricsExtension       // Third: records metrics
+  ]
+})
+```
+
+### With Both Tags and Extensions
+
+```typescript
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig } from './resources'
+import { loggingExtension } from './extensions'
+
+const scope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app'
+    })
+  ],
+  extensions: [loggingExtension]
+})
+```
+
+---
+
+## Environment-Specific Patterns
+
+### HTTP Server (Express/Hono/Fastify)
+
+**Scope lifecycle:** ONE scope for entire application lifetime
+
+```typescript
+// Express
+const app = express()
+const scope = createScope({ tags: [...], extensions: [...] })
+app.set('scope', scope)
+
+// Hono
+const app = new Hono()
+const scope = createScope({ tags: [...], extensions: [...] })
+app.use('*', async (c, next) => {
+  c.set('scope', scope)
+  await next()
+})
+
+// Fastify
+const fastify = Fastify()
+const scope = createScope({ tags: [...], extensions: [...] })
+fastify.decorate('scope', scope)
+fastify.addHook('onClose', async () => {
+  await scope.dispose()
+})
+```
+
+**Key points:**
+- Create scope once at startup
+- Attach to app context
+- Reuse across all requests
+- Dispose on shutdown
+
+### CLI (Commander)
+
+**Scope lifecycle:** ONE scope PER COMMAND execution
+
+```typescript
+const program = new Command()
+
+program
+  .command('create-user')
+  .action(async (email, name) => {
+    const scope = createScope({ tags: [...] })
+    try {
+      const result = await scope.exec(createUser, { email, name })
+      console.log(result)
+    } finally {
+      await scope.dispose()
+    }
+  })
+
+program
+  .command('list-users')
+  .action(async () => {
+    const scope = createScope({ tags: [...] })
+    try {
+      const result = await scope.exec(listUsers, {})
+      console.table(result.users)
+    } finally {
+      await scope.dispose()
+    }
+  })
+```
+
+**Optimization:** Use factory to reduce duplication
+
+```typescript
+const createAppScope = () => createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app'
+    })
+  ]
+})
+
+program
+  .command('create-user')
+  .action(async (email, name) => {
+    const scope = createAppScope()
+    try {
+      await scope.exec(createUser, { email, name })
+    } finally {
+      await scope.dispose()
+    }
+  })
+```
+
+**Key points:**
+- New scope per command
+- Always dispose in finally
+- Use factory for consistency
+- Exit with error code on failure
+
+### Scheduled Jobs (Cron)
+
+**Scope lifecycle:** ONE scope for entire job runner lifetime
+
+```typescript
+import cron from 'node-cron'
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig } from './resources'
+import { cleanupExpiredSessions, sendDailyReport } from './flows'
+
+const scope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app'
+    })
+  ]
+})
+
+cron.schedule('0 * * * *', async () => {
+  console.log('Running hourly cleanup...')
+
+  const result = await scope.exec(cleanupExpiredSessions, {
+    olderThan: new Date(Date.now() - 24 * 60 * 60 * 1000)
+  })
+
+  if (!result.success) {
+    console.error('Cleanup failed:', result.reason)
+    return
+  }
+
+  console.log(`Cleaned up ${result.count} sessions`)
+})
+
+cron.schedule('0 9 * * *', async () => {
+  console.log('Sending daily report...')
+
+  const result = await scope.exec(sendDailyReport, {
+    date: new Date()
+  })
+
+  if (!result.success) {
+    console.error('Report failed:', result.reason)
+    return
+  }
+
+  console.log('Report sent successfully')
+})
+
+const shutdown = async () => {
+  console.log('Shutting down job runner...')
+  await scope.dispose()
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)
+```
+
+**Key points:**
+- One scope for all jobs
+- Resources shared (efficient pooling)
+- Jobs isolated via flow execution
+- Dispose on shutdown
+
+### Event Processors (Kafka/SQS)
+
+**Scope lifecycle:** ONE scope for entire consumer lifetime
+
+```typescript
+import { Kafka } from 'kafkajs'
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig } from './resources'
+import { processOrderCreated, processUserRegistered } from './flows'
+
+const kafka = new Kafka({
+  clientId: 'app',
+  brokers: ['localhost:9092']
+})
+
+const consumer = kafka.consumer({ groupId: 'app-group' })
+
+const scope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app'
+    })
+  ]
+})
+
+await consumer.connect()
+await consumer.subscribe({ topic: 'orders', fromBeginning: false })
+await consumer.subscribe({ topic: 'users', fromBeginning: false })
+
+await consumer.run({
+  eachMessage: async ({ topic, message }) => {
+    const value = JSON.parse(message.value?.toString() || '{}')
+
+    try {
+      switch (topic) {
+        case 'orders': {
+          const result = await scope.exec(processOrderCreated, {
+            orderId: value.orderId,
+            userId: value.userId,
+            items: value.items
+          })
+
+          if (!result.success) {
+            console.error(`Order processing failed: ${result.reason}`)
+          }
+          break
+        }
+
+        case 'users': {
+          const result = await scope.exec(processUserRegistered, {
+            userId: value.userId,
+            email: value.email
+          })
+
+          if (!result.success) {
+            console.error(`User processing failed: ${result.reason}`)
+          }
+          break
+        }
+      }
+    } catch (error) {
+      console.error(`Message processing error:`, error)
+    }
+  }
+})
+
+const shutdown = async () => {
+  console.log('Shutting down consumer...')
+  await consumer.disconnect()
+  await scope.dispose()
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)
+```
+
+**Key points:**
+- One scope for consumer lifetime
+- Resources shared across messages
+- Each message processed via flow
+- Error handling per message (don't crash consumer)
+
+### Serverless (Lambda/Workers)
+
+**Scope lifecycle:** ONE scope PER INVOCATION
+
+```typescript
+// AWS Lambda
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda'
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig } from './resources'
+import { createUser } from './flows'
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const scope = createScope({
+    tags: [
+      dbConfig({
+        host: process.env.DB_HOST!,
+        port: parseInt(process.env.DB_PORT || '5432'),
+        database: process.env.DB_NAME!
+      })
+    ]
+  })
+
+  try {
+    const body = JSON.parse(event.body || '{}')
+
+    const result = await scope.exec(createUser, {
+      email: body.email,
+      name: body.name
+    })
+
+    if (!result.success) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: result.reason })
+      }
+    }
+
+    return {
+      statusCode: 201,
+      body: JSON.stringify(result.user)
+    }
+  } finally {
+    await scope.dispose()
+  }
+}
+```
+
+```typescript
+// Cloudflare Workers
+import { createScope } from '@pumped-fn/core-next'
+import { apiKey } from './resources'
+import { processRequest } from './flows'
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const scope = createScope({
+      tags: [apiKey(env.API_KEY)]
+    })
+
+    try {
+      const url = new URL(request.url)
+
+      const result = await scope.exec(processRequest, {
+        path: url.pathname,
+        method: request.method,
+        body: request.method !== 'GET' ? await request.json() : undefined
+      })
+
+      if (!result.success) {
+        return Response.json({ error: result.reason }, { status: 400 })
+      }
+
+      return Response.json(result.data)
+    } finally {
+      await scope.dispose()
+    }
+  }
+}
+```
+
+**Key points:**
+- New scope per invocation
+- Always dispose in finally
+- Cold start overhead acceptable
+- Stateless (no shared scope)
+
+### Next.js/Meta-frameworks
+
+**Scope lifecycle:** Module-level scope (singleton)
+
+```typescript
+// src/lib/scope.ts
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig, apiKey } from '@/resources'
+
+export const appScope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app'
+    }),
+    apiKey(process.env.API_KEY || '')
+  ]
+})
+```
+
+```typescript
+// src/app/api/users/route.ts
+import { appScope } from '@/lib/scope'
+import { createUser } from '@/flows'
+
+export async function POST(request: Request) {
+  const body = await request.json()
+
+  const result = await appScope.exec(createUser, {
+    email: body.email,
+    name: body.name
+  })
+
+  if (!result.success) {
+    return Response.json({ error: result.reason }, { status: 400 })
+  }
+
+  return Response.json(result.user, { status: 201 })
+}
+```
+
+**Key points:**
+- Module-level scope
+- Import where needed
+- Use in server components/API routes
+- Never dispose (long-running server)
+
+---
+
+## Graceful Shutdown
+
+### HTTP Server Shutdown
+
+```typescript
+const server = app.listen(3000)
+
+const shutdown = async () => {
+  console.log('Shutting down gracefully...')
+
+  // 1. Stop accepting new connections
+  await new Promise<void>((resolve) => {
+    server.close(() => {
+      console.log('HTTP server closed')
+      resolve()
+    })
+  })
+
+  // 2. Dispose resources (database pools, connections, etc.)
+  await scope.dispose()
+  console.log('Resources disposed')
+
+  // 3. Exit cleanly
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)
+
+process.on('uncaughtException', async (error) => {
+  console.error('Uncaught exception:', error)
+  await shutdown()
+})
+
+process.on('unhandledRejection', async (reason) => {
+  console.error('Unhandled rejection:', reason)
+  await shutdown()
+})
+```
+
+### CLI Shutdown
+
+```typescript
+program
+  .command('create-user')
+  .action(async (email, name) => {
+    const scope = createScope({ tags: [...] })
+    try {
+      const result = await scope.exec(createUser, { email, name })
+
+      if (!result.success) {
+        console.error(`Error: ${result.reason}`)
+        process.exit(1)
+      }
+
+      console.log('User created:', result.user)
+    } finally {
+      await scope.dispose()
+    }
+  })
+```
+
+### Job Runner Shutdown
+
+```typescript
+const scope = createScope({ tags: [...] })
+
+cron.schedule('0 * * * *', async () => {
+  const result = await scope.exec(cleanupExpiredSessions, {})
+  if (!result.success) {
+    console.error('Cleanup failed:', result.reason)
+  }
+})
+
+const shutdown = async () => {
+  console.log('Shutting down job runner...')
+  await scope.dispose()
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)
+```
+
+---
+
+## Real Examples from Pumped-fn Tests
+
+### Example 1: Basic Scope with Tags (packages/next/tests/scope-run.test.ts)
+
+```typescript
+const scope = createScope()
+const userService = provide(() => ({ listAll: () => ["user1", "user2"] }))
+
+const result = await scope.run({ userService }, ({ userService }) =>
+  userService.listAll()
+)
+
+expect(result).toEqual(["user1", "user2"])
+await scope.dispose()
+```
+
+### Example 2: Scope with Multiple Executors (packages/next/tests/scope-run.test.ts)
+
+```typescript
+const scope = createScope()
+const userService = provide(() => ({ getUser: (id: string) => `user-${id}` }))
+const postDb = provide(() => ({ getPosts: (page: number) => [`post-${page}`] }))
+
+const result = await scope.run(
+  { userService, postDb },
+  ({ userService, postDb }, userId: string, page: number) => ({
+    user: userService.getUser(userId),
+    posts: postDb.getPosts(page),
+  }),
+  ["user123", 1]
+)
+
+expect(result).toEqual({
+  user: "user-user123",
+  posts: ["post-1"],
+})
+await scope.dispose()
+```
+
+---
+
+## Troubleshooting
+
+### Resources Not Cleaned Up
+
+**Problem:** Memory leaks, open connections after shutdown
+
+**Solutions:**
+- Always call scope.dispose()
+- Use try/finally in CLI/Lambda
+- Register cleanup handlers for HTTP servers
+- Check controller.cleanup() in resources
+
+```typescript
+// ❌ Wrong - no disposal
+const scope = createScope({ tags: [...] })
+await scope.exec(createUser, input)
+// Scope never disposed!
+
+// ✅ Correct - disposed in finally
+const scope = createScope({ tags: [...] })
+try {
+  await scope.exec(createUser, input)
+} finally {
+  await scope.dispose()
+}
+```
+
+### Multiple Scopes in HTTP Server
+
+**Problem:** Creating scope per request (inefficient)
+
+**Solutions:**
+- Create ONE scope at startup
+- Attach to app context
+- Reuse across requests
+
+```typescript
+// ❌ Wrong - scope per request
+app.post('/users', async (req, res) => {
+  const scope = createScope({ tags: [...] })  // New scope every request!
+  const result = await scope.exec(createUser, req.body)
+  await scope.dispose()
+  res.json(result)
+})
+
+// ✅ Correct - shared scope
+const scope = createScope({ tags: [...] })
+app.set('scope', scope)
+
+app.post('/users', async (req, res) => {
+  const scope = req.app.get('scope')
+  const result = await scope.exec(createUser, req.body)
+  res.json(result)
+})
+```
+
+### Forgot Shutdown Handlers
+
+**Problem:** Process doesn't exit cleanly
+
+**Solutions:**
+- Register SIGTERM/SIGINT handlers
+- Close server before disposing scope
+- Handle uncaught exceptions
+
+```typescript
+// ❌ Wrong - no shutdown handler
+const server = app.listen(3000)
+const scope = createScope({ tags: [...] })
+// No way to dispose on shutdown!
+
+// ✅ Correct - graceful shutdown
+const server = app.listen(3000)
+const scope = createScope({ tags: [...] })
+
+const shutdown = async () => {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve())
+  })
+  await scope.dispose()
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)
+```
+
+### Environment Variables Not Loaded
+
+**Problem:** Tags receive undefined values
+
+**Solutions:**
+- Load dotenv before scope creation
+- Provide defaults for development
+- Validate required env vars
+
+```typescript
+// ❌ Wrong - no defaults or validation
+const scope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST,  // Might be undefined!
+      port: parseInt(process.env.DB_PORT),  // NaN if missing!
+      database: process.env.DB_NAME
+    })
+  ]
+})
+
+// ✅ Correct - defaults and validation
+import 'dotenv/config'
+
+const requiredEnvVars = ['DB_HOST', 'DB_NAME']
+for (const varName of requiredEnvVars) {
+  if (!process.env[varName]) {
+    throw new Error(`Missing required env var: ${varName}`)
+  }
+}
+
+const scope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST!,
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME!
+    })
+  ]
+})
+```
+
+### Lambda Cold Start Performance
+
+**Problem:** Slow Lambda cold starts
+
+**Solutions:**
+- Accept per-invocation scope creation overhead
+- Resources cached after first invocation
+- Use provisioned concurrency if needed
+
+```typescript
+// ✅ Correct - scope per invocation is expected
+export const handler = async (event: APIGatewayProxyEvent) => {
+  const scope = createScope({ tags: [...] })  // Cold start overhead acceptable
+  try {
+    return await scope.exec(processRequest, event)
+  } finally {
+    await scope.dispose()
+  }
+}
+```
+
+---
+
+## Anti-patterns
+
+### ❌ Don't Create Global Scope
+
+```typescript
+// ❌ Wrong - global scope
+const scope = createScope({ tags: [...] })
+
+export { scope }  // Don't export global scope
+
+// ✅ Correct - create at entrypoint
+function main() {
+  const scope = createScope({ tags: [...] })
+  // Use scope here
+}
+```
+
+### ❌ Don't Forget finally in CLI/Lambda
+
+```typescript
+// ❌ Wrong - no finally
+const scope = createScope({ tags: [...] })
+const result = await scope.exec(createUser, input)
+await scope.dispose()  // Skipped if exec throws!
+
+// ✅ Correct - dispose in finally
+const scope = createScope({ tags: [...] })
+try {
+  const result = await scope.exec(createUser, input)
+} finally {
+  await scope.dispose()
+}
+```
+
+### ❌ Don't Mix Scope Lifecycles
+
+```typescript
+// ❌ Wrong - mixing patterns
+const globalScope = createScope({ tags: [...] })
+
+app.post('/users', async (req, res) => {
+  const requestScope = createScope({ tags: [...] })  // Don't mix!
+  // ...
+})
+
+// ✅ Correct - one pattern
+const scope = createScope({ tags: [...] })
+app.set('scope', scope)
+
+app.post('/users', async (req, res) => {
+  const scope = req.app.get('scope')
+  // ...
+})
+```
+
+---
+
+## Related Sub-skills
+
+- **extension-basics** - Adding extensions to scope for observability
+- **resource-basic** - Creating resources that scope manages
+- **integration-hono** - Hono-specific entrypoint patterns
+- **integration-nextjs** - Next.js module-level scope patterns

--- a/skills/pumped-design/references/extension-basics.md
+++ b/skills/pumped-design/references/extension-basics.md
@@ -1,0 +1,689 @@
+---
+name: extension-basics
+tags: extension, add, cross-cutting, wrap, logging, metrics, tracing, observability, hooks
+description: Creating extensions with extension() and wrap() for cross-cutting concerns (logging, metrics, tracing). Includes execute and journal hooks, operation interception, and extension composition patterns.
+---
+
+# Extension: Basics
+
+## When to Use
+
+Use extensions when:
+
+- Adding observability (logging, metrics, tracing) to flows
+- Cross-cutting concerns that apply to all or many flows
+- Capturing execution metadata without modifying flow logic
+- Performance monitoring and profiling
+- Error tracking and reporting
+- Auditing flow executions
+
+**Don't use for:**
+- Flow-specific logic (belongs in flow body)
+- Business rules (belongs in flows)
+- Resource management (use provide/derive with cleanup)
+- Modifying flow behavior (extensions are observers, not modifiers)
+
+---
+
+## Code Template
+
+```typescript
+import { extension, type Extension } from '@pumped-fn/core-next'
+
+// Basic logging extension
+export const loggingExtension = extension({
+  name: 'logging',
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'execute') {
+      console.log(`[FLOW START] ${operation.definition.name}`, {
+        input: operation.input
+      })
+
+      return next()
+        .then((result) => {
+          console.log(`[FLOW END] ${operation.definition.name}`, {
+            result
+          })
+          return result
+        })
+        .catch((error) => {
+          console.error(`[FLOW ERROR] ${operation.definition.name}`, {
+            error
+          })
+          throw error
+        })
+    }
+
+    if (operation.kind === 'journal') {
+      console.log(`  [STEP] ${operation.key}`)
+    }
+
+    return next()
+  }
+})
+```
+
+---
+
+## Extension Hooks
+
+### Execute Hook
+
+Intercepts flow execution (both top-level and sub-flows):
+
+```typescript
+const metricsExtension = extension({
+  name: 'metrics',
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'execute') {
+      const startTime = Date.now()
+      const flowName = operation.definition.name
+
+      return next()
+        .then((result) => {
+          const duration = Date.now() - startTime
+          console.log(`METRIC: flow.${flowName}.duration = ${duration}ms`)
+          return result
+        })
+        .catch((error) => {
+          const duration = Date.now() - startTime
+          console.log(`METRIC: flow.${flowName}.duration = ${duration}ms (error)`)
+          console.log(`METRIC: flow.${flowName}.errors = 1`)
+          throw error
+        })
+    }
+
+    return next()
+  }
+})
+```
+
+### Journal Hook
+
+Intercepts ctx.run() operations:
+
+```typescript
+const journalCaptureExtension = extension({
+  name: 'journal-capture',
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'journal') {
+      const record = {
+        key: operation.key,
+        params: operation.params
+      }
+
+      return next()
+        .then((result) => {
+          console.log(`Journal: ${operation.key}`, {
+            params: operation.params,
+            output: result
+          })
+          return result
+        })
+    }
+
+    return next()
+  }
+})
+```
+
+### Subflow Hook
+
+Intercepts ctx.exec() operations:
+
+```typescript
+const subflowTrackerExtension = extension({
+  name: 'subflow-tracker',
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'subflow') {
+      console.log(`[SUBFLOW] ${operation.definition.name}`, {
+        input: operation.input
+      })
+    }
+
+    return next()
+  }
+})
+```
+
+### Parallel Hook
+
+Intercepts ctx.parallel() and ctx.parallelSettled():
+
+```typescript
+const parallelTrackerExtension = extension({
+  name: 'parallel-tracker',
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'parallel') {
+      console.log(`[PARALLEL] mode=${operation.mode} count=${operation.promiseCount}`)
+
+      return next()
+        .then((result) => {
+          console.log(`[PARALLEL COMPLETE] ${operation.promiseCount} promises resolved`)
+          return result
+        })
+    }
+
+    return next()
+  }
+})
+```
+
+---
+
+## Real Examples from Pumped-fn Tests
+
+### Example 1: Journal Capture with Parameters (packages/next/tests/extensions.test.ts)
+
+```typescript
+type JournalRecord = {
+  key: string
+  params?: readonly unknown[]
+  output?: unknown
+}
+
+const capturedJournalRecords: JournalRecord[] = []
+
+const journalCaptureExtension = extension({
+  name: "journal-capture",
+  wrap: (_scope, next, operation) => {
+    if (operation.kind === "journal") {
+      const record: JournalRecord = {
+        key: operation.key,
+        params: operation.params,
+      }
+
+      return next()
+        .then((result) => {
+          record.output = result
+          capturedJournalRecords.push(record)
+          return result
+        })
+        .catch((error) => {
+          capturedJournalRecords.push(record)
+          throw error
+        })
+    }
+    return next()
+  },
+})
+
+const mathCalculationFlow = flow(async (ctx, input: { x: number; y: number }) => {
+  const product = await ctx.run("multiply", (a: number, b: number) => a * b, input.x, input.y)
+  const sum = await ctx.run("add", (a: number, b: number) => a + b, input.x, input.y)
+  const combined = await ctx.run("combine", () => product + sum)
+
+  return { product, sum, combined }
+})
+
+const result = await flow.execute(
+  mathCalculationFlow,
+  { x: 5, y: 3 },
+  { extensions: [journalCaptureExtension] }
+)
+
+// capturedJournalRecords contains:
+// [
+//   { key: "multiply", params: [5, 3], output: 15 },
+//   { key: "add", params: [5, 3], output: 8 },
+//   { key: "combine", params: undefined, output: 23 }
+// ]
+```
+
+### Example 2: Input Capture for Flows and Subflows (packages/next/tests/extensions.test.ts)
+
+```typescript
+const capturedFlowInputs: Array<{ operation: string; input: unknown }> = []
+
+const inputCaptureExtension = extension({
+  name: "input-capture",
+  wrap: (_scope, next, operation) => {
+    if (operation.kind === "execute" || operation.kind === "subflow") {
+      capturedFlowInputs.push({
+        operation: `${operation.kind}:${operation.definition.name}`,
+        input: operation.input,
+      })
+    }
+    return next()
+  },
+})
+
+const incrementFlow = flow((_ctx, x: number) => x + 1)
+const doubleFlow = flow((_ctx, x: number) => x * 2)
+
+const composedFlow = flow(async (ctx, input: { value: number }) => {
+  const incremented = await ctx.exec(incrementFlow, input.value)
+  const doubled = await ctx.exec(doubleFlow, incremented)
+
+  return { original: input.value, result: doubled }
+})
+
+const result = await flow.execute(
+  composedFlow,
+  { value: 5 },
+  { extensions: [inputCaptureExtension] }
+)
+
+// capturedFlowInputs contains:
+// [
+//   { operation: "execute:anonymous", input: { value: 5 } },
+//   { operation: "subflow:anonymous", input: 5 },
+//   { operation: "execute:anonymous", input: 5 },
+//   { operation: "subflow:anonymous", input: 6 },
+//   { operation: "execute:anonymous", input: 6 }
+// ]
+```
+
+### Example 3: Comprehensive Operation Tracker (packages/next/tests/extensions.test.ts)
+
+```typescript
+type OperationRecord = {
+  kind: string
+  flowName?: string
+  journalKey?: string
+  input?: unknown
+  output?: unknown
+  error?: unknown
+  parallelMode?: string
+  promiseCount?: number
+}
+
+const capturedOperations: OperationRecord[] = []
+
+const comprehensiveTracker = extension({
+  name: "tracker",
+  wrap: (_scope, next, operation) => {
+    const record: OperationRecord = { kind: operation.kind }
+
+    if (operation.kind === "execute") {
+      record.flowName = operation.definition.name
+      record.input = operation.input
+    } else if (operation.kind === "journal") {
+      record.journalKey = operation.key
+    } else if (operation.kind === "subflow") {
+      record.flowName = operation.definition.name
+      record.input = operation.input
+    } else if (operation.kind === "parallel") {
+      record.parallelMode = operation.mode
+      record.promiseCount = operation.promiseCount
+    }
+
+    return next()
+      .then((result) => {
+        record.output = result
+        capturedOperations.push(record)
+        return result
+      })
+      .catch((error) => {
+        record.error = error
+        capturedOperations.push(record)
+        throw error
+      })
+  },
+})
+```
+
+---
+
+## Cross-Cutting Concerns Patterns
+
+### Logging Extension
+
+```typescript
+export const loggingExtension = extension({
+  name: 'logging',
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'execute') {
+      const startTime = Date.now()
+      console.log(`[FLOW START] ${operation.definition.name}`, { input: operation.input })
+
+      return next()
+        .then((result) => {
+          const duration = Date.now() - startTime
+          console.log(`[FLOW END] ${operation.definition.name}`, { duration, result })
+          return result
+        })
+        .catch((error) => {
+          const duration = Date.now() - startTime
+          console.error(`[FLOW ERROR] ${operation.definition.name}`, { duration, error })
+          throw error
+        })
+    }
+
+    if (operation.kind === 'journal') {
+      console.log(`  [STEP] ${operation.key}`)
+    }
+
+    return next()
+  }
+})
+```
+
+### Metrics/Instrumentation Extension
+
+```typescript
+export const metricsExtension = extension({
+  name: 'metrics',
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'execute') {
+      const startTime = Date.now()
+      const metricName = `flow.${operation.definition.name}.duration`
+
+      return next()
+        .then((result) => {
+          const duration = Date.now() - startTime
+          console.log(`METRIC: ${metricName} = ${duration}ms`)
+          return result
+        })
+        .catch((error) => {
+          const duration = Date.now() - startTime
+          console.log(`METRIC: ${metricName} = ${duration}ms (error)`)
+          console.log(`METRIC: flow.${operation.definition.name}.errors = 1`)
+          throw error
+        })
+    }
+
+    return next()
+  }
+})
+```
+
+### Tracing Extension
+
+```typescript
+export const tracingExtension = extension({
+  name: 'tracing',
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'execute') {
+      const traceId = Math.random().toString(36).slice(2)
+      const spanId = Math.random().toString(36).slice(2)
+
+      console.log(`[TRACE] trace_id=${traceId} span_id=${spanId} flow=${operation.definition.name} phase=start`)
+
+      return next()
+        .then((result) => {
+          console.log(`[TRACE] trace_id=${traceId} span_id=${spanId} flow=${operation.definition.name} phase=end`)
+          return result
+        })
+        .catch((error) => {
+          console.log(`[TRACE] trace_id=${traceId} span_id=${spanId} flow=${operation.definition.name} phase=error error=${error}`)
+          throw error
+        })
+    }
+
+    if (operation.kind === 'journal') {
+      console.log(`[TRACE] operation=${operation.key}`)
+    }
+
+    return next()
+  }
+})
+```
+
+### Error Tracking Extension
+
+```typescript
+export const errorTrackingExtension = extension({
+  name: 'error-tracking',
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'execute') {
+      return next()
+        .catch((error) => {
+          console.error(`[ERROR TRACKING] Flow: ${operation.definition.name}`, {
+            error: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+            timestamp: new Date().toISOString()
+          })
+          throw error
+        })
+    }
+
+    return next()
+  }
+})
+```
+
+---
+
+## Extension Composition
+
+Multiple extensions work together:
+
+```typescript
+const scope = createScope({
+  extensions: [
+    loggingExtension,
+    metricsExtension,
+    tracingExtension,
+    errorTrackingExtension
+  ]
+})
+
+const result = await scope.exec(processOrder, {
+  orderId: 'order-123',
+  items: ['item1', 'item2']
+})
+```
+
+Extensions execute in order:
+1. First extension wraps next (includes remaining extensions + flow)
+2. Second extension wraps next (includes remaining extensions + flow)
+3. Third extension wraps next (includes remaining extensions + flow)
+4. Fourth extension wraps next (includes flow only)
+5. Flow executes
+
+On return, each extension's `.then()` callback fires in reverse order.
+
+---
+
+## Usage Patterns
+
+### At Scope Creation
+
+```typescript
+import { createScope } from '@pumped-fn/core-next'
+import { loggingExtension, metricsExtension } from './extensions'
+
+const scope = createScope({
+  extensions: [loggingExtension, metricsExtension]
+})
+
+const result = await scope.exec(createUser, {
+  email: 'test@example.com',
+  name: 'Test User'
+})
+```
+
+### At Flow Execution (flow.execute)
+
+```typescript
+const result = await flow.execute(
+  processOrder,
+  { orderId: 'order-123' },
+  { extensions: [loggingExtension, metricsExtension] }
+)
+```
+
+---
+
+## Troubleshooting
+
+### Extension Not Firing
+
+**Problem:** Extension wrap() not called
+
+**Solutions:**
+- Verify extension passed to createScope() or flow.execute()
+- Check operation.kind matches your condition
+- Ensure next() is called in all code paths
+
+```typescript
+// ❌ Wrong - next() not called in all paths
+wrap: (scope, next, operation) => {
+  if (operation.kind === 'execute') {
+    console.log('Execute')
+    return next()
+  }
+  // Missing return next() for other operation kinds
+}
+
+// ✅ Correct - next() called for all operations
+wrap: (scope, next, operation) => {
+  if (operation.kind === 'execute') {
+    console.log('Execute')
+  }
+  return next()
+}
+```
+
+### Extension Errors Breaking Flows
+
+**Problem:** Extension throws, crashes flow
+
+**Solutions:**
+- Wrap extension logic in try/catch
+- Never throw from extensions (log errors instead)
+- Always call next() even if extension logic fails
+
+```typescript
+// ✅ Safe extension
+wrap: (scope, next, operation) => {
+  try {
+    if (operation.kind === 'execute') {
+      // Extension logic might fail
+      logToExternalService(operation)
+    }
+  } catch (error) {
+    // Log but don't crash
+    console.error('Extension error:', error)
+  }
+
+  return next()
+}
+```
+
+### Extension Modifying Results
+
+**Problem:** Extension accidentally modifies flow results
+
+**Solutions:**
+- Extensions should observe, not modify
+- Don't mutate operation.input or result
+- Use .then() to observe, not transform
+
+```typescript
+// ❌ Wrong - modifying result
+wrap: (scope, next, operation) => {
+  return next()
+    .then((result) => {
+      result.modified = true  // Mutation!
+      return result
+    })
+}
+
+// ✅ Correct - observing only
+wrap: (scope, next, operation) => {
+  return next()
+    .then((result) => {
+      console.log('Result:', result)  // Observe
+      return result  // Return unchanged
+    })
+}
+```
+
+### Extension Order Matters
+
+**Problem:** Extensions in wrong order produce unexpected behavior
+
+**Solutions:**
+- Put tracing/correlation first (sets context)
+- Put logging/metrics after (uses context)
+- Put error tracking last (catches all errors)
+
+```typescript
+// ✅ Correct order
+const scope = createScope({
+  extensions: [
+    tracingExtension,      // First: sets trace context
+    loggingExtension,      // Second: logs with trace context
+    metricsExtension,      // Third: records metrics
+    errorTrackingExtension // Last: catches all errors
+  ]
+})
+```
+
+---
+
+## Anti-patterns
+
+### ❌ Don't Use Extensions for Business Logic
+
+```typescript
+// ❌ Wrong - business logic in extension
+const validationExtension = extension({
+  wrap: (scope, next, operation) => {
+    if (operation.kind === 'execute' && operation.input.email) {
+      if (!operation.input.email.includes('@')) {
+        throw new Error('Invalid email')  // Business logic!
+      }
+    }
+    return next()
+  }
+})
+
+// ✅ Correct - validation in flow
+const createUserFlow = flow(async (ctx, input) => {
+  if (!input.email.includes('@')) {
+    return { success: false, reason: 'INVALID_EMAIL' }
+  }
+  // Continue...
+})
+```
+
+### ❌ Don't Mutate Operation Data
+
+```typescript
+// ❌ Wrong - mutating input
+wrap: (scope, next, operation) => {
+  if (operation.kind === 'execute') {
+    operation.input.timestamp = Date.now()  // Mutation!
+  }
+  return next()
+}
+
+// ✅ Correct - observe only
+wrap: (scope, next, operation) => {
+  if (operation.kind === 'execute') {
+    console.log('Input received at', Date.now())
+  }
+  return next()
+}
+```
+
+### ❌ Don't Forget to Call next()
+
+```typescript
+// ❌ Wrong - next() not called
+wrap: (scope, next, operation) => {
+  if (operation.kind === 'execute') {
+    console.log('Execute')
+  }
+  // Missing return next()!
+}
+
+// ✅ Correct - always call next()
+wrap: (scope, next, operation) => {
+  if (operation.kind === 'execute') {
+    console.log('Execute')
+  }
+  return next()
+}
+```
+
+---
+
+## Related Sub-skills
+
+- **entrypoint-patterns** - Attaching extensions to scope at app initialization
+- **testing-flows** - Testing flows with extensions enabled
+- **flow-context** - Understanding ctx.run() and ctx.exec() that extensions intercept

--- a/skills/pumped-design/references/flow-context.md
+++ b/skills/pumped-design/references/flow-context.md
@@ -1,0 +1,776 @@
+---
+name: flow-context
+tags: flow, modify, ctx.run, ctx.parallel, ctx.parallelSettled, ctx.set, ctx.get, context, journaling
+description: Flow execution context operations - ctx.run() for journaled operations, ctx.parallel() for concurrent execution, ctx.parallelSettled() for partial failures, and reading/writing context state with tags. Direct operations use ctx.run(), NOT ctx.exec().
+---
+
+# Flow: Context Operations
+
+## When to Use
+
+Use context operations (`ctx`) when:
+
+- **ctx.run()** - Journaling direct operations (validation, calculation, I/O)
+- **ctx.parallel()** - Running multiple flows/operations concurrently
+- **ctx.parallelSettled()** - Running operations that may partially fail
+- **ctx.set()/ctx.get()** - Storing metadata across flow execution
+- **ctx.exec()** - Calling sub-flows (see flow-subflows.md)
+
+**Don't use for:**
+- Simple calculations that don't need journaling (just use direct code)
+- Sub-flow calls (use `ctx.exec()`, not `ctx.run()`)
+
+---
+
+## ctx.run() - Journaled Operations
+
+### Purpose
+
+`ctx.run()` journals and executes direct operations:
+- Validations
+- Calculations
+- Resource calls (database queries, HTTP requests)
+- Any operation you want tracked in the journal
+
+### Pattern
+
+```typescript
+import { flow } from '@pumped-fn/core-next'
+
+const processData = flow(async (ctx, input: string) => {
+  // ✅ Journal validation
+  const validation = await ctx.run('validate', () => {
+    if (!input || input.trim() === '') {
+      return { ok: false as const, reason: 'EMPTY' as const }
+    }
+    return { ok: true as const }
+  })
+
+  if (!validation.ok) {
+    return { success: false, reason: validation.reason }
+  }
+
+  // ✅ Journal transformation
+  const transformed = await ctx.run('transform', () => {
+    return input.toUpperCase()
+  })
+
+  // ✅ Journal external call
+  const saved = await ctx.run('save', async () => {
+    return await saveToDatabase(transformed)
+  })
+
+  return { success: true, result: saved }
+})
+```
+
+**Key Points:**
+- First argument is journal key (string)
+- Second argument is operation (sync or async function)
+- Returns the operation's result
+- Journal key must be unique within the flow
+- Same key = deduplication (cached result returned)
+
+---
+
+## Real Examples from Pumped-fn Tests
+
+### Example 1: Basic Journaling (flow-expected.test.ts)
+
+```typescript
+const fetchData = vi.fn(() => Promise.resolve("data"))
+
+const loadData = flow<{ url: string }, { data: string }>(
+  async (ctx, _input) => {
+    const data = await ctx.run("fetch", () => fetchData())
+    return { data }
+  }
+)
+
+const result = await flow.execute(loadData, { url: "http://test.com" })
+// result.data === "data"
+// fetchData called once, journaled as "fetch"
+```
+
+### Example 2: Deduplication (flow-expected.test.ts)
+
+```typescript
+let executionCount = 0
+const incrementCounter = vi.fn(() => ++executionCount)
+
+const deduplicatedOps = flow<Record<string, never>, { value: number }>(
+  async (ctx, _input) => {
+    const firstCall = await ctx.run("op", () => incrementCounter())
+    const secondCall = await ctx.run("op", () => incrementCounter())
+    return { value: firstCall }
+  }
+)
+
+const result = await flow.execute(deduplicatedOps, {})
+// result.value === 1
+// incrementCounter called ONLY ONCE (deduplication by key)
+```
+
+**Deduplication behavior:**
+- Same key returns cached result
+- Operation function not executed on duplicate calls
+- Useful for avoiding redundant expensive operations
+
+### Example 3: Multi-step with Resources (flow-expected.test.ts)
+
+```typescript
+const apiService = provide(() => ({ fetch: fetchMock }))
+
+const fetchUserById = flow(apiService, async (api, ctx, userId: number) => {
+  // ✅ ctx.run() journals resource call
+  const response = await ctx.run("fetch-user", () =>
+    api.fetch(`/users/${userId}`)
+  )
+  return { userId, username: `user${userId}`, raw: response.data }
+})
+
+const fetchPostsByUserId = flow(
+  { api: apiService },
+  async ({ api }, ctx, userId: number) => {
+    // ✅ ctx.run() journals resource call
+    const response = await ctx.run("fetch-posts", () =>
+      api.fetch(`/posts?userId=${userId}`)
+    )
+    return { posts: [{ id: 1, title: "Post 1" }], raw: response.data }
+  }
+)
+
+const getUserWithPosts = flow(
+  { api: apiService },
+  async ({ api: _api }, ctx, userId: number) => {
+    const user = await ctx.exec(fetchUserById, userId)
+    const posts = await ctx.exec(fetchPostsByUserId, userId)
+
+    // ✅ ctx.run() journals enrichment logic
+    const enriched = await ctx.run("enrich", () => ({
+      ...user,
+      postCount: posts.posts.length
+    }))
+
+    return enriched
+  }
+)
+```
+
+**Pattern:**
+- Sub-flows use `ctx.run()` internally for operations
+- Parent uses `ctx.exec()` to orchestrate sub-flows
+- `ctx.run()` used for direct logic (enrichment)
+
+### Example 4: Validation with Discriminated Unions (templates.md)
+
+```typescript
+const createUser = flow(
+  { userRepo: userRepository },
+  async ({ userRepo }, ctx, input: { email: string; name: string }) => {
+    // ✅ ctx.run() for validation logic
+    const validation = await ctx.run('validate-input', () => {
+      if (!input.email.includes('@')) {
+        return { ok: false as const, reason: 'INVALID_EMAIL' as const }
+      }
+      if (input.name.length < 2) {
+        return { ok: false as const, reason: 'NAME_TOO_SHORT' as const }
+      }
+      return { ok: true as const }
+    })
+
+    if (!validation.ok) {
+      return { success: false, reason: validation.reason }
+    }
+
+    // ✅ ctx.run() for database query
+    const existing = await ctx.run('check-existing', async () => {
+      return userRepo.findByEmail(input.email)
+    })
+
+    if (existing !== null) {
+      return { success: false, reason: 'EMAIL_EXISTS' }
+    }
+
+    // ✅ ctx.run() for database write
+    const user = await ctx.run('create-user', async () => {
+      return userRepo.create({
+        email: input.email,
+        name: input.name
+      })
+    })
+
+    return { success: true, user }
+  }
+)
+```
+
+**Pattern:**
+- Each logical step gets its own journal key
+- Validation returns discriminated union for type narrowing
+- Resource operations journaled separately
+
+---
+
+## ctx.parallel() - Concurrent Execution
+
+### Purpose
+
+Execute multiple flows concurrently and wait for all to complete. All operations must succeed.
+
+### Pattern
+
+```typescript
+import { flow } from '@pumped-fn/core-next'
+
+const fetchUserData = flow(async (ctx, userId: string) => {
+  // ✅ Start multiple flows concurrently
+  const profilePromise = ctx.exec(fetchProfile, userId)
+  const settingsPromise = ctx.exec(fetchSettings, userId)
+  const preferencesPromise = ctx.exec(fetchPreferences, userId)
+
+  // ✅ Wait for all to complete
+  const parallel = await ctx.parallel([
+    profilePromise,
+    settingsPromise,
+    preferencesPromise
+  ])
+
+  // ✅ Access results in order
+  return {
+    profile: parallel.results[0],
+    settings: parallel.results[1],
+    preferences: parallel.results[2]
+  }
+})
+```
+
+**Key Points:**
+- Takes array of Promised values (from `ctx.exec()` or async operations)
+- Returns `{ results: T[] }` - results in same order as input
+- Throws if ANY operation fails (fail-fast)
+- Operations start immediately when promises are created
+
+---
+
+## Real Example: ctx.parallel() (flow-expected.test.ts)
+
+```typescript
+const doubleAsync = flow<{ x: number }, { r: number }>(async (_ctx, input) => {
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  return { r: input.x * 2 }
+})
+
+const tripleAsync = flow<{ x: number }, { r: number }>(async (_ctx, input) => {
+  await new Promise((resolve) => setTimeout(resolve, 10))
+  return { r: input.x * 3 }
+})
+
+const combineResults = flow<{ val: number }, { sum: number }>(
+  async (ctx, input) => {
+    // ✅ Start both flows concurrently
+    const doublePromise = ctx.exec(doubleAsync, { x: input.val })
+    const triplePromise = ctx.exec(tripleAsync, { x: input.val })
+
+    // ✅ Wait for both to complete
+    const parallel = await ctx.parallel([doublePromise, triplePromise])
+
+    // ✅ Results in same order as input array
+    const sum = parallel.results[0].r + parallel.results[1].r
+    return { sum }
+  }
+)
+
+const result = await flow.execute(combineResults, { val: 5 })
+// result.sum === 25 (10 + 15)
+```
+
+**Performance:**
+- Both flows run concurrently (~10ms total, not ~20ms sequential)
+- Results synchronized and returned in order
+
+---
+
+## ctx.parallelSettled() - Partial Failures
+
+### Purpose
+
+Execute multiple operations concurrently, collecting both successes and failures. Continues even if some operations fail.
+
+### Pattern
+
+```typescript
+import { flow } from '@pumped-fn/core-next'
+
+const fetchMultipleResources = flow(async (ctx, resourceIds: string[]) => {
+  // ✅ Start all fetches concurrently
+  const promises = resourceIds.map(id => ctx.exec(fetchResource, id))
+
+  // ✅ Wait for all to settle (success or failure)
+  const settled = await ctx.parallelSettled(promises)
+
+  // ✅ Access statistics
+  console.log(`Succeeded: ${settled.stats.succeeded}`)
+  console.log(`Failed: ${settled.stats.failed}`)
+
+  // ✅ Filter successes and failures
+  const successful = settled.results
+    .filter(r => r.status === 'fulfilled')
+    .map(r => r.value)
+
+  const failed = settled.results
+    .filter(r => r.status === 'rejected')
+    .map(r => r.reason)
+
+  return { successful, failed }
+})
+```
+
+**Key Points:**
+- Takes array of Promised values
+- Returns `{ results: SettledResult[], stats: { succeeded, failed } }`
+- Each result has `status: 'fulfilled' | 'rejected'`
+- Fulfilled: `{ status: 'fulfilled', value: T }`
+- Rejected: `{ status: 'rejected', reason: Error }`
+- Never throws - always returns results
+
+---
+
+## Real Example: ctx.parallelSettled() (flow-expected.test.ts)
+
+```typescript
+const successFlow = flow<Record<string, never>, { ok: boolean }>(() => ({
+  ok: true
+}))
+
+const failureFlow = flow(() => {
+  throw new FlowError("Failed", "ERR")
+})
+
+const gatherResults = flow<
+  Record<string, never>,
+  { succeeded: number; failed: number }
+>(async (ctx, _input) => {
+  // ✅ Start three flows: two success, one failure
+  const first = ctx.exec(successFlow, {})
+  const second = ctx.exec(failureFlow, {})
+  const third = ctx.exec(successFlow, {})
+
+  // ✅ Wait for all to settle
+  const settled = await ctx.parallelSettled([first, second, third])
+
+  // ✅ Stats automatically calculated
+  return {
+    succeeded: settled.stats.succeeded,
+    failed: settled.stats.failed
+  }
+})
+
+const result = await flow.execute(gatherResults, {})
+// result.succeeded === 2
+// result.failed === 1
+```
+
+**Use cases:**
+- Bulk operations where partial success is acceptable
+- Fetching multiple resources (continue if some fail)
+- Batch processing with error collection
+
+---
+
+## Reading and Writing Context
+
+### Purpose
+
+Store metadata and state across flow execution using tags.
+
+### Pattern: ctx.set() and ctx.get()
+
+```typescript
+import { tag, custom, flow, flowMeta } from '@pumped-fn/core-next'
+
+// Define custom tag
+const processingKey = tag(custom<string>(), { label: 'customKey' })
+
+const storeCustomValue = flow(async (ctx, input: string) => {
+  // ✅ Write to context
+  ctx.set(processingKey, `processed-${input}`)
+
+  // ✅ Read from context
+  const value = ctx.get(processingKey)
+
+  return input.toUpperCase()
+})
+```
+
+### Real Example: Context Access (flow-expected.test.ts)
+
+```typescript
+const processingKey = tag(custom<string>(), { label: "customKey" })
+
+const storeCustomValue = flow(async (ctx, input: string) => {
+  // ✅ Set custom value in context
+  ctx.set(processingKey, `processed-${input}`)
+  return input.toUpperCase()
+})
+
+const execution = flow.execute(storeCustomValue, "hello")
+await execution
+
+// ✅ Access context after execution
+const metadata = await execution.ctx()
+const customValue = metadata?.context.find(processingKey)
+// customValue === "processed-hello"
+```
+
+---
+
+## Built-in Context Metadata (flowMeta)
+
+### Available Metadata
+
+```typescript
+import { flowMeta } from '@pumped-fn/core-next'
+
+const inspectFlow = flow(async (ctx, input: number) => {
+  const result = await ctx.run('operation', () => input * 2)
+  return result
+})
+
+const execution = flow.execute(inspectFlow, 42)
+await execution
+const metadata = await execution.ctx()
+
+// ✅ Flow name
+const flowName = metadata?.context.find(flowMeta.flowName)
+// "anonymous"
+
+// ✅ Execution depth (nested flows)
+const depth = metadata?.context.get(flowMeta.depth)
+// 0 (top-level flow)
+
+// ✅ Parallel execution flag
+const isParallel = metadata?.context.get(flowMeta.isParallel)
+// false
+
+// ✅ Journal (all ctx.run() operations)
+const journal = metadata?.context.find(flowMeta.journal)
+// Map with journal entries
+```
+
+### Example: Accessing Journal (flow-expected.test.ts)
+
+```typescript
+const multiStepCalculation = flow(async (ctx, input: number) => {
+  const doubled = await ctx.run("double", () => input * 2)
+  const tripled = await ctx.run("triple", () => input * 3)
+  const combined = await ctx.run("sum", () => doubled + tripled)
+  return combined
+})
+
+const execution = flow.execute(multiStepCalculation, 10)
+await execution
+const metadata = await execution.ctx()
+
+// ✅ Journal tracks all operations
+const journal = metadata?.context.find(flowMeta.journal)
+// journal?.size === 3
+
+const journalKeys = Array.from(journal?.keys() || [])
+// ["double", "triple", "sum"]
+```
+
+---
+
+## inDetails() - Result with Context
+
+### Purpose
+
+Get both the result AND context in a single call, with discriminated union for success/failure.
+
+### Pattern
+
+```typescript
+import { flow } from '@pumped-fn/core-next'
+
+const calculateBoth = flow(async (ctx, input: { x: number; y: number }) => {
+  const sum = await ctx.run('sum', () => input.x + input.y)
+  const product = await ctx.run('product', () => input.x * input.y)
+  return { sum, product }
+})
+
+const details = await flow.execute(calculateBoth, { x: 5, y: 3 }).inDetails()
+
+// ✅ Discriminated union
+if (details.success) {
+  console.log(details.result.sum)      // 8
+  console.log(details.result.product)  // 15
+} else {
+  console.log(details.error)
+}
+
+// ✅ Context available in both branches
+const journal = details.ctx.context.find(flowMeta.journal)
+```
+
+### Real Example: inDetails() (flow-expected.test.ts)
+
+```typescript
+const calculateBoth = flow(async (ctx, input: { x: number; y: number }) => {
+  const sum = await ctx.run("sum", () => input.x + input.y)
+  const product = await ctx.run("product", () => input.x * input.y)
+  return { sum, product }
+})
+
+const details = await flow.execute(calculateBoth, { x: 5, y: 3 }).inDetails()
+
+// ✅ Type-safe discriminated union
+expect(details.success).toBe(true)
+if (details.success) {
+  expect(details.result.sum).toBe(8)
+  expect(details.result.product).toBe(15)
+}
+
+// ✅ Context always available
+expect(details.ctx).toBeDefined()
+const journal = details.ctx.context.find(flowMeta.journal)
+expect(journal?.size).toBeGreaterThan(0)
+```
+
+### Example: Error with Context (flow-expected.test.ts)
+
+```typescript
+const operationWithError = flow(async (ctx, input: number) => {
+  await ctx.run("before-error", () => input * 2)
+  throw new Error("test error")
+})
+
+const details = await flow.execute(operationWithError, 5).inDetails()
+
+// ✅ Discriminated union narrows error type
+expect(details.success).toBe(false)
+if (!details.success) {
+  expect((details.error as Error).message).toBe("test error")
+}
+
+// ✅ Context preserved even on error
+expect(details.ctx).toBeDefined()
+const journal = details.ctx.context.find(flowMeta.journal)
+expect(journal?.size).toBeGreaterThan(0)  // "before-error" was journaled
+```
+
+---
+
+## Promised Chaining with Context
+
+### Pattern: Access Context After Transformations
+
+```typescript
+const doubleValue = flow(async (ctx, input: number) => {
+  await ctx.run("increment", () => input + 1)
+  return input * 2
+})
+
+// ✅ inDetails() works after .map()
+const details = await flow
+  .execute(doubleValue, 10)
+  .map((x) => x + 1)  // Transform result
+  .inDetails()
+
+if (details.success) {
+  console.log(details.result)  // 21 (10 * 2 + 1)
+}
+
+// ✅ Context preserved through transformations
+const journal = details.ctx.context.find(flowMeta.journal)
+// Still has "increment" entry
+```
+
+---
+
+## Execution Options: details Flag
+
+### details: false (default)
+
+Returns unwrapped result:
+
+```typescript
+const doubleValue = flow((_ctx, input: number) => input * 2)
+
+const result = await flow.execute(doubleValue, 5, { details: false })
+// result === 10 (unwrapped)
+```
+
+### details: true
+
+Returns wrapped result with context:
+
+```typescript
+const incrementValue = flow((_ctx, input: number) => input + 1)
+
+const processNested = flow(async (ctx, input: number) => {
+  const incremented = await ctx.exec(incrementValue, input)
+  return incremented * 2
+})
+
+const details = await flow.execute(processNested, 5, { details: true })
+
+if (details.success) {
+  console.log(details.result)  // 12
+  console.log(details.ctx.context.get(flowMeta.depth))  // 0
+}
+```
+
+---
+
+## Anti-patterns
+
+### ❌ Using ctx.run() for Sub-flows
+
+```typescript
+// ❌ WRONG: Don't use ctx.run() for sub-flows
+const result = await ctx.run('validate', async () => {
+  return await flow.execute(validateOrder, input)
+})
+
+// ✅ CORRECT: Use ctx.exec()
+const result = await ctx.exec(validateOrder, input)
+```
+
+### ❌ Duplicate Journal Keys
+
+```typescript
+// ❌ WRONG: Duplicate keys cause deduplication
+const first = await ctx.run('step', () => calculateA())
+const second = await ctx.run('step', () => calculateB())
+// second === first (deduplication!)
+
+// ✅ CORRECT: Unique keys
+const first = await ctx.run('calculate-a', () => calculateA())
+const second = await ctx.run('calculate-b', () => calculateB())
+```
+
+### ❌ Over-journaling
+
+```typescript
+// ❌ WRONG: Journaling trivial operations
+const result = await ctx.run('add', () => x + y)
+const doubled = await ctx.run('double', () => result * 2)
+
+// ✅ CORRECT: Journal meaningful operations only
+const result = await ctx.run('calculate-total', () => {
+  const sum = x + y
+  return sum * 2
+})
+```
+
+**Guidance:**
+- Journal operations that have side effects (I/O, mutations)
+- Journal complex calculations worth tracking
+- Skip journaling trivial computations
+- Use judgment based on debugging value
+
+---
+
+## Troubleshooting
+
+### Issue: ctx.run() not deduplicating
+
+**Symptom:** Same operation runs multiple times with same key
+
+```typescript
+const first = await ctx.run('fetch', () => fetch('/api/data'))
+const second = await ctx.run('fetch', () => fetch('/api/data'))
+// Both fetch calls execute
+```
+
+**Cause:** Key must be EXACTLY the same string
+
+**Solution:** Verify key spelling, no dynamic keys
+
+```typescript
+// ✅ Static keys deduplicate
+const key = 'fetch-data'
+const first = await ctx.run(key, () => fetch('/api/data'))
+const second = await ctx.run(key, () => fetch('/api/data'))
+// Only first fetch executes
+```
+
+### Issue: Type errors with ctx.parallel()
+
+**Symptom:** TypeScript can't infer result types
+
+```typescript
+const parallel = await ctx.parallel([
+  ctx.exec(flowA, inputA),
+  ctx.exec(flowB, inputB)
+])
+
+const resultA = parallel.results[0]  // Type: unknown
+```
+
+**Solution:** TypeScript limitation - explicitly type or destructure
+
+```typescript
+// ✅ Type assertion
+const [resultA, resultB] = parallel.results as [ResultA, ResultB]
+
+// ✅ Or access with type guard
+if (parallel.results.length === 2) {
+  const resultA = parallel.results[0] as ResultA
+  const resultB = parallel.results[1] as ResultB
+}
+```
+
+### Issue: ctx.get() returns undefined
+
+**Symptom:** Tag not found in context
+
+```typescript
+const value = ctx.get(customTag)
+// value === undefined
+```
+
+**Cause:** Tag not set, or accessed in wrong scope
+
+**Solution:** Verify tag was set, check scope
+
+```typescript
+// ✅ Set before getting
+ctx.set(customTag, 'value')
+const value = ctx.get(customTag)
+
+// ✅ Or use find() for optional access
+const value = ctx.find(customTag)  // undefined if not set
+```
+
+### Issue: Journal not showing operations
+
+**Symptom:** Journal empty or missing operations
+
+```typescript
+const metadata = await execution.ctx()
+const journal = metadata?.context.find(flowMeta.journal)
+// journal empty or undefined
+```
+
+**Cause:** Operations not journaled with `ctx.run()`
+
+**Solution:** Wrap operations in `ctx.run()`
+
+```typescript
+// ❌ Not journaled
+const result = await someOperation()
+
+// ✅ Journaled
+const result = await ctx.run('operation', () => someOperation())
+```
+
+---
+
+## Related Sub-skills
+
+- **flow-subflows.md** - Using `ctx.exec()` for sub-flow composition
+- **testing-flows.md** - Testing flows and verifying journal entries
+- **coding-standards.md** - Code economy rules for when to use ctx.run()
+- **resource-basic.md** - Resource operations journaled via ctx.run()

--- a/skills/pumped-design/references/flow-subflows.md
+++ b/skills/pumped-design/references/flow-subflows.md
@@ -1,0 +1,599 @@
+---
+name: flow-subflows
+tags: flow, add, reuse, orchestration, ctx.exec, composition, sub-flow, error-mapping
+description: Flow orchestration using ctx.exec() to call sub-flows. Sub-flows are called DIRECTLY via ctx.exec(subFlow, input) - NOT wrapped in ctx.run(). Covers error mapping, discriminated union outputs, and reusable vs non-reusable flow patterns.
+---
+
+# Flow: Sub-flows and Orchestration
+
+## When to Use
+
+Use `ctx.exec()` for sub-flows when:
+
+- Orchestrating multi-step business processes by composing smaller flows
+- Reusing flow logic across multiple parent flows
+- Building flows that need discriminated union error handling from sub-flows
+- Creating testable flow hierarchies (test sub-flows independently)
+
+**Critical Pattern:**
+- Sub-flows are called via `ctx.exec(subFlow, input)` - **NOT** wrapped in `ctx.run()`
+- Use `ctx.run()` for direct operations (calculations, validations)
+- Use `ctx.exec()` for flow composition
+
+**Don't use for:**
+- Simple operations that don't need journaling (just use direct calls)
+- Operations that should share the same journal entry (use `ctx.run()`)
+
+---
+
+## Core Pattern: ctx.exec(subFlow, input)
+
+### Basic Sub-flow Execution
+
+```typescript
+import { flow } from '@pumped-fn/core-next'
+
+// Sub-flow: Reusable validation logic
+export namespace ValidateOrder {
+  export type Input = { items: string[]; userId: string }
+  export type Success = { success: true; total: number }
+  export type Error = { success: false; reason: 'INVALID_ITEMS' | 'EMPTY_ORDER' }
+  export type Result = Success | Error
+}
+
+export const validateOrder = flow(
+  async (_ctx, input: ValidateOrder.Input): Promise<ValidateOrder.Result> => {
+    if (input.items.length === 0) {
+      return { success: false, reason: 'EMPTY_ORDER' }
+    }
+
+    const hasInvalid = input.items.some(item => !item || item.trim() === '')
+    if (hasInvalid) {
+      return { success: false, reason: 'INVALID_ITEMS' }
+    }
+
+    return { success: true, total: input.items.length * 100 }
+  }
+)
+
+// Parent flow: Orchestrates sub-flows
+export namespace ProcessOrder {
+  export type Input = { items: string[]; userId: string }
+  export type Success = { success: true; orderId: string; total: number }
+  export type Error = ValidateOrder.Error | { success: false; reason: 'PAYMENT_DECLINED' }
+  export type Result = Success | Error
+}
+
+export const processOrder = flow(
+  async (ctx, input: ProcessOrder.Input): Promise<ProcessOrder.Result> => {
+    // ✅ CORRECT: ctx.exec() called directly, NOT in ctx.run()
+    const validated = await ctx.exec(validateOrder, {
+      items: input.items,
+      userId: input.userId
+    })
+
+    // Type narrowing via discriminated union
+    if (!validated.success) {
+      return validated  // Error flows through
+    }
+
+    // Continue with validated.total available
+    const orderId = await ctx.run('generate-id', () => `order-${Date.now()}`)
+
+    return { success: true, orderId, total: validated.total }
+  }
+)
+```
+
+**Key Points:**
+- `ctx.exec(validateOrder, input)` - direct call, returns the sub-flow result
+- Type narrowing works: `if (!validated.success)` proves error type
+- Parent flow can propagate or transform sub-flow errors
+
+---
+
+## Real Examples from Pumped-fn Tests
+
+### Example 1: Simple Sub-flow Composition (flow-expected.test.ts)
+
+```typescript
+const doubleNumber = flow<{ n: number }, { doubled: number }>(
+  (_ctx, input) => {
+    return { doubled: input.n * 2 }
+  }
+)
+
+const processValue = flow<{ value: number }, { result: number }>(
+  async (ctx, input) => {
+    // ✅ ctx.exec() called directly
+    const doubled = await ctx.exec(doubleNumber, { n: input.value })
+    return { result: doubled.doubled }
+  }
+)
+
+const result = await flow.execute(processValue, { value: 10 })
+// result.result === 20
+```
+
+### Example 2: Multiple Sub-flow Orchestration (flow-expected.test.ts)
+
+```typescript
+const fetchUserById = flow(apiService, async (api, ctx, userId: number) => {
+  const response = await ctx.run("fetch-user", () =>
+    api.fetch(`/users/${userId}`)
+  )
+  return { userId, username: `user${userId}`, raw: response.data }
+})
+
+const fetchPostsByUserId = flow(
+  { api: apiService },
+  async ({ api }, ctx, userId: number) => {
+    const response = await ctx.run("fetch-posts", () =>
+      api.fetch(`/posts?userId=${userId}`)
+    )
+    return { posts: [{ id: 1, title: "Post 1" }], raw: response.data }
+  }
+)
+
+type UserWithPosts = {
+  userId: number
+  username: string
+  raw: string
+  postCount: number
+}
+
+const getUserWithPosts = flow(
+  { api: apiService },
+  async ({ api: _api }, ctx, userId: number): Promise<UserWithPosts> => {
+    // ✅ Multiple ctx.exec() calls orchestrate sub-flows
+    const user = await ctx.exec(fetchUserById, userId)
+    const posts = await ctx.exec(fetchPostsByUserId, userId)
+
+    const enriched = await ctx.run("enrich", () => ({
+      ...user,
+      postCount: posts.posts.length
+    }))
+
+    return enriched
+  }
+)
+```
+
+**Pattern:**
+- Sub-flows (`fetchUserById`, `fetchPostsByUserId`) use `ctx.run()` internally
+- Parent flow (`getUserWithPosts`) uses `ctx.exec()` to orchestrate
+- `ctx.run()` used for direct operations (enrichment logic)
+
+### Example 3: Void Input Sub-flow (flow-expected.test.ts)
+
+```typescript
+const getBaseValue = flow<void, number>(() => {
+  return 100
+})
+
+const incrementValue = flow<void, number>(async (ctx) => {
+  // ✅ ctx.exec() with void input
+  const base = await ctx.exec(getBaseValue, undefined)
+  return base + 1
+})
+
+const result = await flow.execute(incrementValue, undefined)
+// result === 101
+```
+
+### Example 4: Sub-flow with Error Union (templates.md)
+
+```typescript
+export namespace CreateUser {
+  export type Input = { email: string; name: string }
+  export type Success = { success: true; user: User }
+  export type Error =
+    | { success: false; reason: 'INVALID_EMAIL' }
+    | { success: false; reason: 'EMAIL_EXISTS' }
+  export type Result = Success | Error
+}
+
+export const createUser = flow(
+  { userRepo: userRepository },
+  async ({ userRepo }, ctx, input: CreateUser.Input): Promise<CreateUser.Result> => {
+    const validation = await ctx.run('validate-input', () => {
+      if (!input.email.includes('@')) {
+        return { ok: false as const, reason: 'INVALID_EMAIL' as const }
+      }
+      return { ok: true as const }
+    })
+
+    if (!validation.ok) {
+      return { success: false, reason: validation.reason }
+    }
+
+    const existing = await ctx.run('check-existing', async () => {
+      return userRepo.findByEmail(input.email)
+    })
+
+    if (existing !== null) {
+      return { success: false, reason: 'EMAIL_EXISTS' }
+    }
+
+    const user = await ctx.run('create-user', async () => {
+      return userRepo.create(input)
+    })
+
+    return { success: true, user }
+  }
+)
+
+export namespace RegisterUser {
+  export type Input = { email: string; name: string; sendWelcomeEmail: boolean }
+  export type Success = { success: true; user: User; emailSent: boolean }
+  // ✅ Parent error union includes sub-flow errors
+  export type Error = CreateUser.Error | { success: false; reason: 'EMAIL_SEND_FAILED' }
+  export type Result = Success | Error
+}
+
+export const registerUser = flow(
+  { userRepo: userRepository },
+  async ({ userRepo }, ctx, input: RegisterUser.Input): Promise<RegisterUser.Result> => {
+    // ✅ ctx.exec() propagates discriminated union
+    const userResult = await ctx.exec(createUser, {
+      email: input.email,
+      name: input.name
+    })
+
+    // Type narrowing
+    if (!userResult.success) {
+      return userResult  // All CreateUser.Error variants flow through
+    }
+
+    // userResult.user is available after narrowing
+    let emailSent = false
+    if (input.sendWelcomeEmail) {
+      const emailResult = await ctx.run('send-welcome-email', async () => {
+        return { success: true as const }
+      })
+
+      if (!emailResult.success) {
+        return { success: false, reason: 'EMAIL_SEND_FAILED' }
+      }
+      emailSent = true
+    }
+
+    return {
+      success: true,
+      user: userResult.user,
+      emailSent
+    }
+  }
+)
+```
+
+---
+
+## Error Mapping and Discriminated Unions
+
+### Pattern 1: Direct Error Propagation
+
+```typescript
+// Sub-flow returns discriminated union
+const validateInput = flow(
+  async (_ctx, input: string): Promise<
+    | { success: true; validated: string }
+    | { success: false; reason: 'EMPTY' | 'INVALID' }
+  > => {
+    if (!input) return { success: false, reason: 'EMPTY' }
+    if (input.length < 3) return { success: false, reason: 'INVALID' }
+    return { success: true, validated: input }
+  }
+)
+
+// Parent propagates sub-flow errors
+const processInput = flow(
+  async (ctx, input: string): Promise<
+    | { success: true; result: string }
+    | { success: false; reason: 'EMPTY' | 'INVALID' | 'PROCESSING_FAILED' }
+  > => {
+    const validated = await ctx.exec(validateInput, input)
+
+    if (!validated.success) {
+      return validated  // Error flows through unchanged
+    }
+
+    // Process validated input
+    return { success: true, result: validated.validated.toUpperCase() }
+  }
+)
+```
+
+### Pattern 2: Error Transformation
+
+```typescript
+// Sub-flow has specific errors
+const fetchUser = flow(
+  async (_ctx, userId: string): Promise<
+    | { success: true; user: User }
+    | { success: false; reason: 'NOT_FOUND' }
+  > => {
+    // Implementation
+  }
+)
+
+// Parent transforms sub-flow errors
+const getUserProfile = flow(
+  async (ctx, userId: string): Promise<
+    | { success: true; profile: Profile }
+    | { success: false; reason: 'USER_NOT_FOUND' | 'PROFILE_INCOMPLETE' }
+  > => {
+    const userResult = await ctx.exec(fetchUser, userId)
+
+    if (!userResult.success) {
+      // ✅ Transform sub-flow error to parent error
+      return { success: false, reason: 'USER_NOT_FOUND' }
+    }
+
+    // Continue processing
+    return { success: true, profile: buildProfile(userResult.user) }
+  }
+)
+```
+
+### Pattern 3: Multiple Error Unions
+
+```typescript
+const validatePayment = flow(
+  async (_ctx, amount: number): Promise<
+    | { success: true; validated: number }
+    | { success: false; reason: 'INVALID_AMOUNT' }
+  > => {
+    if (amount <= 0) return { success: false, reason: 'INVALID_AMOUNT' }
+    return { success: true, validated: amount }
+  }
+)
+
+const chargeCard = flow(
+  async (_ctx, amount: number): Promise<
+    | { success: true; transactionId: string }
+    | { success: false; reason: 'DECLINED' | 'INSUFFICIENT_FUNDS' }
+  > => {
+    // Implementation
+  }
+)
+
+// Parent aggregates errors from multiple sub-flows
+const processPayment = flow(
+  async (ctx, amount: number): Promise<
+    | { success: true; transactionId: string }
+    | { success: false; reason: 'INVALID_AMOUNT' | 'DECLINED' | 'INSUFFICIENT_FUNDS' }
+  > => {
+    const validated = await ctx.exec(validatePayment, amount)
+    if (!validated.success) return validated
+
+    const charged = await ctx.exec(chargeCard, validated.validated)
+    if (!charged.success) return charged
+
+    return { success: true, transactionId: charged.transactionId }
+  }
+)
+```
+
+---
+
+## Reusable vs Non-reusable Flows
+
+### Reusable Flows
+
+**Characteristics:**
+- Standalone functionality
+- No coupling to parent context
+- Can be called from multiple parents
+- Should be tested independently
+
+```typescript
+// ✅ Reusable: Clear purpose, generic input/output
+export const validateEmail = flow(
+  async (_ctx, email: string): Promise<
+    | { success: true; email: string }
+    | { success: false; reason: 'INVALID_FORMAT' }
+  > => {
+    const isValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+    if (!isValid) return { success: false, reason: 'INVALID_FORMAT' }
+    return { success: true, email }
+  }
+)
+
+// Used by multiple parent flows
+const registerUser = flow(async (ctx, email: string) => {
+  const validated = await ctx.exec(validateEmail, email)
+  // ...
+})
+
+const updateEmail = flow(async (ctx, email: string) => {
+  const validated = await ctx.exec(validateEmail, email)
+  // ...
+})
+```
+
+### Non-reusable Flows
+
+**Characteristics:**
+- Tightly coupled to parent flow
+- Extracts complexity for readability
+- Not intended for reuse
+- Test via parent flow
+
+```typescript
+// ❌ Non-reusable: Specific to processOrder context
+const calculateOrderTotal = flow(
+  async (_ctx, items: OrderItem[]): Promise<{ total: number; taxAmount: number }> => {
+    const subtotal = items.reduce((sum, item) => sum + item.price * item.quantity, 0)
+    const taxAmount = subtotal * 0.08
+    return { total: subtotal + taxAmount, taxAmount }
+  }
+)
+
+// Only used by processOrder
+const processOrder = flow(async (ctx, items: OrderItem[]) => {
+  const { total, taxAmount } = await ctx.exec(calculateOrderTotal, items)
+  // ...
+})
+```
+
+**Guidance:**
+- If a flow is only called from one parent, consider inlining with `ctx.run()`
+- Extract to sub-flow when logic is complex enough to obscure parent flow readability
+- Always export and test flows that are called from multiple parents
+
+---
+
+## Nesting Depth Guidelines
+
+**Maximum nesting:** 3 levels of `ctx.exec()`
+
+```typescript
+// ✅ Level 1: Top-level flow
+const processOrder = flow(async (ctx, input) => {
+  // ✅ Level 2: Direct sub-flow
+  const validated = await ctx.exec(validateOrder, input)
+
+  // ✅ Level 3: Nested sub-flow (inside validateOrder)
+  // validateOrder can call another sub-flow
+
+  // ❌ Level 4: Too deep - refactor if you need this
+})
+```
+
+**Why limit depth?**
+- Deep nesting indicates complex orchestration - consider refactoring
+- Makes testing harder (mocking dependencies at each level)
+- Harder to understand flow hierarchy
+- Signals that flows might have unclear responsibilities
+
+**Refactoring deep nesting:**
+- Extract intermediate orchestration flows
+- Use resources/repositories for data access patterns
+- Flatten by combining related sub-flows
+
+---
+
+## Anti-patterns
+
+### ❌ Wrapping ctx.exec() in ctx.run()
+
+```typescript
+// ❌ WRONG: Don't wrap ctx.exec() in ctx.run()
+const result = await ctx.run('validate', async () => {
+  return await ctx.exec(validateOrder, input)
+})
+
+// ✅ CORRECT: ctx.exec() is already journaled
+const result = await ctx.exec(validateOrder, input)
+```
+
+**Why wrong?** `ctx.exec()` already creates a journal entry. Wrapping in `ctx.run()` creates unnecessary nesting and confuses the journal hierarchy.
+
+### ❌ Using ctx.run() for Flow Composition
+
+```typescript
+// ❌ WRONG: Don't manually call flow inside ctx.run()
+const result = await ctx.run('validate', async () => {
+  return await flow.execute(validateOrder, input)
+})
+
+// ✅ CORRECT: Use ctx.exec()
+const result = await ctx.exec(validateOrder, input)
+```
+
+### ❌ Mixing Direct Calls with ctx.exec()
+
+```typescript
+// ❌ WRONG: Inconsistent - some flows via ctx.exec(), some direct
+const validated = await ctx.exec(validateOrder, input)
+const processed = await processData(validated)  // Direct call
+
+// ✅ CORRECT: All flows via ctx.exec(), utilities direct
+const validated = await ctx.exec(validateOrder, input)
+const processed = await ctx.exec(processData, validated)
+
+// ✅ ALSO CORRECT: Only reusable flows are flows, rest are utilities
+const validated = await ctx.exec(validateOrder, input)
+const processed = processDataUtil(validated)  // Direct utility call
+```
+
+---
+
+## Troubleshooting
+
+### Issue: Type errors with discriminated unions
+
+**Symptom:** TypeScript can't narrow types after checking `success` field
+
+```typescript
+const result = await ctx.exec(validate, input)
+if (!result.success) {
+  return result  // Type error: can't assign Error to Result
+}
+```
+
+**Solution:** Ensure parent Result type includes all sub-flow errors
+
+```typescript
+// ✅ Parent error union includes child errors
+export namespace Parent {
+  export type Error = Child.Error | { success: false; reason: 'PARENT_ERROR' }
+  export type Result = Success | Error
+}
+```
+
+### Issue: Sub-flow not getting dependencies
+
+**Symptom:** Sub-flow throws error about missing dependencies
+
+```typescript
+const subFlow = flow(
+  { db: dbPool },
+  async ({ db }, _ctx, input) => { /* ... */ }
+)
+
+const parentFlow = flow(async (ctx, input) => {
+  const result = await ctx.exec(subFlow, input)  // Error: db not found
+})
+```
+
+**Solution:** Parent scope must include sub-flow dependencies, or pass through scope
+
+```typescript
+// ✅ Parent includes sub-flow dependencies
+const parentFlow = flow(
+  { db: dbPool },  // Include child deps
+  async ({ db }, ctx, input) => {
+    const result = await ctx.exec(subFlow, input)
+  }
+)
+```
+
+### Issue: Void input confusion
+
+**Symptom:** TypeScript error when calling void input sub-flow
+
+```typescript
+const getConfig = flow<void, Config>(() => { /* ... */ })
+
+const parent = flow(async (ctx, input) => {
+  const config = await ctx.exec(getConfig)  // Error: expected 2 args
+})
+```
+
+**Solution:** Pass `undefined` as input for void flows
+
+```typescript
+// ✅ Pass undefined explicitly
+const config = await ctx.exec(getConfig, undefined)
+```
+
+---
+
+## Related Sub-skills
+
+- **flow-context.md** - Using `ctx.run()`, `ctx.parallel()`, reading/writing context
+- **resource-derived.md** - Composing resources with dependencies
+- **testing-flows.md** - Testing flows with `preset()` for mocking sub-flows
+- **coding-standards.md** - Type safety rules for discriminated unions

--- a/skills/pumped-design/references/integration-hono.md
+++ b/skills/pumped-design/references/integration-hono.md
@@ -1,0 +1,505 @@
+---
+name: integration-hono
+tags: integration, add, hono, http, server, routes, middleware, scope
+description: Hono server integration patterns. One scope for application lifetime, attach to context, route handlers call flows via scope.exec(), transform request to flow input, map flow result to HTTP response. Middleware for scope injection. Error handling at route level.
+---
+
+# Integration: Hono
+
+## When to Use
+
+- Building HTTP APIs with Hono
+- Setting up RESTful endpoints
+- Creating middleware chains
+- Integrating pumped-fn flows with HTTP handlers
+
+## Scope Lifecycle Pattern
+
+**ONE scope for entire application lifetime**
+
+- Create scope at startup
+- Attach to Hono context via middleware
+- Reuse across all requests
+- Dispose on graceful shutdown
+
+## Core Integration Pattern
+
+### 1. Entrypoint Setup
+
+Create scope at application startup, not per-request:
+
+```typescript
+import { Hono } from 'hono'
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig, apiKey } from './resources'
+
+const app = new Hono()
+
+const scope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app',
+      user: process.env.DB_USER || 'postgres',
+      password: process.env.DB_PASSWORD || 'postgres'
+    }),
+    apiKey(process.env.API_KEY || '')
+  ]
+})
+```
+
+### 2. Scope Injection Middleware
+
+Attach scope to context for all routes:
+
+```typescript
+app.use('*', async (c, next) => {
+  c.set('scope', scope)
+  await next()
+})
+```
+
+### 3. Route Handlers with Flow Execution
+
+Transform request → flow input, execute via scope.exec(), map result → HTTP response:
+
+```typescript
+import { createUser, type CreateUser } from './flows'
+
+app.post('/users', async (c) => {
+  const scope = c.get('scope')
+  const body = await c.req.json()
+
+  const result = await scope.exec(createUser, {
+    email: body.email,
+    name: body.name
+  })
+
+  if (!result.success) {
+    return c.json({ error: result.reason }, 400)
+  }
+
+  return c.json(result.user, 201)
+})
+```
+
+## Complete Working Example
+
+```typescript
+import { Hono } from 'hono'
+import { createScope, type Scope } from '@pumped-fn/core-next'
+import { dbConfig } from './resources'
+import { createUser, getUser, updateUser, deleteUser } from './flows'
+
+const app = new Hono()
+
+const scope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app',
+      user: process.env.DB_USER || 'postgres',
+      password: process.env.DB_PASSWORD || 'postgres'
+    })
+  ]
+})
+
+app.use('*', async (c, next) => {
+  c.set('scope', scope)
+  await next()
+})
+
+app.post('/users', async (c) => {
+  const scope = c.get('scope')
+  const body = await c.req.json()
+
+  const result = await scope.exec(createUser, {
+    email: body.email,
+    name: body.name
+  })
+
+  if (!result.success) {
+    const statusMap = {
+      INVALID_EMAIL: 400,
+      EMAIL_EXISTS: 409,
+      NAME_TOO_SHORT: 400
+    }
+    return c.json({ error: result.reason }, statusMap[result.reason] || 400)
+  }
+
+  return c.json(result.user, 201)
+})
+
+app.get('/users/:id', async (c) => {
+  const scope = c.get('scope')
+  const id = c.req.param('id')
+
+  const result = await scope.exec(getUser, { id })
+
+  if (!result.success) {
+    return c.json({ error: result.reason }, 404)
+  }
+
+  return c.json(result.user, 200)
+})
+
+app.put('/users/:id', async (c) => {
+  const scope = c.get('scope')
+  const id = c.req.param('id')
+  const body = await c.req.json()
+
+  const result = await scope.exec(updateUser, {
+    id,
+    email: body.email,
+    name: body.name
+  })
+
+  if (!result.success) {
+    const statusMap = {
+      USER_NOT_FOUND: 404,
+      INVALID_EMAIL: 400
+    }
+    return c.json({ error: result.reason }, statusMap[result.reason] || 400)
+  }
+
+  return c.json(result.user, 200)
+})
+
+app.delete('/users/:id', async (c) => {
+  const scope = c.get('scope')
+  const id = c.req.param('id')
+
+  const result = await scope.exec(deleteUser, { id })
+
+  if (!result.success) {
+    return c.json({ error: result.reason }, 404)
+  }
+
+  return c.json({ success: true }, 200)
+})
+
+export default app
+```
+
+## Request Transformation Pattern
+
+Extract only what flows need from HTTP request:
+
+```typescript
+app.post('/orders', async (c) => {
+  const scope = c.get('scope')
+  const body = await c.req.json()
+
+  const result = await scope.exec(createOrder, {
+    userId: body.userId,
+    items: body.items,
+    shippingAddress: {
+      street: body.shipping.street,
+      city: body.shipping.city,
+      postalCode: body.shipping.postalCode
+    }
+  })
+
+  if (!result.success) {
+    return c.json({ error: result.reason }, 400)
+  }
+
+  return c.json(result.order, 201)
+})
+```
+
+**Key principle:** Transform HTTP-specific objects (req, body, params) into plain data structures before calling flows.
+
+## Response Mapping Pattern
+
+Map discriminated union outputs to HTTP responses:
+
+```typescript
+app.post('/checkout', async (c) => {
+  const scope = c.get('scope')
+  const body = await c.req.json()
+
+  const result = await scope.exec(processCheckout, {
+    userId: body.userId,
+    cartId: body.cartId,
+    paymentMethodId: body.paymentMethodId
+  })
+
+  if (!result.success) {
+    const statusMap = {
+      CART_EMPTY: 400,
+      CART_NOT_FOUND: 404,
+      PAYMENT_DECLINED: 402,
+      INSUFFICIENT_STOCK: 409,
+      USER_NOT_FOUND: 404
+    }
+    return c.json(
+      { error: result.reason, message: result.message },
+      statusMap[result.reason] || 500
+    )
+  }
+
+  return c.json({
+    orderId: result.orderId,
+    total: result.total,
+    estimatedDelivery: result.estimatedDelivery
+  }, 201)
+})
+```
+
+## Middleware Patterns
+
+### Authentication Middleware
+
+```typescript
+import { verify } from 'jsonwebtoken'
+
+app.use('/api/*', async (c, next) => {
+  const authHeader = c.req.header('Authorization')
+
+  if (!authHeader?.startsWith('Bearer ')) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+
+  const token = authHeader.slice(7)
+
+  try {
+    const decoded = verify(token, process.env.JWT_SECRET!)
+    c.set('userId', decoded.sub as string)
+    await next()
+  } catch (error) {
+    return c.json({ error: 'Invalid token' }, 401)
+  }
+})
+
+app.get('/api/profile', async (c) => {
+  const scope = c.get('scope')
+  const userId = c.get('userId')
+
+  const result = await scope.exec(getProfile, { userId })
+
+  if (!result.success) {
+    return c.json({ error: result.reason }, 404)
+  }
+
+  return c.json(result.profile, 200)
+})
+```
+
+### Request Validation Middleware
+
+```typescript
+import { z } from 'zod'
+
+const createUserSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(2),
+  age: z.number().optional()
+})
+
+const validateBody = (schema: z.ZodSchema) => {
+  return async (c: any, next: any) => {
+    try {
+      const body = await c.req.json()
+      const validated = schema.parse(body)
+      c.set('validatedBody', validated)
+      await next()
+    } catch (error) {
+      return c.json({ error: 'Validation failed', details: error }, 400)
+    }
+  }
+}
+
+app.post('/users', validateBody(createUserSchema), async (c) => {
+  const scope = c.get('scope')
+  const body = c.get('validatedBody')
+
+  const result = await scope.exec(createUser, body)
+
+  if (!result.success) {
+    return c.json({ error: result.reason }, 400)
+  }
+
+  return c.json(result.user, 201)
+})
+```
+
+### Error Handling Middleware
+
+```typescript
+app.onError((error, c) => {
+  console.error('Unhandled error:', error)
+
+  return c.json({
+    error: 'Internal server error',
+    message: process.env.NODE_ENV === 'development' ? error.message : undefined
+  }, 500)
+})
+```
+
+## Graceful Shutdown
+
+```typescript
+import { serve } from '@hono/node-server'
+
+const server = serve({
+  fetch: app.fetch,
+  port: 3000
+})
+
+const shutdown = async () => {
+  console.log('Shutting down gracefully...')
+
+  server.close(() => {
+    console.log('HTTP server closed')
+  })
+
+  await scope.dispose()
+  console.log('Resources disposed')
+
+  process.exit(0)
+}
+
+process.on('SIGTERM', shutdown)
+process.on('SIGINT', shutdown)
+
+console.log('Server listening on port 3000')
+```
+
+## Type-safe Context
+
+Extend Hono context with scope type:
+
+```typescript
+import { Hono } from 'hono'
+import { type Scope } from '@pumped-fn/core-next'
+
+type Env = {
+  Variables: {
+    scope: Scope
+    userId?: string
+  }
+}
+
+const app = new Hono<Env>()
+
+app.use('*', async (c, next) => {
+  c.set('scope', scope)
+  await next()
+})
+
+app.get('/users/:id', async (c) => {
+  const scope = c.get('scope')
+  const id = c.req.param('id')
+
+  const result = await scope.exec(getUser, { id })
+
+  if (!result.success) {
+    return c.json({ error: result.reason }, 404)
+  }
+
+  return c.json(result.user)
+})
+```
+
+## Troubleshooting
+
+### Scope not found in context
+
+**Problem:** `c.get('scope')` returns undefined
+
+**Solution:**
+- Ensure middleware runs before routes: `app.use('*', ...)`
+- Verify scope creation happens before middleware registration
+- Check middleware order (scope injection must be first)
+
+### Scope created per-request
+
+**Problem:** Performance issues, connection pool exhaustion
+
+**Solution:**
+```typescript
+// ❌ Wrong - creates scope per request
+app.use('*', async (c, next) => {
+  const scope = createScope({ tags: [...] })
+  c.set('scope', scope)
+  await next()
+})
+
+// ✅ Correct - one scope for app lifetime
+const scope = createScope({ tags: [...] })
+
+app.use('*', async (c, next) => {
+  c.set('scope', scope)
+  await next()
+})
+```
+
+### Passing req/res to flows
+
+**Problem:** Framework-specific objects in flow inputs
+
+**Solution:**
+```typescript
+// ❌ Wrong - passing framework objects
+const result = await scope.exec(createUser, { req, body: req.body })
+
+// ✅ Correct - extract plain data
+const body = await c.req.json()
+const result = await scope.exec(createUser, {
+  email: body.email,
+  name: body.name
+})
+```
+
+### Missing error branch handling
+
+**Problem:** Some flow error cases not mapped to HTTP status
+
+**Solution:**
+```typescript
+// ❌ Wrong - incomplete error mapping
+if (!result.success) {
+  return c.json({ error: result.reason }, 400)
+}
+
+// ✅ Correct - explicit status per error reason
+if (!result.success) {
+  const statusMap = {
+    INVALID_EMAIL: 400,
+    EMAIL_EXISTS: 409,
+    DATABASE_ERROR: 500
+  }
+  return c.json({ error: result.reason }, statusMap[result.reason] || 500)
+}
+```
+
+### Resources disposed prematurely
+
+**Problem:** Connections closed while server still running
+
+**Solution:**
+```typescript
+// ❌ Wrong - disposing too early
+app.get('/users', async (c) => {
+  const scope = c.get('scope')
+  const result = await scope.exec(getUsers, {})
+  await scope.dispose() // NEVER do this
+  return c.json(result.users)
+})
+
+// ✅ Correct - dispose only on shutdown
+const shutdown = async () => {
+  await scope.dispose()
+  process.exit(0)
+}
+```
+
+## Related Sub-skills
+
+- `coding-standards.md` - Type safety and naming conventions
+- `flow-subflows.md` - Orchestrating flows called from routes
+- `entrypoint-patterns.md` - Application bootstrap and lifecycle
+- `extension-basics.md` - Adding logging/metrics to HTTP handlers

--- a/skills/pumped-design/references/integration-nextjs.md
+++ b/skills/pumped-design/references/integration-nextjs.md
@@ -1,0 +1,629 @@
+---
+name: integration-nextjs
+tags: integration, add, nextjs, ssr, react, server-actions, api-routes, app-router
+description: Next.js integration patterns. Module-level scope singleton, import where needed, use in Server Components/Actions/API Routes. Server Actions for mutations, API Routes for external APIs, Server Components for data fetching. Never dispose (long-running server). Client components call Server Actions or API Routes.
+---
+
+# Integration: Next.js
+
+## When to Use
+
+- Building Next.js applications (App Router or Pages Router)
+- Server Components data fetching
+- Server Actions for mutations
+- API Routes for external APIs
+- SSR/SSG with pumped-fn flows
+
+## Scope Lifecycle Pattern
+
+**Module-level scope (singleton), never dispose**
+
+- Create scope at module level
+- Import scope where needed
+- Use in Server Components, Server Actions, API Routes
+- Long-running server (no disposal needed)
+
+## Core Integration Pattern
+
+### 1. Create Module-level Scope
+
+Create scope in shared module, import where needed:
+
+```typescript
+// src/lib/scope.ts
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig, apiKey } from '@/resources'
+
+export const appScope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app',
+      user: process.env.DB_USER || 'postgres',
+      password: process.env.DB_PASSWORD || 'postgres'
+    }),
+    apiKey(process.env.API_KEY || '')
+  ]
+})
+```
+
+### 2. Server Components with Flow Execution
+
+Use scope directly in Server Components:
+
+```typescript
+// src/app/users/page.tsx
+import { appScope } from '@/lib/scope'
+import { listUsers } from '@/flows'
+
+export default async function UsersPage() {
+  const result = await appScope.exec(listUsers, {})
+
+  if (!result.success) {
+    return <div>Error: {result.reason}</div>
+  }
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <ul>
+        {result.users.map(user => (
+          <li key={user.id}>{user.name} - {user.email}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+### 3. Server Actions for Mutations
+
+Use "use server" directive with scope:
+
+```typescript
+// src/app/users/actions.ts
+'use server'
+
+import { appScope } from '@/lib/scope'
+import { createUser, updateUser, deleteUser } from '@/flows'
+import { revalidatePath } from 'next/cache'
+
+export async function createUserAction(formData: FormData) {
+  const email = formData.get('email') as string
+  const name = formData.get('name') as string
+
+  const result = await appScope.exec(createUser, { email, name })
+
+  if (!result.success) {
+    return { error: result.reason }
+  }
+
+  revalidatePath('/users')
+  return { success: true, user: result.user }
+}
+
+export async function updateUserAction(id: string, formData: FormData) {
+  const email = formData.get('email') as string
+  const name = formData.get('name') as string
+
+  const result = await appScope.exec(updateUser, { id, email, name })
+
+  if (!result.success) {
+    return { error: result.reason }
+  }
+
+  revalidatePath('/users')
+  revalidatePath(`/users/${id}`)
+  return { success: true, user: result.user }
+}
+
+export async function deleteUserAction(id: string) {
+  const result = await appScope.exec(deleteUser, { id })
+
+  if (!result.success) {
+    return { error: result.reason }
+  }
+
+  revalidatePath('/users')
+  return { success: true }
+}
+```
+
+### 4. Client Components Calling Server Actions
+
+Client components use Server Actions via forms or transitions:
+
+```typescript
+// src/app/users/create-form.tsx
+'use client'
+
+import { useFormState, useFormStatus } from 'react-dom'
+import { createUserAction } from './actions'
+
+function SubmitButton() {
+  const { pending } = useFormStatus()
+
+  return (
+    <button type="submit" disabled={pending}>
+      {pending ? 'Creating...' : 'Create User'}
+    </button>
+  )
+}
+
+export function CreateUserForm() {
+  const [state, formAction] = useFormState(createUserAction, null)
+
+  return (
+    <form action={formAction}>
+      <input name="email" type="email" required placeholder="Email" />
+      <input name="name" type="text" required placeholder="Name" />
+      <SubmitButton />
+      {state?.error && <p>Error: {state.error}</p>}
+      {state?.success && <p>User created!</p>}
+    </form>
+  )
+}
+```
+
+## API Routes Pattern (App Router)
+
+### Route Handlers with Scope
+
+```typescript
+// src/app/api/users/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { appScope } from '@/lib/scope'
+import { createUser, listUsers } from '@/flows'
+
+export async function GET(request: NextRequest) {
+  const result = await appScope.exec(listUsers, {})
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.reason }, { status: 500 })
+  }
+
+  return NextResponse.json(result.users)
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json()
+
+  const result = await appScope.exec(createUser, {
+    email: body.email,
+    name: body.name
+  })
+
+  if (!result.success) {
+    const statusMap = {
+      INVALID_EMAIL: 400,
+      EMAIL_EXISTS: 409,
+      NAME_TOO_SHORT: 400
+    }
+    return NextResponse.json(
+      { error: result.reason },
+      { status: statusMap[result.reason] || 400 }
+    )
+  }
+
+  return NextResponse.json(result.user, { status: 201 })
+}
+```
+
+### Dynamic Route Handlers
+
+```typescript
+// src/app/api/users/[id]/route.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { appScope } from '@/lib/scope'
+import { getUser, updateUser, deleteUser } from '@/flows'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const result = await appScope.exec(getUser, { id: params.id })
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.reason }, { status: 404 })
+  }
+
+  return NextResponse.json(result.user)
+}
+
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const body = await request.json()
+
+  const result = await appScope.exec(updateUser, {
+    id: params.id,
+    email: body.email,
+    name: body.name
+  })
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.reason }, { status: 400 })
+  }
+
+  return NextResponse.json(result.user)
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const result = await appScope.exec(deleteUser, { id: params.id })
+
+  if (!result.success) {
+    return NextResponse.json({ error: result.reason }, { status: 404 })
+  }
+
+  return NextResponse.json({ success: true })
+}
+```
+
+## API Routes Pattern (Pages Router)
+
+```typescript
+// pages/api/users/index.ts
+import { NextApiRequest, NextApiResponse } from 'next'
+import { appScope } from '@/lib/scope'
+import { createUser, listUsers } from '@/flows'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const result = await appScope.exec(listUsers, {})
+
+    if (!result.success) {
+      return res.status(500).json({ error: result.reason })
+    }
+
+    return res.status(200).json(result.users)
+  }
+
+  if (req.method === 'POST') {
+    const result = await appScope.exec(createUser, {
+      email: req.body.email,
+      name: req.body.name
+    })
+
+    if (!result.success) {
+      const statusMap = {
+        INVALID_EMAIL: 400,
+        EMAIL_EXISTS: 409,
+        NAME_TOO_SHORT: 400
+      }
+      return res.status(statusMap[result.reason] || 400).json({
+        error: result.reason
+      })
+    }
+
+    return res.status(201).json(result.user)
+  }
+
+  return res.status(405).json({ error: 'Method not allowed' })
+}
+```
+
+## Server-side Rendering (getServerSideProps)
+
+```typescript
+// pages/users/index.tsx
+import { GetServerSideProps } from 'next'
+import { appScope } from '@/lib/scope'
+import { listUsers } from '@/flows'
+
+export const getServerSideProps: GetServerSideProps = async () => {
+  const result = await appScope.exec(listUsers, {})
+
+  if (!result.success) {
+    return {
+      props: { users: [], error: result.reason }
+    }
+  }
+
+  return {
+    props: { users: result.users, error: null }
+  }
+}
+
+export default function UsersPage({ users, error }: { users: any[]; error: string | null }) {
+  if (error) {
+    return <div>Error: {error}</div>
+  }
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>{user.name} - {user.email}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+## Static Site Generation (getStaticProps)
+
+```typescript
+// pages/users/[id].tsx
+import { GetStaticProps, GetStaticPaths } from 'next'
+import { appScope } from '@/lib/scope'
+import { getUser, listUsers } from '@/flows'
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const result = await appScope.exec(listUsers, {})
+
+  if (!result.success) {
+    return { paths: [], fallback: 'blocking' }
+  }
+
+  const paths = result.users.map(user => ({
+    params: { id: user.id }
+  }))
+
+  return { paths, fallback: 'blocking' }
+}
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const result = await appScope.exec(getUser, { id: params?.id as string })
+
+  if (!result.success) {
+    return { notFound: true }
+  }
+
+  return {
+    props: { user: result.user },
+    revalidate: 60
+  }
+}
+
+export default function UserPage({ user }: { user: any }) {
+  return (
+    <div>
+      <h1>{user.name}</h1>
+      <p>{user.email}</p>
+    </div>
+  )
+}
+```
+
+## Middleware Pattern
+
+```typescript
+// src/middleware.ts
+import { NextRequest, NextResponse } from 'next/server'
+import { appScope } from '@/lib/scope'
+import { validateSession } from '@/flows'
+
+export async function middleware(request: NextRequest) {
+  const sessionToken = request.cookies.get('session')?.value
+
+  if (!sessionToken) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  const result = await appScope.exec(validateSession, { token: sessionToken })
+
+  if (!result.success) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  const response = NextResponse.next()
+  response.headers.set('x-user-id', result.userId)
+
+  return response
+}
+
+export const config = {
+  matcher: ['/dashboard/:path*', '/api/protected/:path*']
+}
+```
+
+## Progressive Enhancement with Forms
+
+```typescript
+// src/app/users/page.tsx
+import { appScope } from '@/lib/scope'
+import { listUsers } from '@/flows'
+import { CreateUserForm } from './create-form'
+
+export default async function UsersPage() {
+  const result = await appScope.exec(listUsers, {})
+
+  if (!result.success) {
+    return <div>Error loading users</div>
+  }
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <CreateUserForm />
+      <ul>
+        {result.users.map(user => (
+          <li key={user.id}>{user.name} - {user.email}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+```typescript
+// src/app/users/create-form.tsx
+'use client'
+
+import { useFormState } from 'react-dom'
+import { createUserAction } from './actions'
+
+export function CreateUserForm() {
+  const [state, formAction] = useFormState(createUserAction, null)
+
+  return (
+    <form action={formAction}>
+      <input name="email" type="email" required />
+      <input name="name" type="text" required />
+      <button type="submit">Create</button>
+      {state?.error && <p>Error: {state.error}</p>}
+    </form>
+  )
+}
+```
+
+## Troubleshooting
+
+### Scope created per-request
+
+**Problem:** New scope on every request, performance issues
+
+**Solution:**
+```typescript
+// ❌ Wrong - creating scope in route/action
+export async function GET(request: NextRequest) {
+  const scope = createScope({ tags: [...] }) // Don't do this
+  const result = await scope.exec(listUsers, {})
+  return NextResponse.json(result.users)
+}
+
+// ✅ Correct - module-level scope
+// src/lib/scope.ts
+export const appScope = createScope({ tags: [...] })
+
+// src/app/api/users/route.ts
+import { appScope } from '@/lib/scope'
+
+export async function GET(request: NextRequest) {
+  const result = await appScope.exec(listUsers, {})
+  return NextResponse.json(result.users)
+}
+```
+
+### Using flows in Client Components
+
+**Problem:** Flows imported in "use client" components
+
+**Solution:**
+```typescript
+// ❌ Wrong - can't use flows directly in client
+'use client'
+
+import { appScope } from '@/lib/scope'
+import { createUser } from '@/flows'
+
+export function UserForm() {
+  const handleSubmit = async (e) => {
+    const result = await appScope.exec(createUser, {...}) // Server code!
+  }
+}
+
+// ✅ Correct - use Server Actions
+// actions.ts
+'use server'
+export async function createUserAction(data) {
+  return appScope.exec(createUser, data)
+}
+
+// form.tsx
+'use client'
+import { createUserAction } from './actions'
+
+export function UserForm() {
+  const handleSubmit = async (e) => {
+    const result = await createUserAction({ email, name })
+  }
+}
+```
+
+### Missing revalidation after mutations
+
+**Problem:** Stale data shown after Server Action completes
+
+**Solution:**
+```typescript
+// ❌ Wrong - no revalidation
+'use server'
+
+export async function createUserAction(formData: FormData) {
+  const result = await appScope.exec(createUser, {...})
+  return result // Page shows stale data
+}
+
+// ✅ Correct - revalidate paths
+'use server'
+
+import { revalidatePath } from 'next/cache'
+
+export async function createUserAction(formData: FormData) {
+  const result = await appScope.exec(createUser, {...})
+
+  if (result.success) {
+    revalidatePath('/users')
+  }
+
+  return result
+}
+```
+
+### Environment variables not available
+
+**Problem:** process.env.* undefined in scope creation
+
+**Solution:**
+- Ensure variables defined in .env.local
+- Prefix with NEXT_PUBLIC_ for client-side access
+- Access server-side variables only in Server Components/Actions/API Routes
+- Never expose sensitive values to client
+
+```typescript
+// ✅ Correct - server-only scope
+// src/lib/scope.ts
+export const appScope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST!, // Server-side only
+      password: process.env.DB_PASSWORD! // Never NEXT_PUBLIC_
+    })
+  ]
+})
+```
+
+### Disposal in Server Actions
+
+**Problem:** Calling scope.dispose() in actions/routes
+
+**Solution:**
+```typescript
+// ❌ Wrong - never dispose in Next.js
+export async function createUserAction(data) {
+  const result = await appScope.exec(createUser, data)
+  await appScope.dispose() // NEVER do this
+  return result
+}
+
+// ✅ Correct - never dispose (long-running server)
+export async function createUserAction(data) {
+  const result = await appScope.exec(createUser, data)
+  return result
+}
+```
+
+### Mixing App Router and Pages Router patterns
+
+**Problem:** Inconsistent data fetching patterns
+
+**Solution:**
+- Choose one router architecture
+- App Router: Use Server Components and Server Actions
+- Pages Router: Use getServerSideProps/getStaticProps and API Routes
+- Don't mix patterns in same application
+
+## Related Sub-skills
+
+- `coding-standards.md` - Type safety and file organization
+- `flow-subflows.md` - Orchestrating business logic
+- `entrypoint-patterns.md` - Application initialization
+- `testing-flows.md` - Testing Server Actions and flows

--- a/skills/pumped-design/references/integration-tanstack.md
+++ b/skills/pumped-design/references/integration-tanstack.md
@@ -1,0 +1,739 @@
+---
+name: integration-tanstack
+tags: integration, add, tanstack, router, ssr, loader, action, start
+description: TanStack Start/Router integration patterns. Module-level scope singleton, use in loaders/actions for data fetching and mutations. Loaders for SSR data, actions for mutations, scope shared across request lifecycle. Type-safe routing with flow results. Error boundaries handle flow errors.
+---
+
+# Integration: TanStack Start
+
+## When to Use
+
+- Building TanStack Start applications
+- Type-safe routing with TanStack Router
+- SSR data fetching with loaders
+- Mutations with actions
+- Full-stack TypeScript applications
+
+## Scope Lifecycle Pattern
+
+**Module-level scope (singleton), shared across SSR lifecycle**
+
+- Create scope at module level
+- Import scope in route files
+- Use in loaders (data fetching) and actions (mutations)
+- Scope persists across requests (long-running server)
+
+## Core Integration Pattern
+
+### 1. Create Module-level Scope
+
+```typescript
+// src/lib/scope.ts
+import { createScope } from '@pumped-fn/core-next'
+import { dbConfig, apiKey } from '@/resources'
+
+export const appScope = createScope({
+  tags: [
+    dbConfig({
+      host: process.env.DB_HOST || 'localhost',
+      port: parseInt(process.env.DB_PORT || '5432'),
+      database: process.env.DB_NAME || 'app',
+      user: process.env.DB_USER || 'postgres',
+      password: process.env.DB_PASSWORD || 'postgres'
+    }),
+    apiKey(process.env.API_KEY || '')
+  ]
+})
+```
+
+### 2. Loaders for Data Fetching
+
+Use scope in route loaders for SSR data:
+
+```typescript
+// src/routes/users.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { appScope } from '@/lib/scope'
+import { listUsers } from '@/flows'
+
+export const Route = createFileRoute('/users')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return { users: result.users }
+  },
+  component: UsersPage
+})
+
+function UsersPage() {
+  const { users } = Route.useLoaderData()
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>{user.name} - {user.email}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+### 3. Dynamic Route Loaders
+
+```typescript
+// src/routes/users/$userId.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { appScope } from '@/lib/scope'
+import { getUser } from '@/flows'
+
+export const Route = createFileRoute('/users/$userId')({
+  loader: async ({ params }) => {
+    const result = await appScope.exec(getUser, { id: params.userId })
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return { user: result.user }
+  },
+  component: UserDetailPage
+})
+
+function UserDetailPage() {
+  const { user } = Route.useLoaderData()
+
+  return (
+    <div>
+      <h1>{user.name}</h1>
+      <p>{user.email}</p>
+      <p>Created: {user.createdAt.toLocaleDateString()}</p>
+    </div>
+  )
+}
+```
+
+### 4. Actions for Mutations
+
+Use scope in server functions for mutations:
+
+```typescript
+// src/routes/users/index.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/start'
+import { appScope } from '@/lib/scope'
+import { createUser, listUsers } from '@/flows'
+
+const createUserAction = createServerFn('POST', async (data: { email: string; name: string }) => {
+  const result = await appScope.exec(createUser, data)
+
+  if (!result.success) {
+    throw new Error(result.reason)
+  }
+
+  return result.user
+})
+
+export const Route = createFileRoute('/users/')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return { users: result.users }
+  },
+  component: UsersPage
+})
+
+function UsersPage() {
+  const { users } = Route.useLoaderData()
+  const navigate = Route.useNavigate()
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+
+    try {
+      await createUserAction({
+        email: formData.get('email') as string,
+        name: formData.get('name') as string
+      })
+
+      navigate({ to: '/users' })
+    } catch (error) {
+      console.error('Failed to create user:', error)
+    }
+  }
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <form onSubmit={handleSubmit}>
+        <input name="email" type="email" required />
+        <input name="name" type="text" required />
+        <button type="submit">Create User</button>
+      </form>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>{user.name} - {user.email}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+## Complete CRUD Example
+
+```typescript
+// src/routes/users.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/start'
+import { appScope } from '@/lib/scope'
+import { listUsers, createUser, updateUser, deleteUser } from '@/flows'
+
+const createUserFn = createServerFn('POST', async (data: { email: string; name: string }) => {
+  const result = await appScope.exec(createUser, data)
+
+  if (!result.success) {
+    throw new Error(result.reason)
+  }
+
+  return result.user
+})
+
+const updateUserFn = createServerFn('PUT', async (data: { id: string; email: string; name: string }) => {
+  const result = await appScope.exec(updateUser, data)
+
+  if (!result.success) {
+    throw new Error(result.reason)
+  }
+
+  return result.user
+})
+
+const deleteUserFn = createServerFn('DELETE', async (data: { id: string }) => {
+  const result = await appScope.exec(deleteUser, data)
+
+  if (!result.success) {
+    throw new Error(result.reason)
+  }
+
+  return { success: true }
+})
+
+export const Route = createFileRoute('/users')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return { users: result.users }
+  },
+  component: UsersPage
+})
+
+function UsersPage() {
+  const { users } = Route.useLoaderData()
+  const navigate = Route.useNavigate()
+
+  const handleCreate = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+
+    await createUserFn({
+      email: formData.get('email') as string,
+      name: formData.get('name') as string
+    })
+
+    navigate({ to: '/users' })
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete user?')) return
+
+    await deleteUserFn({ id })
+    navigate({ to: '/users' })
+  }
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <form onSubmit={handleCreate}>
+        <input name="email" type="email" placeholder="Email" required />
+        <input name="name" type="text" placeholder="Name" required />
+        <button type="submit">Create</button>
+      </form>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>
+            {user.name} - {user.email}
+            <button onClick={() => handleDelete(user.id)}>Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+## Search Params with Loaders
+
+```typescript
+// src/routes/users/index.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { appScope } from '@/lib/scope'
+import { searchUsers } from '@/flows'
+import { z } from 'zod'
+
+const usersSearchSchema = z.object({
+  query: z.string().optional(),
+  page: z.number().optional()
+})
+
+export const Route = createFileRoute('/users/')({
+  validateSearch: usersSearchSchema,
+  loaderDeps: ({ search }) => ({ search }),
+  loader: async ({ deps }) => {
+    const result = await appScope.exec(searchUsers, {
+      query: deps.search.query || '',
+      page: deps.search.page || 1
+    })
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return { users: result.users, total: result.total }
+  },
+  component: UsersPage
+})
+
+function UsersPage() {
+  const { users, total } = Route.useLoaderData()
+  const navigate = Route.useNavigate()
+  const { query } = Route.useSearch()
+
+  const handleSearch = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    const query = formData.get('query') as string
+
+    navigate({ search: { query } })
+  }
+
+  return (
+    <div>
+      <h1>Users ({total})</h1>
+      <form onSubmit={handleSearch}>
+        <input name="query" defaultValue={query} placeholder="Search..." />
+        <button type="submit">Search</button>
+      </form>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>{user.name} - {user.email}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+## Error Boundaries
+
+```typescript
+// src/routes/__root.tsx
+import { createRootRoute, Outlet } from '@tanstack/react-router'
+
+export const Route = createRootRoute({
+  component: RootComponent,
+  errorComponent: ({ error }) => (
+    <div>
+      <h1>Error</h1>
+      <p>{error.message}</p>
+    </div>
+  )
+})
+
+function RootComponent() {
+  return (
+    <>
+      <nav>
+        <a href="/users">Users</a>
+      </nav>
+      <Outlet />
+    </>
+  )
+}
+```
+
+## Optimistic Updates
+
+```typescript
+// src/routes/users/index.tsx
+import { createFileRoute, useRouter } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/start'
+import { appScope } from '@/lib/scope'
+import { createUser, listUsers } from '@/flows'
+import { useState } from 'react'
+
+const createUserFn = createServerFn('POST', async (data: { email: string; name: string }) => {
+  const result = await appScope.exec(createUser, data)
+
+  if (!result.success) {
+    throw new Error(result.reason)
+  }
+
+  return result.user
+})
+
+export const Route = createFileRoute('/users/')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return { users: result.users }
+  },
+  component: UsersPage
+})
+
+function UsersPage() {
+  const { users } = Route.useLoaderData()
+  const router = useRouter()
+  const [optimisticUsers, setOptimisticUsers] = useState(users)
+
+  const handleCreate = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+    const email = formData.get('email') as string
+    const name = formData.get('name') as string
+
+    const tempUser = {
+      id: `temp-${Date.now()}`,
+      email,
+      name,
+      createdAt: new Date()
+    }
+
+    setOptimisticUsers([...optimisticUsers, tempUser])
+
+    try {
+      const user = await createUserFn({ email, name })
+      await router.invalidate()
+    } catch (error) {
+      setOptimisticUsers(optimisticUsers)
+      console.error('Failed to create user:', error)
+    }
+  }
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <form onSubmit={handleCreate}>
+        <input name="email" type="email" required />
+        <input name="name" type="text" required />
+        <button type="submit">Create</button>
+      </form>
+      <ul>
+        {optimisticUsers.map(user => (
+          <li key={user.id}>{user.name} - {user.email}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+## Pending States
+
+```typescript
+// src/routes/users/index.tsx
+import { createFileRoute, useRouter } from '@tanstack/react-router'
+import { createServerFn } from '@tanstack/start'
+import { appScope } from '@/lib/scope'
+import { createUser, listUsers } from '@/flows'
+import { useState } from 'react'
+
+const createUserFn = createServerFn('POST', async (data: { email: string; name: string }) => {
+  const result = await appScope.exec(createUser, data)
+
+  if (!result.success) {
+    throw new Error(result.reason)
+  }
+
+  return result.user
+})
+
+export const Route = createFileRoute('/users/')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return { users: result.users }
+  },
+  component: UsersPage
+})
+
+function UsersPage() {
+  const { users } = Route.useLoaderData()
+  const router = useRouter()
+  const [isPending, setIsPending] = useState(false)
+
+  const handleCreate = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    const formData = new FormData(e.currentTarget)
+
+    setIsPending(true)
+
+    try {
+      await createUserFn({
+        email: formData.get('email') as string,
+        name: formData.get('name') as string
+      })
+
+      await router.invalidate()
+      e.currentTarget.reset()
+    } catch (error) {
+      console.error('Failed to create user:', error)
+    } finally {
+      setIsPending(false)
+    }
+  }
+
+  return (
+    <div>
+      <h1>Users</h1>
+      <form onSubmit={handleCreate}>
+        <input name="email" type="email" required disabled={isPending} />
+        <input name="name" type="text" required disabled={isPending} />
+        <button type="submit" disabled={isPending}>
+          {isPending ? 'Creating...' : 'Create User'}
+        </button>
+      </form>
+      <ul>
+        {users.map(user => (
+          <li key={user.id}>{user.name} - {user.email}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+```
+
+## Authentication with Before Load
+
+```typescript
+// src/routes/_authenticated.tsx
+import { createFileRoute, redirect } from '@tanstack/react-router'
+import { appScope } from '@/lib/scope'
+import { validateSession } from '@/flows'
+
+export const Route = createFileRoute('/_authenticated')({
+  beforeLoad: async ({ context }) => {
+    const sessionToken = context.session?.token
+
+    if (!sessionToken) {
+      throw redirect({ to: '/login' })
+    }
+
+    const result = await appScope.exec(validateSession, { token: sessionToken })
+
+    if (!result.success) {
+      throw redirect({ to: '/login' })
+    }
+
+    return { userId: result.userId }
+  }
+})
+```
+
+```typescript
+// src/routes/_authenticated/dashboard.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { appScope } from '@/lib/scope'
+import { getUserDashboard } from '@/flows'
+
+export const Route = createFileRoute('/_authenticated/dashboard')({
+  loader: async ({ context }) => {
+    const result = await appScope.exec(getUserDashboard, { userId: context.userId })
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return { dashboard: result.dashboard }
+  },
+  component: DashboardPage
+})
+
+function DashboardPage() {
+  const { dashboard } = Route.useLoaderData()
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <p>Welcome back!</p>
+      <pre>{JSON.stringify(dashboard, null, 2)}</pre>
+    </div>
+  )
+}
+```
+
+## Troubleshooting
+
+### Scope created in loader/action
+
+**Problem:** New scope per request, performance issues
+
+**Solution:**
+```typescript
+// ❌ Wrong - creating scope in loader
+export const Route = createFileRoute('/users')({
+  loader: async () => {
+    const scope = createScope({ tags: [...] }) // Don't do this
+    const result = await scope.exec(listUsers, {})
+    return { users: result.users }
+  }
+})
+
+// ✅ Correct - module-level scope
+// src/lib/scope.ts
+export const appScope = createScope({ tags: [...] })
+
+// src/routes/users.tsx
+import { appScope } from '@/lib/scope'
+
+export const Route = createFileRoute('/users')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+    return { users: result.users }
+  }
+})
+```
+
+### Throwing raw errors from flows
+
+**Problem:** Discriminated unions not converted to thrown errors
+
+**Solution:**
+```typescript
+// ❌ Wrong - returning error, not throwing
+export const Route = createFileRoute('/users')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+    return result // Component gets error object
+  }
+})
+
+// ✅ Correct - throw on error
+export const Route = createFileRoute('/users')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return { users: result.users }
+  }
+})
+```
+
+### Missing loader dependencies
+
+**Problem:** Loader doesn't re-run when search params change
+
+**Solution:**
+```typescript
+// ❌ Wrong - no loaderDeps
+export const Route = createFileRoute('/users')({
+  loader: async ({ search }) => {
+    const result = await appScope.exec(searchUsers, { query: search.query })
+    return result
+  }
+})
+
+// ✅ Correct - declare dependencies
+export const Route = createFileRoute('/users')({
+  loaderDeps: ({ search }) => ({ search }),
+  loader: async ({ deps }) => {
+    const result = await appScope.exec(searchUsers, { query: deps.search.query })
+
+    if (!result.success) {
+      throw new Error(result.reason)
+    }
+
+    return result
+  }
+})
+```
+
+### Stale data after mutation
+
+**Problem:** UI doesn't update after server function completes
+
+**Solution:**
+```typescript
+// ❌ Wrong - no invalidation
+const handleCreate = async (data) => {
+  await createUserFn(data)
+  // UI shows stale data
+}
+
+// ✅ Correct - invalidate router
+import { useRouter } from '@tanstack/react-router'
+
+const router = useRouter()
+
+const handleCreate = async (data) => {
+  await createUserFn(data)
+  await router.invalidate() // Refetch loader data
+}
+```
+
+### Disposal in loaders/actions
+
+**Problem:** Calling scope.dispose() in routes
+
+**Solution:**
+```typescript
+// ❌ Wrong - never dispose in TanStack Start
+export const Route = createFileRoute('/users')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+    await appScope.dispose() // NEVER do this
+    return result
+  }
+})
+
+// ✅ Correct - never dispose (long-running server)
+export const Route = createFileRoute('/users')({
+  loader: async () => {
+    const result = await appScope.exec(listUsers, {})
+    return result
+  }
+})
+```
+
+## Related Sub-skills
+
+- `coding-standards.md` - Type safety and discriminated unions
+- `flow-subflows.md` - Orchestrating business logic
+- `entrypoint-patterns.md` - Application structure
+- `testing-flows.md` - Testing loaders and actions

--- a/skills/pumped-design/references/resource-basic.md
+++ b/skills/pumped-design/references/resource-basic.md
@@ -1,0 +1,313 @@
+---
+name: resource-basic
+tags: resource, add, config, lifecycle, provide, cleanup, external
+description: Standalone resources for external systems (database, HTTP clients, cache) using provide(). Includes configuration via tags, lifecycle management with controller.cleanup(), and proper resource disposal patterns.
+---
+
+# Resource: Basic Patterns
+
+## When to Use
+
+Use basic resources (`provide()`) when:
+
+- Integrating external systems (database pools, HTTP clients, cache connections)
+- Managing stateful connections with lifecycle (open/close, connect/dispose)
+- Wrapping third-party libraries with cleanup requirements
+- Creating resources that don't depend on other resources
+
+**Don't use for:**
+- Resources depending on other resources (use `derive()` instead)
+- Business logic (belongs in flows)
+- Data access operations (belongs in repositories via `derive()`)
+
+---
+
+## Code Template
+
+```typescript
+import { provide, tag, custom } from '@pumped-fn/core-next'
+import { Pool } from 'pg'
+
+// Configuration via tags
+export const dbConfig = tag(custom<{
+  host: string
+  port: number
+  database: string
+}>(), { label: 'config.database' })
+
+// Basic resource with lifecycle
+export const dbPool = provide((controller) => {
+  const config = dbConfig.get(controller.scope)
+
+  const pool = new Pool({
+    host: config.host,
+    port: config.port,
+    database: config.database,
+    max: 20
+  })
+
+  // Register cleanup
+  controller.cleanup(async () => {
+    await pool.end()
+  })
+
+  // Return resource interface
+  return {
+    query: async <T>(sql: string, params: any[]): Promise<T[]> => {
+      const result = await pool.query(sql, params)
+      return result.rows
+    }
+  }
+})
+```
+
+---
+
+## Real Examples from Pumped-fn Tests
+
+### Example 1: Simple Resource (packages/next/tests/core.test.ts)
+
+```typescript
+const baseExecutor = provide(() => {
+  executionOrder.push("base")
+  return 1
+})
+```
+
+### Example 2: Async Resource with Lifecycle (packages/next/tests/core.test.ts)
+
+```typescript
+const dbConnection = provide(() => {
+  dbConnectionCount++
+  return { connected: true, id: dbConnectionCount }
+})
+```
+
+### Example 3: Resource with Configuration (packages/next/tests/core.test.ts)
+
+```typescript
+const config = provide(() => ({ multiplier: 3 }))
+
+const multiplyFlow = flow(config, (deps, _ctx, input: number) => {
+  return input * deps.multiplier
+})
+```
+
+### Example 4: Resource with Cleanup (from templates.md)
+
+```typescript
+const dbPool = provide((controller) => {
+  const pool = new Pool({ /* config */ })
+
+  controller.cleanup(async () => {
+    await pool.end()
+  })
+
+  return {
+    query: async <T>(sql: string, params: any[]): Promise<T[]> => {
+      const result = await pool.query(sql, params)
+      return result.rows
+    },
+    transaction: async <T>(callback: (client: any) => Promise<T>): Promise<T> => {
+      const client = await pool.connect()
+      try {
+        await client.query('BEGIN')
+        const result = await callback(client)
+        await client.query('COMMIT')
+        return result
+      } catch (error) {
+        await client.query('ROLLBACK')
+        throw error
+      } finally {
+        client.release()
+      }
+    }
+  }
+})
+```
+
+---
+
+## Configuration Pattern
+
+**ALWAYS use tags for configuration, NEVER access process.env directly inside resources.**
+
+```typescript
+// ✅ Correct: Configuration via tags
+export const apiUrl = tag(custom<string>(), { label: 'config.apiUrl' })
+export const apiKey = tag(custom<string>(), { label: 'config.apiKey' })
+
+export const externalApi = provide((controller) => {
+  const url = apiUrl.get(controller.scope)
+  const key = apiKey.get(controller.scope)
+
+  return {
+    get: async <T>(path: string): Promise<T> => {
+      const response = await fetch(`${url}${path}`, {
+        headers: { 'Authorization': `Bearer ${key}` }
+      })
+      if (!response.ok) throw new Error(`API error: ${response.status}`)
+      return response.json()
+    }
+  }
+})
+
+// ❌ Wrong: Direct environment access
+export const externalApi = provide(() => {
+  const url = process.env.API_URL  // NEVER do this
+  // ...
+})
+```
+
+**Why tags?** Configuration is provided at scope creation, making resources testable with `preset()`.
+
+---
+
+## Lifecycle Management
+
+Resources with cleanup must register via `controller.cleanup()`:
+
+```typescript
+// ✅ Proper cleanup registration
+export const dbPool = provide((controller) => {
+  const pool = new Pool({ /* config */ })
+
+  controller.cleanup(async () => {
+    await pool.end()
+  })
+
+  return { query: async (sql, params) => { /* ... */ } }
+})
+
+// ❌ No cleanup - connection leak
+export const dbPool = provide(() => {
+  const pool = new Pool({ /* config */ })
+  return { query: async (sql, params) => { /* ... */ } }
+})
+```
+
+**When to register cleanup:**
+- Database connections
+- HTTP clients with connection pools
+- File handles
+- Cache connections
+- WebSocket connections
+- Timers/intervals
+
+---
+
+## Troubleshooting
+
+### Problem: "Resource is resolved multiple times"
+
+**Symptom:** Resource initialization runs multiple times per scope
+
+**Cause:** Resource is not cached by scope
+
+**Solution:** Resources are automatically cached by scope. If seeing multiple initializations, check if creating multiple scopes accidentally.
+
+```typescript
+// ❌ Wrong: Creating multiple scopes
+const scope1 = createScope()
+const scope2 = createScope()
+await scope1.resolve(dbPool)  // Initializes dbPool
+await scope2.resolve(dbPool)  // Initializes dbPool again
+
+// ✅ Correct: Single scope
+const scope = createScope()
+await scope.resolve(dbPool)  // Initializes dbPool
+await scope.resolve(dbPool)  // Uses cached instance
+```
+
+---
+
+### Problem: "Cleanup not running on scope.dispose()"
+
+**Symptom:** Resources not cleaned up, connections remain open
+
+**Cause:** Cleanup not registered via `controller.cleanup()`
+
+**Solution:**
+
+```typescript
+// ❌ Wrong: No cleanup registration
+export const dbPool = provide(() => {
+  const pool = new Pool({ /* config */ })
+  return { query: async (sql, params) => { /* ... */ } }
+})
+
+// ✅ Correct: Register cleanup
+export const dbPool = provide((controller) => {
+  const pool = new Pool({ /* config */ })
+
+  controller.cleanup(async () => {
+    await pool.end()
+  })
+
+  return { query: async (sql, params) => { /* ... */ } }
+})
+```
+
+---
+
+### Problem: "Cannot access process.env in tests"
+
+**Symptom:** Tests fail because environment variables not available
+
+**Cause:** Accessing process.env directly inside resource
+
+**Solution:** Use tags for configuration
+
+```typescript
+// ❌ Wrong: Direct environment access
+export const apiClient = provide(() => {
+  const apiKey = process.env.API_KEY
+  return { get: (path) => fetch(path, { headers: { 'Authorization': apiKey }}) }
+})
+
+// ✅ Correct: Configuration via tags
+export const apiKey = tag(custom<string>(), { label: 'config.apiKey' })
+
+export const apiClient = provide((controller) => {
+  const key = apiKey.get(controller.scope)
+  return { get: (path) => fetch(path, { headers: { 'Authorization': key }}) }
+})
+
+// Test with preset
+const scope = createScope({
+  presets: [preset(apiKey, 'test-key-123')]
+})
+```
+
+---
+
+### Problem: "TypeScript error: Property 'controller' does not exist"
+
+**Symptom:** TypeScript error when trying to access controller
+
+**Cause:** Not using controller parameter correctly
+
+**Solution:**
+
+```typescript
+// ❌ Wrong: No controller parameter
+export const resource = provide(() => {
+  controller.cleanup(() => {})  // Error: controller not in scope
+})
+
+// ✅ Correct: Accept controller parameter
+export const resource = provide((controller) => {
+  controller.cleanup(() => {})
+  return {}
+})
+```
+
+---
+
+## Related Sub-skills
+
+- **resource-derived.md** - Resources depending on other resources
+- **resource-lazy.md** - Lazy/conditional resource loading
+- **coding-standards.md** - Type safety, naming conventions
+- **testing-utilities.md** - Testing resources with preset()
+- **entrypoint-patterns.md** - Scope creation and configuration

--- a/skills/pumped-design/references/resource-derived.md
+++ b/skills/pumped-design/references/resource-derived.md
@@ -1,0 +1,399 @@
+---
+name: resource-derived
+tags: resource, add, dependencies, derive, repository, data-access
+description: Derived resources that depend on other resources using derive(). Common for repositories, services, and data access layers that need database connections or other resources.
+---
+
+# Resource: Derived Patterns
+
+## When to Use
+
+Use derived resources (`derive()`) when:
+
+- Creating repositories that depend on database connections
+- Building services that need multiple resources
+- Composing resources from other resources
+- Creating data access layers
+- Implementing domain-specific operations on top of generic resources
+
+**Don't use for:**
+- Standalone resources with no dependencies (use `provide()`)
+- Business logic with validation/orchestration (use `flow()`)
+- Resources that need lifecycle management (use `provide()` with controller)
+
+---
+
+## Code Template
+
+```typescript
+import { derive } from '@pumped-fn/core-next'
+import { dbPool } from './resources'
+
+export namespace UserRepo {
+  export type User = {
+    id: string
+    email: string
+    name: string
+    createdAt: Date
+  }
+
+  export type CreateInput = {
+    email: string
+    name: string
+  }
+}
+
+// Derived resource depending on dbPool
+export const userRepository = derive({ db: dbPool }, ({ db }) => ({
+  findById: async (id: string): Promise<UserRepo.User | null> => {
+    const rows = await db.query<UserRepo.User>(
+      'SELECT id, email, name, created_at as "createdAt" FROM users WHERE id = $1',
+      [id]
+    )
+    return rows[0] || null
+  },
+
+  create: async (input: UserRepo.CreateInput): Promise<UserRepo.User> => {
+    const rows = await db.query<UserRepo.User>(
+      'INSERT INTO users (email, name) VALUES ($1, $2) RETURNING id, email, name, created_at as "createdAt"',
+      [input.email, input.name]
+    )
+    return rows[0]
+  }
+}))
+```
+
+---
+
+## Real Examples from Pumped-fn Tests
+
+### Example 1: Simple Derived Resource (packages/next/tests/core.test.ts)
+
+```typescript
+const baseExecutor = provide(() => {
+  executionOrder.push("base")
+  return 1
+})
+
+const dependentExecutor = derive(
+  { base: baseExecutor },
+  (deps: { base: number }) => {
+    executionOrder.push("dependent")
+    return deps.base + 1
+  }
+)
+```
+
+### Example 2: Mixed Sync/Async Dependencies (packages/next/tests/core.test.ts)
+
+```typescript
+const syncDependency = provide(() => 1)
+const asyncDependency = provide(async () => {
+  await new Promise((resolve) => setTimeout(resolve, 1))
+  return 2
+})
+
+const combinedExecutor = derive(
+  { sync: syncDependency, async: asyncDependency },
+  (deps: { sync: number; async: number }) => deps.sync + deps.async
+)
+
+// Result: 3
+```
+
+### Example 3: Service with Database (packages/next/tests/core.test.ts)
+
+```typescript
+const dbConnection = provide(() => {
+  dbConnectionCount++
+  return { connected: true, id: dbConnectionCount }
+})
+
+const service = derive({ db: dbConnection }, ({ db }) => {
+  serviceResolveCount++
+  return { db, count: serviceResolveCount }
+})
+```
+
+### Example 4: Multiple Named Dependencies (packages/next/tests/core.test.ts)
+
+```typescript
+const dependencyA = provide(() => "a")
+const dependencyB = provide(() => "b")
+const dependencyC = provide(() => "c")
+
+const executorWithDependencies = derive(
+  { depA: dependencyA, depB: dependencyB, depC: dependencyC },
+  (deps) => deps
+)
+```
+
+### Example 5: Repository with Database Pool (from templates.md)
+
+```typescript
+export const userRepository = derive({ db: dbPool }, ({ db }) => ({
+  findById: async (id: string): Promise<UserRepo.User | null> => {
+    const rows = await db.query<UserRepo.User>(
+      'SELECT id, email, name, created_at as "createdAt" FROM users WHERE id = $1',
+      [id]
+    )
+    return rows[0] || null
+  },
+
+  findByEmail: async (email: string): Promise<UserRepo.User | null> => {
+    const rows = await db.query<UserRepo.User>(
+      'SELECT id, email, name, created_at as "createdAt" FROM users WHERE email = $1',
+      [email]
+    )
+    return rows[0] || null
+  },
+
+  create: async (input: UserRepo.CreateInput): Promise<UserRepo.User> => {
+    const rows = await db.query<UserRepo.User>(
+      'INSERT INTO users (email, name) VALUES ($1, $2) RETURNING id, email, name, created_at as "createdAt"',
+      [input.email, input.name]
+    )
+    return rows[0]
+  },
+
+  update: async (id: string, input: UserRepo.UpdateInput): Promise<UserRepo.User | null> => {
+    const fields: string[] = []
+    const values: any[] = []
+    let paramCount = 1
+
+    if (input.email !== undefined) {
+      fields.push(`email = $${paramCount++}`)
+      values.push(input.email)
+    }
+    if (input.name !== undefined) {
+      fields.push(`name = $${paramCount++}`)
+      values.push(input.name)
+    }
+
+    if (fields.length === 0) return null
+
+    values.push(id)
+    const rows = await db.query<UserRepo.User>(
+      `UPDATE users SET ${fields.join(', ')} WHERE id = $${paramCount} RETURNING id, email, name, created_at as "createdAt"`,
+      values
+    )
+    return rows[0] || null
+  },
+
+  delete: async (id: string): Promise<boolean> => {
+    const rows = await db.query<{ id: string }>(
+      'DELETE FROM users WHERE id = $1 RETURNING id',
+      [id]
+    )
+    return rows.length > 0
+  }
+}))
+```
+
+---
+
+## Dependency Patterns
+
+### Single Dependency
+
+```typescript
+// Object destructuring (recommended)
+const derived = derive({ base }, ({ base }) => base * 2)
+
+// Direct value (simpler for single deps)
+const derived = derive(base, (val) => val * 2)
+```
+
+### Multiple Dependencies
+
+```typescript
+// Always use object destructuring
+const derived = derive(
+  { db: dbPool, logger, cache },
+  ({ db, logger, cache }) => ({
+    get: async (key: string) => {
+      logger.info('Getting key', { key })
+      const cached = await cache.get(key)
+      if (cached) return cached
+
+      const result = await db.query('SELECT * FROM data WHERE key = $1', [key])
+      await cache.set(key, result)
+      return result
+    }
+  })
+)
+```
+
+---
+
+## Type Safety
+
+### Explicit Types for Exports
+
+```typescript
+// ✅ Export clean interface
+export type UserRepository = {
+  findById: (id: string) => Promise<UserRepo.User | null>
+  create: (input: UserRepo.CreateInput) => Promise<UserRepo.User>
+}
+
+export const userRepository = derive(
+  { db: dbPool },
+  ({ db }): UserRepository => ({
+    findById: async (id) => { /* ... */ },
+    create: async (input) => { /* ... */ }
+  })
+)
+
+// ❌ Don't expose implementation types
+export const userRepository = derive(
+  { db: dbPool },
+  ({ db }): { db: Pool, findById: ... } => {  // Exposes Pool
+    // ...
+  }
+)
+```
+
+### Type Inference
+
+```typescript
+// ✅ Let TypeScript infer internal types
+const derived = derive(
+  { db: dbPool },
+  ({ db }) => ({  // Types inferred from dbPool
+    query: (sql: string) => db.query(sql, [])
+  })
+)
+
+// ❌ Don't explicitly type internals
+const derived = derive(
+  { db: dbPool },
+  ({ db }: { db: DatabasePool }) => {  // Redundant
+    // ...
+  }
+)
+```
+
+---
+
+## Troubleshooting
+
+### Problem: "Derived resource not receiving dependencies"
+
+**Symptom:** Dependencies are undefined or null in derived resource
+
+**Cause:** Dependencies not resolved by scope before derived resource
+
+**Solution:** Dependencies are automatically resolved. Check if dependencies are correctly defined:
+
+```typescript
+// ❌ Wrong: Typo in dependency name
+const derived = derive({ db: dbPool }, ({ database }) => {
+  // database is undefined, should be 'db'
+})
+
+// ✅ Correct: Consistent naming
+const derived = derive({ db: dbPool }, ({ db }) => {
+  // db is correctly resolved
+})
+```
+
+---
+
+### Problem: "Circular dependency detected"
+
+**Symptom:** Error about circular dependencies during resolution
+
+**Cause:** Resource A depends on B, B depends on A
+
+**Solution:** Refactor to break the cycle:
+
+```typescript
+// ❌ Wrong: Circular dependency
+const serviceA = derive({ b: serviceB }, ({ b }) => ({ callB: () => b.method() }))
+const serviceB = derive({ a: serviceA }, ({ a }) => ({ callA: () => a.method() }))
+
+// ✅ Correct: Extract shared dependency
+const shared = provide(() => ({ data: {} }))
+const serviceA = derive({ shared }, ({ shared }) => ({ useShared: () => shared.data }))
+const serviceB = derive({ shared }, ({ shared }) => ({ useShared: () => shared.data }))
+```
+
+---
+
+### Problem: "Derived resource resolved multiple times"
+
+**Symptom:** Initialization code runs multiple times
+
+**Cause:** Same as basic resources - multiple scopes
+
+**Solution:**
+
+```typescript
+// ✅ Correct: Single scope resolves once
+const scope = createScope()
+const repo1 = await scope.resolve(userRepository)  // Initializes
+const repo2 = await scope.resolve(userRepository)  // Uses cached
+expect(repo1).toBe(repo2)  // Same instance
+```
+
+---
+
+### Problem: "TypeScript error: Type 'X' is not assignable"
+
+**Symptom:** Type mismatch between dependency and usage
+
+**Cause:** Dependency types don't match what's expected
+
+**Solution:** Check dependency types match:
+
+```typescript
+// ❌ Wrong: Type mismatch
+const dbPool = provide(() => ({ query: (sql: string) => [] }))
+const repo = derive({ db: dbPool }, ({ db }) => ({
+  get: () => db.execute('SELECT')  // Error: 'execute' doesn't exist
+}))
+
+// ✅ Correct: Use correct method name
+const repo = derive({ db: dbPool }, ({ db }) => ({
+  get: () => db.query('SELECT')
+}))
+```
+
+---
+
+### Problem: "Derived resource has no cleanup"
+
+**Symptom:** Need to cleanup derived resource but no controller available
+
+**Cause:** `derive()` doesn't provide controller parameter
+
+**Solution:** Put cleanup in base resource via `provide()`:
+
+```typescript
+// ❌ Wrong: Trying to cleanup in derived resource
+const repo = derive({ db }, ({ db }) => {
+  controller.cleanup(() => {})  // Error: controller not available
+})
+
+// ✅ Correct: Cleanup in base resource
+const dbPool = provide((controller) => {
+  const pool = new Pool()
+  controller.cleanup(async () => await pool.end())
+  return pool
+})
+
+const repo = derive({ db: dbPool }, ({ db }) => ({
+  // No cleanup needed - db will cleanup itself
+}))
+```
+
+---
+
+## Related Sub-skills
+
+- **resource-basic.md** - Basic resources with provide()
+- **resource-lazy.md** - Lazy/conditional loading
+- **coding-standards.md** - Type safety and naming
+- **testing-utilities.md** - Testing with preset()
+- **flow-subflows.md** - Using repositories in flows

--- a/skills/pumped-design/references/resource-lazy.md
+++ b/skills/pumped-design/references/resource-lazy.md
@@ -1,0 +1,437 @@
+---
+name: resource-lazy
+tags: resource, add, lazy, conditional, reactive, static, update, accessor
+description: Lazy loading and reactive resources. Use .reactive for resources that can be updated, .lazy for conditional initialization, .static for immutable dependencies. Includes scope.update() and accessor patterns for reactive state.
+---
+
+# Resource: Lazy and Reactive Patterns
+
+## When to Use
+
+Use lazy/reactive resource patterns when:
+
+- **Reactive (.reactive)**: Resources that can be updated after initialization (config, feature flags, user preferences)
+- **Lazy (.lazy)**: Resources that should only initialize when first accessed (expensive operations, optional features)
+- **Static (.static)**: Resources that should never change (constants, immutable config)
+
+**Don't use for:**
+- Simple resources without update requirements (use basic `provide()`)
+- Resources that need complex lifecycle (use basic `provide()` with controller)
+- Business logic (belongs in flows)
+
+---
+
+## Reactive Resources
+
+### Basic Pattern
+
+```typescript
+import { provide, derive, createScope } from '@pumped-fn/core-next'
+
+// Reactive resource that can be updated
+const counter = provide(() => 0)
+
+// Derived resource depending on reactive counter
+const incrementedCounter = derive(
+  counter.reactive,
+  (count) => count + 1
+)
+
+// Usage
+const scope = createScope()
+
+const value = await scope.resolve(counter)  // 0
+await scope.update(counter, (current) => current + 1)
+
+const newValue = await scope.resolve(incrementedCounter)  // 2
+```
+
+### Why .reactive?
+
+When a derived resource depends on `counter.reactive`, it automatically re-computes when the counter is updated via `scope.update()`.
+
+```typescript
+// ✅ Reactive dependency - re-computes on update
+const derived = derive(
+  counter.reactive,
+  (count) => count * 2
+)
+
+await scope.update(counter, (c) => c + 1)
+const value = await scope.resolve(derived)  // Updated
+
+// ❌ Non-reactive dependency - doesn't re-compute
+const derived = derive(
+  counter,
+  (count) => count * 2
+)
+
+await scope.update(counter, (c) => c + 1)
+const value = await scope.resolve(derived)  // Stale
+```
+
+---
+
+## Real Examples from Pumped-fn Tests
+
+### Example 1: Basic Reactive Dependency (packages/next/tests/index.test.ts)
+
+```typescript
+const counter = provide(() => 0, name("counter"))
+const incrementedCounter = derive(
+  counter.reactive,
+  (count) => {
+    return count + 1
+  },
+  name("incrementedCounter")
+)
+
+const scope = createScope()
+
+const counterValue = await scope.resolve(counter)  // 0
+const incrementedValue = await scope.resolve(incrementedCounter)  // 1
+
+await scope.update(counter, (current) => current + 1)
+
+const updatedIncrementedValue = await scope.resolve(incrementedCounter)
+expect(updatedIncrementedValue).toBe(2)
+```
+
+### Example 2: Chained Reactive Dependencies (packages/next/tests/index.test.ts)
+
+```typescript
+const counter = provide(() => 0)
+const incrementedCounter = derive(
+  counter.reactive,
+  (count) => count + 1
+)
+
+const doubleIncrementedCounter = derive(
+  incrementedCounter.reactive,
+  (count) => count + 1
+)
+
+const scope = createScope()
+const doubleAccessor = scope.accessor(doubleIncrementedCounter)
+
+expect(await doubleAccessor.resolve()).toBe(2)
+
+await scope.update(counter, (current) => current + 1)
+
+expect(doubleAccessor.get()).toBe(3)
+```
+
+### Example 3: Multiple Reactive Dependency Patterns (packages/next/tests/index.test.ts)
+
+```typescript
+const counter = provide(() => 0)
+
+// Single reactive dependency
+const derivedCounter = derive(counter.reactive, (count) => count.toString())
+
+// Array pattern
+const derivedArrayCounter = derive([counter.reactive], (count, ctl) => {
+  ctl.cleanup(() => {})
+  return count.toString()
+})
+
+// Object pattern
+const derivedObjectCounter = derive(
+  { counter: counter.reactive },
+  ({ counter }) => counter.toString()
+)
+
+const scope = createScope()
+
+await scope.update(counter, (current) => current + 1)
+
+// All derived resources reflect the update
+const str1 = await scope.resolve(derivedCounter)  // "1"
+const str2 = await scope.resolve(derivedArrayCounter)  // "1"
+const str3 = await scope.resolve(derivedObjectCounter)  // "1"
+```
+
+### Example 4: Update Callbacks (packages/next/tests/index.test.ts)
+
+```typescript
+const counter = provide(() => 0)
+const scope = createScope()
+
+const updateCallback = vi.fn()
+const cleanup = scope.onUpdate(counter, (accessor) => {
+  updateCallback(accessor.get())
+})
+
+await scope.update(counter, (current) => current + 1)
+
+expect(updateCallback).toBeCalledTimes(1)
+expect(updateCallback).toBeCalledWith(1)
+
+await scope.update(counter, (current) => current + 1)
+
+expect(updateCallback).toBeCalledTimes(2)
+expect(updateCallback).toBeCalledWith(2)
+
+await cleanup()  // Remove listener
+```
+
+---
+
+## Accessor Pattern
+
+Accessors provide synchronous access to resolved reactive resources:
+
+```typescript
+const counter = provide(() => 0)
+const derived = derive(counter.reactive, (count) => count * 2)
+
+const scope = createScope()
+
+// Create accessor
+const accessor = scope.accessor(derived)
+
+// First access requires resolution
+const value1 = await accessor.resolve()  // 0
+
+// After resolution, synchronous access
+const value2 = accessor.get()  // 0 (no await)
+
+// Updates propagate automatically
+await scope.update(counter, (c) => c + 1)
+const value3 = accessor.get()  // 2 (updated)
+```
+
+---
+
+## Lazy Resources
+
+Lazy resources initialize only when first accessed:
+
+```typescript
+// ❌ Basic resource - initializes immediately
+const dbPool = provide(() => {
+  console.log('Initializing DB pool')
+  return new Pool()
+})
+
+// ✅ Lazy resource - initializes on first access
+const dbPool = provide(() => {
+  console.log('Initializing DB pool')
+  return new Pool()
+}).lazy
+
+const scope = createScope()
+// No output yet
+
+const pool = await scope.resolve(dbPool)
+// Output: "Initializing DB pool"
+```
+
+**Use cases for lazy:**
+- Expensive resources only needed conditionally
+- Optional features
+- Resources with slow initialization
+- Feature flags
+
+---
+
+## Static Resources
+
+Static resources are immutable - they never change and don't support updates:
+
+```typescript
+const config = provide(() => ({
+  apiUrl: 'https://api.example.com',
+  timeout: 5000
+}))
+
+// Use .static for immutable dependencies
+const apiClient = derive(
+  config.static,
+  (cfg) => createClient(cfg)
+)
+
+// ✅ Static - more efficient, no reactivity overhead
+// ❌ Cannot use scope.update(config, ...)
+```
+
+**Use .static when:**
+- Resource is truly immutable
+- No updates will ever be needed
+- Want to avoid reactivity overhead
+
+**Don't use .static when:**
+- Resource might need updates
+- Unsure if updates will be needed (use basic dependency)
+
+---
+
+## Troubleshooting
+
+### Problem: "Derived resource not updating when dependency changes"
+
+**Symptom:** Updates to resource don't propagate to derived resources
+
+**Cause:** Derived resource doesn't depend on `.reactive`
+
+**Solution:**
+
+```typescript
+// ❌ Wrong: No .reactive
+const derived = derive(counter, (count) => count * 2)
+
+await scope.update(counter, (c) => c + 1)
+// derived doesn't update
+
+// ✅ Correct: Use .reactive
+const derived = derive(counter.reactive, (count) => count * 2)
+
+await scope.update(counter, (c) => c + 1)
+// derived updates automatically
+```
+
+---
+
+### Problem: "Cannot update static resource"
+
+**Symptom:** Error when calling `scope.update()` on static dependency
+
+**Cause:** Static resources are immutable by design
+
+**Solution:**
+
+```typescript
+// ❌ Wrong: Trying to update static
+const config = provide(() => ({ port: 3000 }))
+const derived = derive(config.static, (cfg) => cfg)
+
+await scope.update(config, (c) => ({ port: 4000 }))  // Error
+
+// ✅ Correct: Use reactive if updates needed
+const config = provide(() => ({ port: 3000 }))
+const derived = derive(config.reactive, (cfg) => cfg)
+
+await scope.update(config, (c) => ({ port: 4000 }))  // Works
+```
+
+---
+
+### Problem: "Lazy resource initializes immediately"
+
+**Symptom:** Lazy resource runs initialization code before being accessed
+
+**Cause:** Not using `.lazy` modifier
+
+**Solution:**
+
+```typescript
+// ❌ Wrong: No .lazy
+const dbPool = provide(() => {
+  console.log('Init')  // Runs immediately
+  return new Pool()
+})
+
+// ✅ Correct: Use .lazy
+const dbPool = provide(() => {
+  console.log('Init')  // Runs on first access
+  return new Pool()
+}).lazy
+```
+
+---
+
+### Problem: "Accessor returns stale value"
+
+**Symptom:** `accessor.get()` doesn't reflect recent updates
+
+**Cause:** Accessor not created from reactive dependency
+
+**Solution:**
+
+```typescript
+// ❌ Wrong: Accessor from non-reactive
+const counter = provide(() => 0)
+const derived = derive(counter, (c) => c * 2)  // No .reactive
+
+const accessor = scope.accessor(derived)
+await scope.update(counter, (c) => c + 1)
+accessor.get()  // Stale value
+
+// ✅ Correct: Use .reactive
+const derived = derive(counter.reactive, (c) => c * 2)
+
+const accessor = scope.accessor(derived)
+await scope.update(counter, (c) => c + 1)
+accessor.get()  // Updated value
+```
+
+---
+
+### Problem: "Memory leak with update callbacks"
+
+**Symptom:** Update callbacks continue firing after component unmounts
+
+**Cause:** Not cleaning up `onUpdate()` listener
+
+**Solution:**
+
+```typescript
+// ❌ Wrong: No cleanup
+scope.onUpdate(counter, (accessor) => {
+  console.log(accessor.get())
+})
+
+// ✅ Correct: Cleanup when done
+const cleanup = scope.onUpdate(counter, (accessor) => {
+  console.log(accessor.get())
+})
+
+// Later (e.g., component unmount)
+await cleanup()
+```
+
+---
+
+## Performance Considerations
+
+### Reactive Overhead
+
+```typescript
+// More expensive: Reactive tracking
+const derived = derive(counter.reactive, (c) => c * 2)
+
+// Less expensive: No tracking
+const derived = derive(counter, (c) => c * 2)
+
+// Most expensive: Multiple reactive deps
+const derived = derive(
+  { a: counter.reactive, b: other.reactive },
+  ({ a, b }) => a + b
+)
+```
+
+**Guideline:** Only use `.reactive` when updates are actually needed.
+
+### Lazy Initialization
+
+```typescript
+// Expensive resource - use .lazy
+const mlModel = provide(() => {
+  return loadLargeMLModel()  // 500ms initialization
+}).lazy
+
+// Only pay cost if feature is used
+if (featureEnabled) {
+  const model = await scope.resolve(mlModel)
+}
+```
+
+---
+
+## Related Sub-skills
+
+- **resource-basic.md** - Basic resource patterns
+- **resource-derived.md** - Derived resources with dependencies
+- **coding-standards.md** - Type safety and naming
+- **testing-utilities.md** - Testing reactive resources
+- **flow-context.md** - Using reactive resources in flows

--- a/skills/pumped-design/references/testing-flows.md
+++ b/skills/pumped-design/references/testing-flows.md
@@ -1,0 +1,730 @@
+---
+name: testing-flows
+tags: testing, flow, integration, branches, preset, mock, subflow, reusable
+description: Integration testing flows with preset() for mocking dependencies. Test ALL output branches (Success + each Error). Reusable flows test standalone, non-reusable flows test via parent. Use scope.exec() to invoke flows in tests.
+---
+
+# Testing Flows (Integration Tests)
+
+## When to Use This Pattern
+
+**Integration testing flows means:**
+- Testing flow orchestration with mocked dependencies
+- Testing ALL discriminated union branches (Success + each Error)
+- Testing sub-flow composition
+- Testing ctx.run() operations
+- Mocking resources/repositories via `preset()`
+
+**Use integration tests for:**
+- Business logic flows (validation + orchestration)
+- Flows calling sub-flows (ctx.exec)
+- Multi-step operations with error handling
+- Flows with dependencies (resources, repositories)
+
+---
+
+## Critical Rule: Test ALL Branches
+
+**Every flow MUST test:**
+1. Success case
+2. EVERY error case (each discriminated union variant)
+
+```typescript
+export namespace ProcessOrder {
+  export type Success = { success: true; orderId: string }
+  export type InvalidItems = { success: false; reason: 'INVALID_ITEMS' }
+  export type PaymentFailed = { success: false; reason: 'PAYMENT_FAILED' }
+  export type InsufficientStock = { success: false; reason: 'INSUFFICIENT_STOCK' }
+
+  export type Result = Success | InvalidItems | PaymentFailed | InsufficientStock
+}
+
+// ✅ MUST test all 4 branches:
+// 1. Success
+// 2. INVALID_ITEMS
+// 3. PAYMENT_FAILED
+// 4. INSUFFICIENT_STOCK
+```
+
+---
+
+## Pattern: Testing Reusable Flows Standalone
+
+**Reusable flows:** Flows designed for composition (called by other flows)
+
+**Test reusable flows standalone** - they're public API
+
+```typescript
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import { flow, createScope, preset, derive, type Scope } from '@pumped-fn/core-next'
+
+// Reusable validation flow
+export namespace ValidateOrder {
+  export type Input = {
+    items: Array<{ id: string; quantity: number }>
+    userId: string
+  }
+
+  export type Success = { success: true; totalItems: number }
+  export type EmptyCart = { success: false; reason: 'EMPTY_CART' }
+  export type InvalidQuantity = { success: false; reason: 'INVALID_QUANTITY' }
+
+  export type Result = Success | EmptyCart | InvalidQuantity
+}
+
+export const validateOrder = flow(
+  async (_ctx, input: ValidateOrder.Input): Promise<ValidateOrder.Result> => {
+    if (input.items.length === 0) {
+      return { success: false, reason: 'EMPTY_CART' }
+    }
+
+    const hasInvalidQuantity = input.items.some((item) => item.quantity <= 0)
+    if (hasInvalidQuantity) {
+      return { success: false, reason: 'INVALID_QUANTITY' }
+    }
+
+    return { success: true, totalItems: input.items.length }
+  }
+)
+
+describe('validateOrder flow (reusable)', () => {
+  let scope: Scope
+
+  beforeEach(() => {
+    scope = createScope()
+  })
+
+  afterEach(async () => {
+    await scope.dispose()
+  })
+
+  test('SUCCESS: accepts valid order', async () => {
+    const result = await scope.exec(validateOrder, {
+      userId: 'user-1',
+      items: [
+        { id: 'item-1', quantity: 2 },
+        { id: 'item-2', quantity: 1 }
+      ]
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.totalItems).toBe(2)
+    }
+  })
+
+  test('ERROR: EMPTY_CART when no items', async () => {
+    const result = await scope.exec(validateOrder, {
+      userId: 'user-1',
+      items: []
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('EMPTY_CART')
+    }
+  })
+
+  test('ERROR: INVALID_QUANTITY when quantity is zero', async () => {
+    const result = await scope.exec(validateOrder, {
+      userId: 'user-1',
+      items: [{ id: 'item-1', quantity: 0 }]
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_QUANTITY')
+    }
+  })
+
+  test('ERROR: INVALID_QUANTITY when quantity is negative', async () => {
+    const result = await scope.exec(validateOrder, {
+      userId: 'user-1',
+      items: [{ id: 'item-1', quantity: -5 }]
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_QUANTITY')
+    }
+  })
+})
+```
+
+**Key principles:**
+- Test standalone (not via parent flow)
+- Test ALL branches (1 Success + 2 Errors = 3 tests minimum)
+- Use scope.exec() to invoke flow
+- No dependencies = no presets needed
+
+---
+
+## Pattern: Testing Flows with Dependencies
+
+Use `preset()` to mock dependencies:
+
+```typescript
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import { flow, derive, createScope, preset, type Scope } from '@pumped-fn/core-next'
+
+// Mock repository interface
+export type UserRepository = {
+  findById: (id: string) => Promise<{ id: string; name: string } | null>
+  create: (input: { name: string; email: string }) => Promise<{ id: string }>
+}
+
+export const userRepository = derive(
+  { /* db dependency */ },
+  () => ({
+    findById: async (id: string) => null,
+    create: async (input: { name: string; email: string }) => ({ id: 'new-id' })
+  })
+)
+
+export namespace CreateUser {
+  export type Input = { name: string; email: string }
+
+  export type Success = { success: true; userId: string }
+  export type NameTooShort = { success: false; reason: 'NAME_TOO_SHORT' }
+  export type InvalidEmail = { success: false; reason: 'INVALID_EMAIL' }
+
+  export type Result = Success | NameTooShort | InvalidEmail
+}
+
+export const createUser = flow(
+  { userRepo: userRepository },
+  ({ userRepo }) =>
+    async (ctx, input: CreateUser.Input): Promise<CreateUser.Result> => {
+      const validation = await ctx.run('validate', () => {
+        if (input.name.length < 2) {
+          return { ok: false as const, reason: 'NAME_TOO_SHORT' as const }
+        }
+        if (!input.email.includes('@')) {
+          return { ok: false as const, reason: 'INVALID_EMAIL' as const }
+        }
+        return { ok: true as const }
+      })
+
+      if (!validation.ok) {
+        return { success: false, reason: validation.reason }
+      }
+
+      const created = await ctx.run('create', () =>
+        userRepo.create({ name: input.name, email: input.email })
+      )
+
+      return { success: true, userId: created.id }
+    }
+)
+
+describe('createUser flow', () => {
+  let scope: Scope
+
+  beforeEach(() => {
+    const mockUserRepo: UserRepository = {
+      findById: async (id: string) => null,
+      create: async (input: { name: string; email: string }) => ({
+        id: `user-${input.name}`
+      })
+    }
+
+    scope = createScope({
+      presets: [preset(userRepository, mockUserRepo)]
+    })
+  })
+
+  afterEach(async () => {
+    await scope.dispose()
+  })
+
+  test('SUCCESS: creates user with valid input', async () => {
+    const result = await scope.exec(createUser, {
+      name: 'Alice',
+      email: 'alice@example.com'
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.userId).toBe('user-Alice')
+    }
+  })
+
+  test('ERROR: NAME_TOO_SHORT when name is 1 character', async () => {
+    const result = await scope.exec(createUser, {
+      name: 'A',
+      email: 'alice@example.com'
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('NAME_TOO_SHORT')
+    }
+  })
+
+  test('ERROR: INVALID_EMAIL when email missing @', async () => {
+    const result = await scope.exec(createUser, {
+      name: 'Alice',
+      email: 'invalid-email.com'
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_EMAIL')
+    }
+  })
+})
+```
+
+**Key principles:**
+- Mock dependencies in beforeEach with preset()
+- Fresh scope per test suite
+- Dispose scope in afterEach
+- Mock returns deterministic values
+
+---
+
+## Pattern: Testing Flows with Sub-flows
+
+Test parent flow, sub-flow tested separately:
+
+```typescript
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import { flow, createScope, type Scope } from '@pumped-fn/core-next'
+
+// Sub-flow (tested separately)
+export namespace ValidateEmail {
+  export type Success = { success: true; email: string }
+  export type Invalid = { success: false; reason: 'INVALID_EMAIL' }
+  export type Result = Success | Invalid
+}
+
+export const validateEmail = flow(
+  async (_ctx, email: string): Promise<ValidateEmail.Result> => {
+    if (!email.includes('@')) {
+      return { success: false, reason: 'INVALID_EMAIL' }
+    }
+    return { success: true, email: email.toLowerCase() }
+  }
+)
+
+// Parent flow (composes sub-flow)
+export namespace RegisterUser {
+  export type Input = { name: string; email: string }
+
+  export type Success = { success: true; userId: string }
+  export type NameTooShort = { success: false; reason: 'NAME_TOO_SHORT' }
+  export type InvalidEmail = ValidateEmail.Invalid
+
+  export type Result = Success | NameTooShort | InvalidEmail
+}
+
+export const registerUser = flow(
+  async (ctx, input: RegisterUser.Input): Promise<RegisterUser.Result> => {
+    if (input.name.length < 2) {
+      return { success: false, reason: 'NAME_TOO_SHORT' }
+    }
+
+    const emailResult = await ctx.exec(validateEmail, input.email)
+
+    if (!emailResult.success) {
+      return emailResult
+    }
+
+    return {
+      success: true,
+      userId: `user-${emailResult.email}`
+    }
+  }
+)
+
+describe('validateEmail sub-flow (reusable)', () => {
+  let scope: Scope
+
+  beforeEach(() => {
+    scope = createScope()
+  })
+
+  afterEach(async () => {
+    await scope.dispose()
+  })
+
+  test('SUCCESS: validates and normalizes email', async () => {
+    const result = await scope.exec(validateEmail, 'User@EXAMPLE.COM')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.email).toBe('user@example.com')
+    }
+  })
+
+  test('ERROR: INVALID_EMAIL when missing @', async () => {
+    const result = await scope.exec(validateEmail, 'not-an-email')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_EMAIL')
+    }
+  })
+})
+
+describe('registerUser flow (parent)', () => {
+  let scope: Scope
+
+  beforeEach(() => {
+    scope = createScope()
+  })
+
+  afterEach(async () => {
+    await scope.dispose()
+  })
+
+  test('SUCCESS: registers user with valid input', async () => {
+    const result = await scope.exec(registerUser, {
+      name: 'Alice',
+      email: 'alice@example.com'
+    })
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.userId).toBe('user-alice@example.com')
+    }
+  })
+
+  test('ERROR: NAME_TOO_SHORT when name invalid', async () => {
+    const result = await scope.exec(registerUser, {
+      name: 'A',
+      email: 'alice@example.com'
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('NAME_TOO_SHORT')
+    }
+  })
+
+  test('ERROR: INVALID_EMAIL propagated from sub-flow', async () => {
+    const result = await scope.exec(registerUser, {
+      name: 'Alice',
+      email: 'invalid-email'
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_EMAIL')
+    }
+  })
+})
+```
+
+**Key principles:**
+- Sub-flow tested separately (validateEmail)
+- Parent flow tested with real sub-flow (no mocking)
+- Test error propagation from sub-flow
+- Test parent-specific errors (NAME_TOO_SHORT)
+
+---
+
+## Real Example: Flow Tests from pumped-fn
+
+From `packages/next/tests/flow-expected.test.ts`:
+
+```typescript
+describe("Nameless flows", () => {
+  test("flow composes dependencies, nested flows, and operations", async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve({ data: `fetched from ${url}` })
+    );
+    const apiService = provide(() => ({ fetch: fetchMock }));
+
+    const fetchUserById = flow(apiService, async (api, ctx, userId: number) => {
+      const response = await ctx.run("fetch-user", () =>
+        api.fetch(`/users/${userId}`)
+      );
+      return { userId, username: `user${userId}`, raw: response.data };
+    });
+
+    const fetchPostsByUserId = flow(
+      { api: apiService },
+      async ({ api }, ctx, userId: number) => {
+        const response = await ctx.run("fetch-posts", () =>
+          api.fetch(`/posts?userId=${userId}`)
+        );
+        return { posts: [{ id: 1, title: "Post 1" }], raw: response.data };
+      }
+    );
+
+    const getUserWithPosts = flow(
+      { api: apiService },
+      async ({ api: _api }, ctx, userId: number) => {
+        const user = await ctx.exec(fetchUserById, userId);
+        const posts = await ctx.exec(fetchPostsByUserId, userId);
+        const enriched = await ctx.run("enrich", () => ({
+          ...user,
+          postCount: posts.posts.length,
+        }));
+        return enriched;
+      }
+    );
+
+    const result = await flow.execute(getUserWithPosts, 42);
+
+    expect(result.userId).toBe(42);
+    expect(result.username).toBe("user42");
+    expect(result.postCount).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+**What makes this good:**
+- Tests complete flow orchestration
+- Mocks external dependency (apiService)
+- Tests ctx.run() and ctx.exec() together
+- Verifies sub-flow composition
+- Checks mock invocation count
+
+---
+
+## Pattern: Testing Non-Reusable Flows
+
+**Non-reusable flows:** Implementation details, not public API
+
+**Test non-reusable flows via parent** - they're not meant to be called directly
+
+```typescript
+// ❌ Non-reusable flow (internal implementation detail)
+const checkInventory = flow(
+  { inventory: inventoryRepo },
+  ({ inventory }) =>
+    async (_ctx, itemId: string): Promise<boolean> => {
+      const stock = await inventory.getStock(itemId)
+      return stock > 0
+    }
+)
+
+// ✅ Public flow (uses checkInventory internally)
+export const processOrder = flow(
+  { inventory: inventoryRepo, payment: paymentService },
+  ({ inventory, payment }) =>
+    async (ctx, input: { itemId: string; userId: string }): Promise<ProcessOrder.Result> => {
+      const hasStock = await ctx.exec(checkInventory, input.itemId)
+
+      if (!hasStock) {
+        return { success: false, reason: 'OUT_OF_STOCK' }
+      }
+
+      // ... rest of flow
+    }
+)
+
+// ✅ Test processOrder (public), which exercises checkInventory (internal)
+describe('processOrder flow', () => {
+  test('ERROR: OUT_OF_STOCK when inventory check fails', async () => {
+    const mockInventory = {
+      getStock: async (itemId: string) => 0  // No stock
+    }
+
+    const scope = createScope({
+      presets: [preset(inventoryRepo, mockInventory)]
+    })
+
+    const result = await scope.exec(processOrder, {
+      itemId: 'item-1',
+      userId: 'user-1'
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('OUT_OF_STOCK')
+    }
+
+    await scope.dispose()
+  })
+})
+```
+
+**Key principles:**
+- Non-reusable flows are private (not exported or used by name)
+- Test via parent flow
+- Mock parent's dependencies (not sub-flow itself)
+
+---
+
+## Pattern: Testing ctx.parallel()
+
+Test concurrent execution:
+
+```typescript
+import { describe, test, expect } from 'vitest'
+import { flow } from '@pumped-fn/core-next'
+
+describe("ctx.parallel()", () => {
+  test("executes multiple flows concurrently", async () => {
+    const doubleAsync = flow<{ x: number }, { r: number }>(async (_ctx, input) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return { r: input.x * 2 };
+    });
+
+    const tripleAsync = flow<{ x: number }, { r: number }>(async (_ctx, input) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return { r: input.x * 3 };
+    });
+
+    const combineResults = flow<{ val: number }, { sum: number }>(
+      async (ctx, input) => {
+        const doublePromise = ctx.exec(doubleAsync, { x: input.val });
+        const triplePromise = ctx.exec(tripleAsync, { x: input.val });
+        const parallel = await ctx.parallel([doublePromise, triplePromise]);
+
+        const sum = parallel.results[0].r + parallel.results[1].r;
+        return { sum };
+      }
+    );
+
+    const result = await flow.execute(combineResults, { val: 5 });
+
+    expect(result.sum).toBe(25);
+  });
+});
+```
+
+---
+
+## Pattern: Testing ctx.parallelSettled()
+
+Test partial failures:
+
+```typescript
+import { describe, test, expect } from 'vitest'
+import { flow, FlowError } from '@pumped-fn/core-next'
+
+describe("ctx.parallelSettled()", () => {
+  test("collects successes and failures", async () => {
+    const successFlow = flow<Record<string, never>, { ok: boolean }>(() => ({
+      ok: true,
+    }));
+
+    const failureFlow = flow(() => {
+      throw new FlowError("Failed", "ERR");
+    });
+
+    const gatherResults = flow<
+      Record<string, never>,
+      { succeeded: number; failed: number }
+    >(async (ctx, _input) => {
+      const first = ctx.exec(successFlow, {});
+      const second = ctx.exec(failureFlow, {});
+      const third = ctx.exec(successFlow, {});
+      const settled = await ctx.parallelSettled([first, second, third]);
+
+      return {
+        succeeded: settled.stats.succeeded,
+        failed: settled.stats.failed,
+      };
+    });
+
+    const result = await flow.execute(gatherResults, {});
+
+    expect(result.succeeded).toBe(2);
+    expect(result.failed).toBe(1);
+  });
+});
+```
+
+---
+
+## Troubleshooting
+
+### Problem: Forgot to test an error branch
+
+**Symptom:** Flow has 3 error types, only 2 tested
+
+**Solution:** List all discriminated union variants, create one test per variant
+
+```typescript
+export type Result = Success | ErrorA | ErrorB | ErrorC
+
+// ✅ 4 tests minimum:
+test('SUCCESS: ...')
+test('ERROR: ErrorA when ...')
+test('ERROR: ErrorB when ...')
+test('ERROR: ErrorC when ...')
+```
+
+### Problem: Mock not working in sub-flow
+
+**Cause:** Trying to mock sub-flow instead of its dependencies
+
+**Solution:**
+```typescript
+// ❌ Wrong - mocking sub-flow itself
+scope = createScope({
+  presets: [preset(validateEmail, mockValidateEmail)]
+})
+
+// ✅ Correct - mock sub-flow's dependencies (if any)
+// Or use real sub-flow (preferred)
+const result = await scope.exec(registerUser, input)
+```
+
+### Problem: Test depends on other tests
+
+**Cause:** Shared scope or mutable state
+
+**Solution:**
+```typescript
+// ❌ Wrong - shared scope
+const scope = createScope()
+
+test('test 1', async () => { /* ... */ })
+test('test 2', async () => { /* ... */ })
+
+// ✅ Correct - fresh scope per test
+beforeEach(() => {
+  scope = createScope()
+})
+
+afterEach(async () => {
+  await scope.dispose()
+})
+```
+
+### Problem: Preset doesn't match dependency type
+
+**Cause:** Mock interface doesn't match actual dependency
+
+**Solution:**
+```typescript
+// ❌ Wrong - missing methods
+const mockRepo = {
+  findById: async (id: string) => null
+  // Missing create, update, delete
+}
+
+// ✅ Correct - complete interface
+const mockRepo: UserRepository = {
+  findById: async (id: string) => null,
+  create: async (input) => ({ id: 'new-id' }),
+  update: async (id, input) => null,
+  delete: async (id) => false
+}
+```
+
+---
+
+## Summary
+
+**Integration testing flows:**
+- Test ALL branches (Success + each Error)
+- Reusable flows: test standalone
+- Non-reusable flows: test via parent
+- Use preset() to mock dependencies
+- Fresh scope per test suite
+- Dispose scope in afterEach
+- Test error propagation from sub-flows
+
+**Related sub-skills:**
+- `testing-utilities.md` - Unit testing pure functions
+- `testing-integration.md` - End-to-end testing
+- `flow-subflows.md` - Flow composition patterns
+- `coding-standards.md` - Type safety rules

--- a/skills/pumped-design/references/testing-integration.md
+++ b/skills/pumped-design/references/testing-integration.md
@@ -1,0 +1,779 @@
+---
+name: testing-integration
+tags: testing, integration, e2e, real, database, http, lifecycle, cleanup
+description: End-to-end integration testing with real resources (test database, real HTTP calls). Test complete application lifecycle including resource initialization and cleanup. When to use integration vs unit tests. Test scope disposal and graceful shutdown.
+---
+
+# Testing Integration (End-to-End)
+
+## When to Use This Pattern
+
+**Integration testing means:**
+- Testing with real resources (test database, real file system)
+- Testing complete application lifecycle
+- Testing resource cleanup and disposal
+- Testing actual HTTP endpoints
+- Testing framework integration (Hono, Next.js)
+
+**Use integration tests when:**
+- Unit tests with mocks aren't sufficient
+- Testing external system integration (database, APIs)
+- Verifying resource lifecycle (init, cleanup)
+- Testing production-like scenarios
+- Catching integration bugs (network, timing, concurrency)
+
+---
+
+## Integration vs Unit Tests: When to Use Each
+
+### Use Unit Tests (with preset()) When:
+
+- ✅ Testing business logic in isolation
+- ✅ Fast execution needed (CI/CD)
+- ✅ No external dependencies required
+- ✅ Testing edge cases and boundary conditions
+- ✅ Deterministic, repeatable results
+
+### Use Integration Tests (real resources) When:
+
+- ✅ Testing database queries/transactions
+- ✅ Testing real HTTP clients/servers
+- ✅ Testing file system operations
+- ✅ Testing resource lifecycle (cleanup)
+- ✅ Finding integration bugs (network failures, timeouts)
+- ✅ Testing framework integration (Hono routes, Next.js actions)
+
+**Golden rule:** Start with unit tests, add integration tests for critical paths
+
+---
+
+## Pattern: Testing with Real Database
+
+Use test database for integration tests:
+
+```typescript
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { createScope, provide, derive, tag, custom, type Scope } from '@pumped-fn/core-next'
+import { Pool } from 'pg'
+
+// Configuration for test database
+export const dbConfig = tag(custom<{
+  host: string
+  port: number
+  database: string
+  user: string
+  password: string
+}>(), { label: 'config.database' })
+
+// Real database pool
+export const dbPool = provide((controller) => {
+  const config = dbConfig.get(controller.scope)
+
+  const pool = new Pool({
+    host: config.host,
+    port: config.port,
+    database: config.database,
+    user: config.user,
+    password: config.password,
+    max: 10
+  })
+
+  controller.cleanup(async () => {
+    await pool.end()
+  })
+
+  return {
+    query: async <T>(sql: string, params: unknown[]): Promise<T[]> => {
+      const result = await pool.query(sql, params)
+      return result.rows
+    }
+  }
+})
+
+// User repository
+export type User = {
+  id: string
+  email: string
+  name: string
+  createdAt: Date
+}
+
+export const userRepository = derive(
+  { db: dbPool },
+  ({ db }) => ({
+    create: async (input: { email: string; name: string }): Promise<User> => {
+      const rows = await db.query<User>(
+        'INSERT INTO users (email, name) VALUES ($1, $2) RETURNING id, email, name, created_at as "createdAt"',
+        [input.email, input.name]
+      )
+      return rows[0]
+    },
+    findByEmail: async (email: string): Promise<User | null> => {
+      const rows = await db.query<User>(
+        'SELECT id, email, name, created_at as "createdAt" FROM users WHERE email = $1',
+        [email]
+      )
+      return rows[0] || null
+    },
+    deleteAll: async (): Promise<void> => {
+      await db.query('DELETE FROM users', [])
+    }
+  })
+)
+
+describe('userRepository integration tests', () => {
+  let scope: Scope
+  let repo: Awaited<ReturnType<typeof userRepository['factory']>>
+
+  beforeAll(async () => {
+    // Create scope with REAL database config
+    scope = createScope({
+      tags: [
+        dbConfig({
+          host: 'localhost',
+          port: 5432,
+          database: 'test_db',  // Separate test database
+          user: 'test_user',
+          password: 'test_password'
+        })
+      ]
+    })
+
+    repo = await scope.resolve(userRepository)
+
+    // Setup: Create schema
+    const db = await scope.resolve(dbPool)
+    await db.query(`
+      CREATE TABLE IF NOT EXISTS users (
+        id SERIAL PRIMARY KEY,
+        email VARCHAR(255) UNIQUE NOT NULL,
+        name VARCHAR(255) NOT NULL,
+        created_at TIMESTAMP DEFAULT NOW()
+      )
+    `, [])
+  })
+
+  afterAll(async () => {
+    // Teardown: Drop schema and dispose scope
+    const db = await scope.resolve(dbPool)
+    await db.query('DROP TABLE IF EXISTS users', [])
+    await scope.dispose()
+  })
+
+  beforeEach(async () => {
+    // Clean data before each test
+    await repo.deleteAll()
+  })
+
+  test('creates user in real database', async () => {
+    const user = await repo.create({
+      email: 'test@example.com',
+      name: 'Test User'
+    })
+
+    expect(user.id).toBeDefined()
+    expect(user.email).toBe('test@example.com')
+    expect(user.name).toBe('Test User')
+    expect(user.createdAt).toBeInstanceOf(Date)
+  })
+
+  test('findByEmail returns null when user does not exist', async () => {
+    const user = await repo.findByEmail('nonexistent@example.com')
+
+    expect(user).toBeNull()
+  })
+
+  test('findByEmail returns user after creation', async () => {
+    await repo.create({
+      email: 'alice@example.com',
+      name: 'Alice'
+    })
+
+    const found = await repo.findByEmail('alice@example.com')
+
+    expect(found).not.toBeNull()
+    expect(found?.email).toBe('alice@example.com')
+    expect(found?.name).toBe('Alice')
+  })
+
+  test('enforces unique email constraint', async () => {
+    await repo.create({
+      email: 'duplicate@example.com',
+      name: 'User 1'
+    })
+
+    await expect(
+      repo.create({
+        email: 'duplicate@example.com',
+        name: 'User 2'
+      })
+    ).rejects.toThrow()
+  })
+})
+```
+
+**Key principles:**
+- Use separate test database (never production)
+- Setup schema in beforeAll
+- Clean data in beforeEach (deterministic tests)
+- Drop schema in afterAll
+- Dispose scope in afterAll
+- Test real constraints (unique, foreign keys)
+
+---
+
+## Pattern: Testing Resource Lifecycle
+
+Test resource initialization and cleanup:
+
+```typescript
+import { describe, test, expect } from 'vitest'
+import { createScope, provide } from '@pumped-fn/core-next'
+
+describe('resource lifecycle integration', () => {
+  test('resource cleanup called on scope.dispose()', async () => {
+    let cleanupCalled = false
+    let connectionClosed = false
+
+    const mockDbPool = provide((controller) => {
+      const connection = { status: 'open' }
+
+      controller.cleanup(async () => {
+        cleanupCalled = true
+        connection.status = 'closed'
+        connectionClosed = true
+      })
+
+      return {
+        query: async (sql: string) => [],
+        getStatus: () => connection.status
+      }
+    })
+
+    const scope = createScope()
+    const pool = await scope.resolve(mockDbPool)
+
+    expect(pool.getStatus()).toBe('open')
+    expect(cleanupCalled).toBe(false)
+
+    await scope.dispose()
+
+    expect(cleanupCalled).toBe(true)
+    expect(connectionClosed).toBe(true)
+  })
+
+  test('cleanup called in reverse order of initialization', async () => {
+    const cleanupOrder: string[] = []
+
+    const resourceA = provide((controller) => {
+      controller.cleanup(async () => {
+        cleanupOrder.push('A')
+      })
+      return { name: 'A' }
+    })
+
+    const resourceB = provide((controller) => {
+      controller.cleanup(async () => {
+        cleanupOrder.push('B')
+      })
+      return { name: 'B' }
+    })
+
+    const resourceC = provide((controller) => {
+      controller.cleanup(async () => {
+        cleanupOrder.push('C')
+      })
+      return { name: 'C' }
+    })
+
+    const scope = createScope()
+
+    // Initialize in order: A, B, C
+    await scope.resolve(resourceA)
+    await scope.resolve(resourceB)
+    await scope.resolve(resourceC)
+
+    await scope.dispose()
+
+    // Cleanup in reverse order: C, B, A
+    expect(cleanupOrder).toEqual(['C', 'B', 'A'])
+  })
+
+  test('dispose handles cleanup errors gracefully', async () => {
+    const cleanupCalls: string[] = []
+
+    const failingResource = provide((controller) => {
+      controller.cleanup(async () => {
+        cleanupCalls.push('failing')
+        throw new Error('Cleanup failed')
+      })
+      return {}
+    })
+
+    const successResource = provide((controller) => {
+      controller.cleanup(async () => {
+        cleanupCalls.push('success')
+      })
+      return {}
+    })
+
+    const scope = createScope()
+    await scope.resolve(failingResource)
+    await scope.resolve(successResource)
+
+    // Should not throw, continues cleanup even if one fails
+    await expect(scope.dispose()).resolves.not.toThrow()
+
+    // Both cleanups attempted
+    expect(cleanupCalls).toContain('failing')
+    expect(cleanupCalls).toContain('success')
+  })
+})
+```
+
+**Key principles:**
+- Test cleanup is called
+- Test cleanup order (reverse initialization)
+- Test error handling in cleanup
+- Verify resources released (connections, files)
+
+---
+
+## Pattern: Testing HTTP Integration with Hono
+
+Test real HTTP server:
+
+```typescript
+import { describe, test, expect, beforeAll, afterAll } from 'vitest'
+import { Hono } from 'hono'
+import { createScope, flow, type Scope } from '@pumped-fn/core-next'
+
+// Flow to test
+export namespace GetUser {
+  export type Input = { userId: string }
+  export type Success = { success: true; user: { id: string; name: string } }
+  export type NotFound = { success: false; reason: 'USER_NOT_FOUND' }
+  export type Result = Success | NotFound
+}
+
+export const getUser = flow(
+  async (_ctx, input: GetUser.Input): Promise<GetUser.Result> => {
+    if (input.userId === 'user-123') {
+      return { success: true, user: { id: 'user-123', name: 'Alice' } }
+    }
+    return { success: false, reason: 'USER_NOT_FOUND' }
+  }
+)
+
+// Hono app
+export function createApp(scope: Scope) {
+  const app = new Hono()
+
+  app.get('/users/:id', async (c) => {
+    const userId = c.req.param('id')
+
+    const result = await scope.exec(getUser, { userId })
+
+    if (!result.success) {
+      return c.json({ error: result.reason }, 404)
+    }
+
+    return c.json(result.user)
+  })
+
+  return app
+}
+
+describe('Hono integration tests', () => {
+  let scope: Scope
+  let app: Hono
+  let baseUrl: string
+  let server: ReturnType<typeof Bun.serve>
+
+  beforeAll(async () => {
+    scope = createScope()
+    app = createApp(scope)
+
+    // Start real HTTP server
+    server = Bun.serve({
+      port: 0,  // Random available port
+      fetch: app.fetch
+    })
+
+    baseUrl = `http://localhost:${server.port}`
+  })
+
+  afterAll(async () => {
+    server.stop()
+    await scope.dispose()
+  })
+
+  test('GET /users/:id returns user when found', async () => {
+    const response = await fetch(`${baseUrl}/users/user-123`)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual({ id: 'user-123', name: 'Alice' })
+  })
+
+  test('GET /users/:id returns 404 when not found', async () => {
+    const response = await fetch(`${baseUrl}/users/unknown`)
+    const data = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(data).toEqual({ error: 'USER_NOT_FOUND' })
+  })
+})
+```
+
+**Key principles:**
+- Start real HTTP server in beforeAll
+- Use random port (avoid conflicts)
+- Stop server in afterAll
+- Test actual HTTP requests/responses
+- Test status codes and response bodies
+
+---
+
+## Pattern: Testing File System Operations
+
+Test real file operations:
+
+```typescript
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import { createScope, provide, derive } from '@pumped-fn/core-next'
+import { readFile, writeFile, rm, mkdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+
+// Real file system executor
+export const fsOps = provide(() => ({
+  read: readFile,
+  write: writeFile,
+  delete: rm,
+  createDir: mkdir
+}))
+
+// File repository
+export const fileRepository = derive(
+  { fs: fsOps },
+  ({ fs }) => ({
+    save: async (path: string, content: string): Promise<void> => {
+      await fs.write(path, content, 'utf-8')
+    },
+    load: async (path: string): Promise<string> => {
+      return fs.read(path, 'utf-8')
+    },
+    remove: async (path: string): Promise<void> => {
+      await fs.delete(path)
+    }
+  })
+)
+
+describe('fileRepository integration tests', () => {
+  let scope: Scope
+  let repo: Awaited<ReturnType<typeof fileRepository['factory']>>
+  let testDir: string
+
+  beforeAll(async () => {
+    scope = createScope()
+    repo = await scope.resolve(fileRepository)
+
+    // Create temp directory for tests
+    testDir = join(tmpdir(), `pumped-test-${Date.now()}`)
+    const fs = await scope.resolve(fsOps)
+    await fs.createDir(testDir, { recursive: true })
+  })
+
+  afterAll(async () => {
+    // Cleanup temp directory
+    const fs = await scope.resolve(fsOps)
+    await fs.delete(testDir, { recursive: true, force: true })
+    await scope.dispose()
+  })
+
+  test('saves and loads file content', async () => {
+    const filePath = join(testDir, 'test.txt')
+    const content = 'Hello, World!'
+
+    await repo.save(filePath, content)
+    const loaded = await repo.load(filePath)
+
+    expect(loaded).toBe(content)
+  })
+
+  test('removes file successfully', async () => {
+    const filePath = join(testDir, 'to-delete.txt')
+
+    await repo.save(filePath, 'content')
+    await repo.remove(filePath)
+
+    await expect(repo.load(filePath)).rejects.toThrow()
+  })
+
+  test('throws when loading non-existent file', async () => {
+    const filePath = join(testDir, 'nonexistent.txt')
+
+    await expect(repo.load(filePath)).rejects.toThrow()
+  })
+})
+```
+
+**Key principles:**
+- Use temp directory (tmpdir())
+- Create test directory in beforeAll
+- Clean up directory in afterAll
+- Test real file operations (not mocked)
+- Test error cases (missing files)
+
+---
+
+## Pattern: Testing Concurrent Operations
+
+Test real concurrency issues:
+
+```typescript
+import { describe, test, expect } from 'vitest'
+import { createScope, flow } from '@pumped-fn/core-next'
+
+describe('concurrent operations integration', () => {
+  test('ctx.parallel() executes flows concurrently', async () => {
+    const timestamps: number[] = []
+
+    const delayedFlow = flow(async (_ctx, delay: number) => {
+      const start = Date.now()
+      timestamps.push(start)
+      await new Promise(resolve => setTimeout(resolve, delay))
+      return Date.now() - start
+    })
+
+    const parentFlow = flow(async (ctx, _input: void) => {
+      const promise1 = ctx.exec(delayedFlow, 100)
+      const promise2 = ctx.exec(delayedFlow, 100)
+      const promise3 = ctx.exec(delayedFlow, 100)
+
+      const result = await ctx.parallel([promise1, promise2, promise3])
+
+      return result.results
+    })
+
+    const scope = createScope()
+    const durations = await scope.exec(parentFlow, undefined)
+
+    // All flows started roughly at same time (concurrent)
+    const maxTimeDiff = Math.max(...timestamps) - Math.min(...timestamps)
+    expect(maxTimeDiff).toBeLessThan(50)  // Started within 50ms
+
+    // All flows took ~100ms
+    durations.forEach(duration => {
+      expect(duration).toBeGreaterThanOrEqual(90)
+      expect(duration).toBeLessThan(150)
+    })
+
+    await scope.dispose()
+  })
+
+  test('sequential execution takes longer than parallel', async () => {
+    const sequentialFlow = flow(async (ctx, _input: void) => {
+      const start = Date.now()
+
+      const result1 = await ctx.exec(
+        flow(async () => {
+          await new Promise(resolve => setTimeout(resolve, 50))
+          return 1
+        }),
+        undefined
+      )
+
+      const result2 = await ctx.exec(
+        flow(async () => {
+          await new Promise(resolve => setTimeout(resolve, 50))
+          return 2
+        }),
+        undefined
+      )
+
+      return Date.now() - start
+    })
+
+    const parallelFlow = flow(async (ctx, _input: void) => {
+      const start = Date.now()
+
+      const promise1 = ctx.exec(
+        flow(async () => {
+          await new Promise(resolve => setTimeout(resolve, 50))
+          return 1
+        }),
+        undefined
+      )
+
+      const promise2 = ctx.exec(
+        flow(async () => {
+          await new Promise(resolve => setTimeout(resolve, 50))
+          return 2
+        }),
+        undefined
+      )
+
+      await ctx.parallel([promise1, promise2])
+
+      return Date.now() - start
+    })
+
+    const scope = createScope()
+
+    const sequentialTime = await scope.exec(sequentialFlow, undefined)
+    const parallelTime = await scope.exec(parallelFlow, undefined)
+
+    // Sequential takes ~100ms, parallel takes ~50ms
+    expect(sequentialTime).toBeGreaterThanOrEqual(90)
+    expect(parallelTime).toBeLessThan(sequentialTime)
+
+    await scope.dispose()
+  })
+})
+```
+
+**Key principles:**
+- Test actual timing (not mocked delays)
+- Verify concurrent execution happens
+- Compare sequential vs parallel performance
+- Use real setTimeout/Promise delays
+
+---
+
+## When to Use Integration vs Unit Tests
+
+| Scenario | Unit Test (preset) | Integration Test (real) |
+|----------|-------------------|------------------------|
+| Business logic validation | ✅ Preferred | ❌ Overkill |
+| Database queries | ⚠️ Simple cases | ✅ Preferred |
+| HTTP endpoints | ❌ Not possible | ✅ Required |
+| File system ops | ⚠️ Simple cases | ✅ Preferred |
+| Resource cleanup | ❌ Can't verify | ✅ Required |
+| Error handling | ✅ Preferred | ⚠️ Supplement |
+| Edge cases | ✅ Preferred | ❌ Overkill |
+| Concurrency | ❌ Can't verify | ✅ Required |
+
+**Strategy:**
+1. Start with unit tests (fast, deterministic)
+2. Add integration tests for:
+   - Database interactions
+   - HTTP/API integration
+   - File system operations
+   - Resource lifecycle
+   - Concurrency/timing issues
+3. Use integration tests sparingly (slower, setup overhead)
+
+---
+
+## Troubleshooting
+
+### Problem: Integration tests fail in CI but pass locally
+
+**Cause:** Different environment (ports, paths, database config)
+
+**Solution:**
+```typescript
+// ✅ Use environment variables for config
+const testDbConfig = {
+  host: process.env.TEST_DB_HOST || 'localhost',
+  port: parseInt(process.env.TEST_DB_PORT || '5432'),
+  database: process.env.TEST_DB_NAME || 'test_db'
+}
+
+// ✅ Use random ports for HTTP servers
+server = Bun.serve({
+  port: 0,  // Random available port
+  fetch: app.fetch
+})
+```
+
+### Problem: Tests interfere with each other
+
+**Cause:** Shared database state or concurrent writes
+
+**Solution:**
+```typescript
+// ✅ Clean database before each test
+beforeEach(async () => {
+  await repo.deleteAll()
+})
+
+// ✅ Use unique test data per test
+test('test 1', async () => {
+  await repo.create({ email: 'test1@example.com', name: 'Test 1' })
+})
+
+test('test 2', async () => {
+  await repo.create({ email: 'test2@example.com', name: 'Test 2' })
+})
+```
+
+### Problem: Resource cleanup not happening
+
+**Cause:** Forgot to call scope.dispose() or error in cleanup
+
+**Solution:**
+```typescript
+// ✅ Always dispose scope in afterAll
+afterAll(async () => {
+  await scope.dispose()
+})
+
+// ✅ Use try/finally for critical cleanup
+afterAll(async () => {
+  try {
+    await scope.dispose()
+  } finally {
+    // Additional cleanup (delete temp files, etc.)
+  }
+})
+```
+
+### Problem: Integration tests too slow
+
+**Cause:** Too many integration tests or inefficient setup
+
+**Solution:**
+- Use unit tests for edge cases (faster)
+- Share scope across tests (setup once in beforeAll)
+- Run integration tests in parallel (Vitest pool)
+- Use faster test database (in-memory SQLite)
+
+```typescript
+// ✅ Share scope for faster tests
+let scope: Scope
+
+beforeAll(async () => {
+  scope = createScope({ /* config */ })
+})
+
+afterAll(async () => {
+  await scope.dispose()
+})
+
+beforeEach(async () => {
+  // Only clean data, don't recreate scope
+  await cleanDatabase()
+})
+```
+
+---
+
+## Summary
+
+**Integration testing:**
+- Use real resources (test DB, real FS)
+- Test resource lifecycle (cleanup)
+- Test actual HTTP requests
+- Test concurrency and timing
+- Setup in beforeAll, cleanup in afterAll
+- Use unit tests for edge cases
+- Integration tests for critical paths
+
+**Related sub-skills:**
+- `testing-utilities.md` - Unit testing pure functions
+- `testing-flows.md` - Integration testing flows with preset()
+- `resource-basic.md` - Resource lifecycle patterns
+- `integration-hono.md` - Hono HTTP integration

--- a/skills/pumped-design/references/testing-utilities.md
+++ b/skills/pumped-design/references/testing-utilities.md
@@ -1,0 +1,551 @@
+---
+name: testing-utilities
+tags: testing, util, unit, preset, pure, executor, mock, boundary
+description: Unit testing pure functions and executor-wrapped utilities with preset(). Test edge cases, boundary conditions, and input validation. Mock dependencies via preset() for isolated testing. Test discriminated union branches with type narrowing.
+---
+
+# Testing Utilities (Unit Tests)
+
+## When to Use This Pattern
+
+**Unit testing utilities means:**
+- Testing pure functions (no side effects)
+- Testing executor-wrapped built-ins with `preset()`
+- Testing edge cases and boundary conditions
+- Testing input validation logic
+- Isolated testing (no real resources)
+
+**Use unit tests for:**
+- Pure utility functions (formatters, parsers, validators)
+- Executor-wrapped Node.js built-ins (fs, crypto, etc.)
+- Boundary conditions (empty arrays, null, undefined)
+- Error cases (invalid input, out of range)
+- Type narrowing with discriminated unions
+
+---
+
+## Pattern: Testing Pure Functions
+
+Pure functions have no dependencies and produce deterministic output.
+
+```typescript
+import { describe, test, expect } from 'vitest'
+
+// Pure utility function
+export const formatCurrency = (amount: number, currency: string): string => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency
+  }).format(amount)
+}
+
+export const parseEmail = (raw: string): { success: true; email: string } | { success: false; reason: 'INVALID_FORMAT' } => {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+  if (!emailRegex.test(raw)) {
+    return { success: false, reason: 'INVALID_FORMAT' }
+  }
+
+  return { success: true, email: raw.toLowerCase() }
+}
+
+// Tests for pure functions
+describe('formatCurrency', () => {
+  test('formats USD correctly', () => {
+    const result = formatCurrency(1234.56, 'USD')
+
+    expect(result).toBe('$1,234.56')
+  })
+
+  test('formats EUR correctly', () => {
+    const result = formatCurrency(9999.99, 'EUR')
+
+    expect(result).toBe('€9,999.99')
+  })
+
+  test('handles zero amount', () => {
+    const result = formatCurrency(0, 'USD')
+
+    expect(result).toBe('$0.00')
+  })
+
+  test('handles negative amounts', () => {
+    const result = formatCurrency(-50.25, 'USD')
+
+    expect(result).toBe('-$50.25')
+  })
+})
+
+describe('parseEmail', () => {
+  test('accepts valid email', () => {
+    const result = parseEmail('user@example.com')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.email).toBe('user@example.com')
+    }
+  })
+
+  test('normalizes email to lowercase', () => {
+    const result = parseEmail('User@EXAMPLE.COM')
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.email).toBe('user@example.com')
+    }
+  })
+
+  test('rejects email without @', () => {
+    const result = parseEmail('invalid-email.com')
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_FORMAT')
+    }
+  })
+
+  test('rejects email without domain', () => {
+    const result = parseEmail('user@')
+
+    expect(result.success).toBe(false)
+  })
+
+  test('rejects empty string', () => {
+    const result = parseEmail('')
+
+    expect(result.success).toBe(false)
+  })
+})
+```
+
+**Key principles:**
+- Test happy path first
+- Test edge cases (empty, zero, negative)
+- Test all discriminated union branches
+- Use type narrowing (if result.success)
+- No scope needed (pure functions)
+
+---
+
+## Pattern: Testing Executor-Wrapped Built-ins
+
+Executor-wrapped built-ins need `preset()` for mocking.
+
+```typescript
+import { describe, test, expect, beforeEach, afterEach } from 'vitest'
+import { provide, derive, preset, createScope, type Scope } from '@pumped-fn/core-next'
+import { readFile } from 'node:fs/promises'
+
+// Executor wrapping Node.js built-in
+export const fsRead = provide(() => ({ read: readFile }))
+
+// Derived utility using fs
+export const loadJsonFile = derive(
+  { fs: fsRead },
+  ({ fs }) => async (path: string): Promise<unknown> => {
+    const content = await fs.read(path, 'utf-8')
+    return JSON.parse(content)
+  }
+)
+
+describe('loadJsonFile', () => {
+  let scope: Scope
+
+  beforeEach(() => {
+    // Mock fsRead with preset()
+    const mockFs = {
+      read: async (path: string, _encoding: string) => {
+        if (path === '/valid.json') {
+          return '{"name":"test","value":42}'
+        }
+        if (path === '/empty.json') {
+          return '{}'
+        }
+        if (path === '/invalid.json') {
+          return 'not json'
+        }
+        throw new Error('File not found')
+      }
+    }
+
+    scope = createScope({
+      presets: [preset(fsRead, mockFs)]
+    })
+  })
+
+  afterEach(async () => {
+    await scope.dispose()
+  })
+
+  test('parses valid JSON file', async () => {
+    const loader = await scope.resolve(loadJsonFile)
+    const result = await loader('/valid.json')
+
+    expect(result).toEqual({ name: 'test', value: 42 })
+  })
+
+  test('handles empty JSON file', async () => {
+    const loader = await scope.resolve(loadJsonFile)
+    const result = await loader('/empty.json')
+
+    expect(result).toEqual({})
+  })
+
+  test('throws on invalid JSON', async () => {
+    const loader = await scope.resolve(loadJsonFile)
+
+    await expect(loader('/invalid.json')).rejects.toThrow()
+  })
+
+  test('throws on missing file', async () => {
+    const loader = await scope.resolve(loadJsonFile)
+
+    await expect(loader('/missing.json')).rejects.toThrow('File not found')
+  })
+})
+```
+
+**Key principles:**
+- Use `preset()` to mock executor dependencies
+- Create fresh scope in `beforeEach`
+- Dispose scope in `afterEach`
+- Mock returns deterministic values (no randomness)
+- Test error cases (throw/reject)
+
+---
+
+## Real Example: Tag Tests from pumped-fn
+
+From `packages/next/tests/core.test.ts`:
+
+```typescript
+describe("Tag functionality", () => {
+  test("tag provides default value when created with initial value", () => {
+    const numberTag = tag(custom<number>(), { label: "test.number", default: 42 });
+    const store = new Map();
+
+    const result = numberTag.find(store);
+
+    expect(result).toBe(42);
+  });
+
+  test("tag stores and retrieves values from store", () => {
+    const stringTag = tag(custom<string>(), { label: "test.string" });
+    const store = new Map();
+
+    stringTag.set(store, "hello");
+    const result = stringTag.find(store);
+
+    expect(result).toBe("hello");
+  });
+
+  test("tag returns undefined when no value set and no default provided", () => {
+    const optionalTag = tag(custom<string>(), { label: "test.optional" });
+    const store = new Map();
+
+    const result = optionalTag.find(store);
+
+    expect(result).toBeUndefined();
+  });
+});
+```
+
+**What makes this good:**
+- Tests default value behavior
+- Tests set/get operations
+- Tests undefined case (no default)
+- No external dependencies
+- Fast execution
+
+---
+
+## Pattern: Testing Boundary Conditions
+
+Always test edge cases:
+
+```typescript
+import { describe, test, expect } from 'vitest'
+
+export const calculateDiscount = (
+  price: number,
+  discountPercent: number
+): { success: true; finalPrice: number } | { success: false; reason: 'INVALID_PRICE' | 'INVALID_DISCOUNT' } => {
+  if (price < 0) {
+    return { success: false, reason: 'INVALID_PRICE' }
+  }
+
+  if (discountPercent < 0 || discountPercent > 100) {
+    return { success: false, reason: 'INVALID_DISCOUNT' }
+  }
+
+  const finalPrice = price * (1 - discountPercent / 100)
+
+  return { success: true, finalPrice }
+}
+
+describe('calculateDiscount boundary conditions', () => {
+  test('handles zero price', () => {
+    const result = calculateDiscount(0, 10)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.finalPrice).toBe(0)
+    }
+  })
+
+  test('handles zero discount', () => {
+    const result = calculateDiscount(100, 0)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.finalPrice).toBe(100)
+    }
+  })
+
+  test('handles 100% discount', () => {
+    const result = calculateDiscount(100, 100)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.finalPrice).toBe(0)
+    }
+  })
+
+  test('rejects negative price', () => {
+    const result = calculateDiscount(-1, 10)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_PRICE')
+    }
+  })
+
+  test('rejects negative discount', () => {
+    const result = calculateDiscount(100, -1)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_DISCOUNT')
+    }
+  })
+
+  test('rejects discount over 100', () => {
+    const result = calculateDiscount(100, 101)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_DISCOUNT')
+    }
+  })
+
+  test('handles floating point prices', () => {
+    const result = calculateDiscount(99.99, 15)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.finalPrice).toBeCloseTo(84.99, 2)
+    }
+  })
+})
+```
+
+**Boundary cases to test:**
+- Zero values
+- Negative values
+- Maximum values
+- Empty collections ([], {}, '')
+- Null/undefined (if allowed)
+- Floating point precision
+
+---
+
+## Pattern: Testing Type Narrowing
+
+Discriminated unions enable type-safe testing:
+
+```typescript
+import { describe, test, expect } from 'vitest'
+
+export namespace ValidateAge {
+  export type Success = { success: true; age: number; category: 'child' | 'adult' | 'senior' }
+  export type TooYoung = { success: false; reason: 'TOO_YOUNG' }
+  export type TooOld = { success: false; reason: 'TOO_OLD' }
+  export type Invalid = { success: false; reason: 'INVALID_AGE' }
+
+  export type Result = Success | TooYoung | TooOld | Invalid
+}
+
+export const validateAge = (age: number): ValidateAge.Result => {
+  if (!Number.isInteger(age) || age < 0) {
+    return { success: false, reason: 'INVALID_AGE' }
+  }
+
+  if (age < 13) {
+    return { success: false, reason: 'TOO_YOUNG' }
+  }
+
+  if (age > 120) {
+    return { success: false, reason: 'TOO_OLD' }
+  }
+
+  const category = age < 18 ? 'child' : age >= 65 ? 'senior' : 'adult'
+
+  return { success: true, age, category }
+}
+
+describe('validateAge type narrowing', () => {
+  test('child category (13-17)', () => {
+    const result = validateAge(15)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      // TypeScript knows: result has age, category
+      expect(result.age).toBe(15)
+      expect(result.category).toBe('child')
+    }
+  })
+
+  test('adult category (18-64)', () => {
+    const result = validateAge(30)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.category).toBe('adult')
+    }
+  })
+
+  test('senior category (65+)', () => {
+    const result = validateAge(70)
+
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.category).toBe('senior')
+    }
+  })
+
+  test('TOO_YOUNG error', () => {
+    const result = validateAge(10)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      // TypeScript knows: result has reason property
+      expect(result.reason).toBe('TOO_YOUNG')
+    }
+  })
+
+  test('TOO_OLD error', () => {
+    const result = validateAge(150)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('TOO_OLD')
+    }
+  })
+
+  test('INVALID_AGE error (negative)', () => {
+    const result = validateAge(-5)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_AGE')
+    }
+  })
+
+  test('INVALID_AGE error (float)', () => {
+    const result = validateAge(25.5)
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.reason).toBe('INVALID_AGE')
+    }
+  })
+})
+```
+
+**Key principles:**
+- Test ALL branches (Success + each Error type)
+- Use `if (result.success)` for type narrowing
+- TypeScript proves completeness
+- No optional chaining after narrowing
+
+---
+
+## Troubleshooting
+
+### Problem: Tests fail with "Cannot resolve executor"
+
+**Cause:** Forgot to create scope or use preset()
+
+**Solution:**
+```typescript
+// ❌ Wrong - no scope
+const loader = await loadJsonFile('/test.json')
+
+// ✅ Correct - use scope.resolve()
+const scope = createScope({ presets: [preset(fsRead, mockFs)] })
+const loader = await scope.resolve(loadJsonFile)
+await scope.dispose()
+```
+
+### Problem: Mock not working
+
+**Cause:** Preset applied to wrong executor or missing dependency
+
+**Solution:**
+```typescript
+// ❌ Wrong - preset doesn't match dependency
+const mockRepo = { find: async () => null }
+scope = createScope({ presets: [preset(dbPool, mockRepo)] })
+
+// ✅ Correct - preset matches actual dependency
+const mockRepo = { find: async () => null }
+scope = createScope({ presets: [preset(userRepository, mockRepo)] })
+```
+
+### Problem: Type narrowing doesn't work
+
+**Cause:** Forgot to check discriminator or used wrong check
+
+**Solution:**
+```typescript
+// ❌ Wrong - no discriminator check
+const result = validateAge(30)
+expect(result.age).toBe(30)  // TypeScript error: age might not exist
+
+// ✅ Correct - check discriminator first
+const result = validateAge(30)
+expect(result.success).toBe(true)
+if (result.success) {
+  expect(result.age).toBe(30)  // TypeScript knows age exists
+}
+```
+
+### Problem: Floating point assertion fails
+
+**Cause:** Precision issues with floating point arithmetic
+
+**Solution:**
+```typescript
+// ❌ Wrong - exact equality
+expect(result.finalPrice).toBe(84.9915)
+
+// ✅ Correct - use toBeCloseTo()
+expect(result.finalPrice).toBeCloseTo(84.99, 2)
+```
+
+---
+
+## Summary
+
+**Unit testing utilities:**
+- Pure functions need no scope/preset
+- Executor-wrapped built-ins need preset()
+- Always test boundary conditions
+- Test ALL discriminated union branches
+- Use type narrowing for type safety
+- Dispose scope in afterEach
+
+**Related sub-skills:**
+- `testing-flows.md` - Integration testing flows
+- `testing-integration.md` - End-to-end testing
+- `coding-standards.md` - Type safety rules


### PR DESCRIPTION
## Summary

Restructures plugin directory to comply with official Claude Code plugin specification:

- Moves `plugin.json` from `claude-skill/` to `.claude-plugin/`
- Creates distributable `skills/pumped-design/` (separate from `.claude/skills/`)
- Updates `marketplace.json` with correct paths and version sync
- Fixes repository URLs to `pumped-fn/pumped-fn` organization

## Changes

**Plugin structure:**
- `.claude-plugin/plugin.json` - Plugin manifest per docs
- `skills/pumped-design/` - Distributable skill (copied from `.claude/skills/`)
- `README-plugin.md` - Plugin documentation with updated paths
- Removed `claude-skill/` directory

**Metadata updates:**
- `marketplace.json` - Source path, version, URLs
- Repository URLs → `pumped-fn/pumped-fn`
- Homepage paths → `skills/pumped-design`

## Installation

After merge, users can install via:

**Local:**
```bash
/plugin install /path/to/pumped-fn
```

**Remote:**
```bash
/plugin marketplace add https://github.com/pumped-fn/pumped-fn
/plugin install pumped-design@pumped-fn
```

## Test plan

- [x] Created proper `.claude-plugin/` structure
- [x] Verified `skills/pumped-design/` contains all references
- [x] Updated all paths in `plugin.json` and `marketplace.json`
- [ ] Test local installation: `/plugin install /path/to/repo`
- [ ] Test remote installation after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)