### PR TITLE
feat(lite): add Controller.set() and Controller.update() for direct value mutation

### DIFF
--- a/.c3/adr/adr-013-controller-set-update.md
+++ b/.c3/adr/adr-013-controller-set-update.md
@@ -1,0 +1,443 @@
+---
+id: adr-013
+title: Controller.set() and Controller.update() for Direct Value Mutation
+summary: >
+  Add set() and update() methods to Controller for pushing values directly
+  without re-running the factory, enabling external data sources (WebSocket,
+  etc.) to update atom values reactively while preserving the invalidation queue.
+status: proposed
+date: 2025-12-03
+---
+
+# [ADR-013] Controller.set() and Controller.update() for Direct Value Mutation
+
+## Status {#adr-013-status}
+**Proposed** - 2025-12-03
+
+## Problem/Requirement {#adr-013-problem}
+
+Frontend applications need to push data from external sources (WebSocket, server-sent events, etc.) into the atom system while maintaining reactivity.
+
+**Example scenario:**
+```
+WebSocket message → User data → Authentication state → Dashboard
+```
+
+Currently, the only way to update an atom's value is `invalidate()`, which re-runs the factory. This is problematic when:
+
+1. **Data comes from outside** - WebSocket pushes new user data; factory would re-fetch, missing the pushed value
+2. **Factory is expensive** - Re-running setup logic (connections, subscriptions) just to accept a new value
+3. **Value is known** - Caller already has the new value; factory can't "receive" it
+
+**Current workarounds:**
+- Store value in module-level closure, `invalidate()`, factory reads closure → breaks scope isolation
+- Use `ctx.data` to cache, `invalidate()`, factory reads from data → awkward indirection
+- Create separate "source" atoms with shared state → complex dual-model
+
+## Exploration Journey {#adr-013-exploration}
+
+**Initial hypothesis:** Add scope-level `sharedData` storage with reactive subscriptions.
+
+**Explored:**
+- `ctx.sharedData` / `scope.sharedData` with `.on(tag, callback)` subscriptions
+- Tags as keys for type safety
+- Reactive notifications on `.set()`
+
+**Discovered:**
+- Adds new primitive (`SharedData`) and new concepts
+- Duplicates what Controller already provides (reactive access, subscriptions)
+- Doesn't leverage existing dependency graph
+
+**Key insight:** Controller already has:
+- The cached value
+- The listener notification system (`on()`)
+- The state machine and queue infrastructure (ADR-011)
+- The type `T` from `Controller<T>`
+
+Adding `set(value: T)` requires no new primitives - just extends Controller.
+
+**Revisiting ADR-003 rejection:**
+
+ADR-003 rejected `set()` citing type inference problems. However:
+- Controller already has `T` from `Controller<T>`
+- `set(value: T)` uses same `T` - no additional inference
+- Type safety is preserved
+
+**Confirmed:**
+- `set()` and `update()` should use same queue as `invalidate()` (ADR-011)
+- Same state transitions: `resolved → resolving → resolved`
+- Same cleanup execution
+- Same listener notification
+
+## Solution {#adr-013-solution}
+
+### API Addition
+
+```typescript
+interface Controller<T> {
+  // Existing
+  readonly state: AtomState
+  get(): T
+  resolve(): Promise<T>
+  release(): Promise<void>
+  invalidate(): void
+  on(event: ControllerEvent, listener: () => void): () => void
+
+  // New
+  set(value: T): void
+  update(fn: (prev: T) => T): void
+}
+```
+
+### Behavior
+
+Both `set()` and `update()` follow the same pattern as `invalidate()`:
+
+1. Queue operation via `scheduleInvalidation()` (sync return)
+2. On microtask processing:
+   - State: `resolved → resolving` (notify listeners)
+   - Run cleanups (LIFO)
+   - Replace value (from argument, not factory)
+   - State: `resolving → resolved` (notify listeners)
+
+**Comparison:**
+
+| | `invalidate()` | `set(value)` / `update(fn)` |
+|---|---|---|
+| Runs cleanups | Yes | Yes |
+| State transition | resolving → resolved | resolving → resolved |
+| Gets value from | Factory (async) | Argument (sync) |
+| Triggers listeners | Yes | Yes |
+| Uses queue | Yes | Yes |
+
+**`update()` is sugar:**
+
+```typescript
+controller.update(fn)
+// Equivalent to:
+controller.set(fn(controller.get()))
+```
+
+### Usage Examples
+
+**WebSocket pushing user updates:**
+
+```typescript
+const userAtom = atom({
+  factory: async () => fetch('/api/me').then(r => r.json())
+})
+
+const wsAtom = atom({
+  deps: { user: controller(userAtom) },
+  factory: (ctx, { user }) => {
+    const ws = new WebSocket('wss://api.example.com')
+
+    ws.onmessage = (event) => {
+      const data = JSON.parse(event.data)
+      if (data.type === 'user-update') {
+        user.set(data.payload)  // Push value directly
+      }
+    }
+
+    ctx.cleanup(() => ws.close())
+    return ws
+  }
+})
+```
+
+**External control:**
+
+```typescript
+const scope = createScope()
+const userCtrl = scope.controller(userAtom)
+
+await userCtrl.resolve()
+
+// Push from outside (e.g., form submission)
+userCtrl.set({ name: 'Alice', role: 'admin' })
+
+// Transform existing value
+userCtrl.update(user => ({ ...user, lastSeen: Date.now() }))
+```
+
+**React integration unchanged:**
+
+```typescript
+function useAtom<T>(ctrl: Controller<T>): T {
+  return useSyncExternalStore(ctrl.on, ctrl.get)
+}
+// Works with set/update - listeners fire, component re-renders
+```
+
+### State Requirements
+
+`set()` and `update()` require the atom to be in `resolved` state:
+
+| State | `set()` / `update()` Behavior |
+|-------|-------------------------------|
+| `idle` | Throws "Atom not resolved" |
+| `resolving` | Queues (pendingSet), executes after resolution |
+| `resolved` | Queues normally |
+| `failed` | Throws the stored error |
+
+## Changes Across Layers {#adr-013-changes}
+
+### Types (types.ts)
+
+```typescript
+export interface Controller<T> {
+  // ... existing ...
+
+  set(value: T): void
+  update(fn: (prev: T) => T): void
+}
+```
+
+### Scope Implementation (scope.ts)
+
+```typescript
+// AtomEntry - add pending set value
+interface AtomEntry<T> {
+  // ... existing ...
+  pendingSet?: { value: T } | { fn: (prev: T) => T }
+}
+
+// ControllerImpl - add methods
+class ControllerImpl<T> implements Lite.Controller<T> {
+  // ... existing ...
+
+  set(value: T): void {
+    this.scope.scheduleSet(this.atom, value)
+  }
+
+  update(fn: (prev: T) => T): void {
+    this.scope.scheduleUpdate(this.atom, fn)
+  }
+}
+
+// ScopeImpl - add scheduling methods
+class ScopeImpl {
+  scheduleSet<T>(atom: Lite.Atom<T>, value: T): void {
+    const entry = this.cache.get(atom)
+    if (!entry || entry.state === 'idle') {
+      throw new Error("Atom not resolved")
+    }
+    if (entry.state === 'failed' && entry.error) {
+      throw entry.error
+    }
+
+    if (entry.state === 'resolving') {
+      entry.pendingSet = { value }
+      return
+    }
+
+    entry.pendingSet = { value }
+    this.scheduleInvalidation(atom)
+  }
+
+  scheduleUpdate<T>(atom: Lite.Atom<T>, fn: (prev: T) => T): void {
+    const entry = this.cache.get(atom)
+    if (!entry || entry.state === 'idle') {
+      throw new Error("Atom not resolved")
+    }
+    if (entry.state === 'failed' && entry.error) {
+      throw entry.error
+    }
+
+    if (entry.state === 'resolving') {
+      entry.pendingSet = { fn }
+      return
+    }
+
+    entry.pendingSet = { fn }
+    this.scheduleInvalidation(atom)
+  }
+
+  // Modified doInvalidateSequential
+  private async doInvalidateSequential<T>(atom: Lite.Atom<T>): Promise<void> {
+    const entry = this.cache.get(atom)
+    if (!entry) return
+
+    // ... cleanup, state = resolving, notify ...
+
+    // Check for pending set
+    if (entry.pendingSet) {
+      const pending = entry.pendingSet
+      entry.pendingSet = undefined
+
+      if ('value' in pending) {
+        entry.value = pending.value
+      } else {
+        entry.value = pending.fn(entry.value as T)
+      }
+      entry.state = 'resolved'
+      entry.hasValue = true
+      this.notifyListeners(atom, 'resolved')
+      this.emitStateChange('resolved', atom)
+      return
+    }
+
+    // Normal invalidation - run factory
+    await this.resolve(atom)
+  }
+}
+```
+
+### Component Docs (c3-201-scope.md)
+
+Add section `#c3-201-set-update`:
+
+```markdown
+## Direct Value Mutation {#c3-201-set-update}
+
+### Controller.set() and Controller.update()
+
+Push values directly without re-running the factory:
+
+\`\`\`typescript
+const ctrl = scope.controller(userAtom)
+await ctrl.resolve()
+
+// Replace value
+ctrl.set({ name: 'Alice' })
+
+// Transform value
+ctrl.update(user => ({ ...user, lastSeen: Date.now() }))
+\`\`\`
+
+### Behavior
+
+Both methods:
+1. Queue via same mechanism as `invalidate()`
+2. Run cleanups (LIFO)
+3. State: `resolving` → `resolved`
+4. Notify listeners
+
+### When to Use
+
+| Use Case | Method |
+|----------|--------|
+| External data source pushes value | `set()` |
+| Transform based on current value | `update()` |
+| Re-fetch from source | `invalidate()` |
+\`\`\`
+```
+
+### Test Files
+
+Add to `tests/scope.test.ts`:
+
+```typescript
+describe('Controller.set()', () => {
+  it('replaces value and notifies listeners', async () => {
+    const userAtom = atom({ factory: () => ({ name: 'Guest' }) })
+    const scope = createScope()
+    const ctrl = scope.controller(userAtom)
+
+    await ctrl.resolve()
+
+    const notifications: string[] = []
+    ctrl.on('resolved', () => notifications.push('resolved'))
+
+    ctrl.set({ name: 'Alice' })
+    await scope.flush()
+
+    expect(ctrl.get()).toEqual({ name: 'Alice' })
+    expect(notifications).toEqual(['resolved'])
+  })
+
+  it('runs cleanups before setting', async () => {
+    const cleanups: string[] = []
+    const userAtom = atom({
+      factory: (ctx) => {
+        ctx.cleanup(() => cleanups.push('cleanup'))
+        return { name: 'Guest' }
+      }
+    })
+
+    const scope = createScope()
+    const ctrl = scope.controller(userAtom)
+    await ctrl.resolve()
+
+    ctrl.set({ name: 'Alice' })
+    await scope.flush()
+
+    expect(cleanups).toEqual(['cleanup'])
+  })
+
+  it('throws when atom not resolved', () => {
+    const userAtom = atom({ factory: () => ({ name: 'Guest' }) })
+    const scope = createScope()
+    const ctrl = scope.controller(userAtom)
+
+    expect(() => ctrl.set({ name: 'Alice' })).toThrow("Atom not resolved")
+  })
+
+  it('queues when atom is resolving', async () => {
+    let resolveFactory: () => void
+    const userAtom = atom({
+      factory: () => new Promise(r => { resolveFactory = () => r({ name: 'Guest' }) })
+    })
+
+    const scope = createScope()
+    const ctrl = scope.controller(userAtom)
+
+    const resolvePromise = ctrl.resolve()
+    ctrl.set({ name: 'Alice' })  // Should queue, not throw
+
+    resolveFactory!()
+    await resolvePromise
+    await scope.flush()
+
+    expect(ctrl.get()).toEqual({ name: 'Alice' })
+  })
+})
+
+describe('Controller.update()', () => {
+  it('transforms value using function', async () => {
+    const countAtom = atom({ factory: () => 0 })
+    const scope = createScope()
+    const ctrl = scope.controller(countAtom)
+
+    await ctrl.resolve()
+
+    ctrl.update(n => n + 1)
+    await scope.flush()
+
+    expect(ctrl.get()).toBe(1)
+  })
+})
+```
+
+## Verification {#adr-013-verification}
+
+### Type System
+- [ ] `ctrl.set(value)` requires `value: T` matching atom type
+- [ ] `ctrl.update(fn)` requires `fn: (prev: T) => T`
+- [ ] Compile error if type mismatch
+
+### Runtime Behavior
+- [ ] `set()` replaces value without calling factory
+- [ ] `update()` transforms value without calling factory
+- [ ] Cleanups run before value replacement
+- [ ] State transitions: `resolved → resolving → resolved`
+- [ ] Listeners notified at each transition
+- [ ] Throws on idle/failed state
+- [ ] Queues when resolving (pendingSet)
+
+### Queue Integration
+- [ ] Uses same queue as `invalidate()`
+- [ ] Same frame model (trigger → process → settle)
+- [ ] Loop detection still works
+- [ ] Concurrent `set()` calls deduplicated
+
+### Integration
+- [ ] Works with `scope.select()` (derived subscriptions update)
+- [ ] Works with `useSyncExternalStore` (React re-renders)
+- [ ] Works with controller dependency pattern
+
+## Related {#adr-013-related}
+
+- [c3-201](../c3-2-lite/c3-201-scope.md) - Scope & Controller component
+- [ADR-003](./adr-003-controller-reactivity.md) - Original Controller design (addresses rejection)
+- [ADR-011](./adr-011-sequential-invalidation-chain.md) - Queue infrastructure reused

--- a/.c3/adr/adr-014-datastore-map-semantics.md
+++ b/.c3/adr/adr-014-datastore-map-semantics.md
@@ -1,0 +1,310 @@
+---
+id: adr-014
+title: DataStore Map-like Semantics
+summary: >
+  Align DataStore with Map semantics - get() always returns T | undefined
+  (pure lookup), defaults only used by getOrSet() not get().
+status: proposed
+date: 2025-12-03
+---
+
+# [ADR-014] DataStore Map-like Semantics
+
+## Status {#adr-014-status}
+**Proposed** - 2025-12-03
+
+## Problem/Requirement {#adr-014-problem}
+
+The current DataStore API (ADR-010, ADR-012) has subtle semantics that differ from JavaScript's `Map`:
+
+**Issue: `get()` returns default for tags with defaults**
+
+```typescript
+const countTag = tag<number>({ label: 'count', default: 0 })
+
+ctx.data.get(countTag)  // Returns 0 (default) - but not stored!
+ctx.data.has(countTag)  // Returns false - confusing!
+```
+
+This creates confusion:
+- `get()` returns a value, but `has()` returns false
+- Different behavior based on tag configuration
+- Not Map-like: `Map.get()` returns undefined if key not present
+
+**The mental model should be:**
+- `get()` = pure lookup (like `Map.get()`)
+- `getOrSet()` = initialize if missing, return value (like React's `useState` initial value)
+
+## Exploration Journey {#adr-014-exploration}
+
+**Initial hypothesis:** Changes isolated to DataStore interface and implementation.
+
+**Explored:**
+- **Isolated (DataStore):** Interface in types.ts, implementation in scope.ts
+- **Upstream (ADR-010, ADR-012):** Original design decisions
+- **Downstream (c3-202):** Documentation of ctx.data patterns
+
+**Discovered:**
+- Current `get()` behavior with defaults is "magical" - does more than a pure lookup
+- Map-like semantics are simpler to reason about
+- `getOrSet` name is accurate: "get the value, or set and return if missing" (like React's `useState`)
+
+**Confirmed:** Changes affect DataStore interface, implementation, and documentation only.
+
+## Solution {#adr-014-solution}
+
+### Change: `get()` Always Returns `T | undefined`
+
+Make `get()` a pure lookup - returns stored value or undefined, never uses defaults:
+
+```typescript
+// BEFORE (ADR-010)
+get<T, H extends boolean>(tag: Tag<T, H>): H extends true ? T : T | undefined
+
+// AFTER
+get<T>(tag: Tag<T, boolean>): T | undefined
+```
+
+**Behavior:**
+
+```typescript
+const countTag = tag<number>({ label: 'count', default: 0 })
+
+ctx.data.get(countTag)  // undefined (not stored)
+ctx.data.has(countTag)  // false
+
+ctx.data.set(countTag, 5)
+ctx.data.get(countTag)  // 5
+ctx.data.has(countTag)  // true
+```
+
+**Rationale:**
+- Map-like: `get()` is pure lookup, no magic
+- Predictable: same behavior regardless of tag configuration
+- `has()` and `get()` are consistent
+
+### `getOrSet` Unchanged (ADR-012)
+
+The existing `getOrSet` name is accurate:
+- **Get** the value if it exists
+- **Or Set** (and return) if missing
+
+This follows React's `useState` pattern - the default is only used on first access:
+
+```typescript
+// React
+const [count, setCount] = useState(0)  // 0 only used on first render
+
+// DataStore
+const count = ctx.data.getOrSet(countTag)  // default only used if not stored
+```
+
+### Updated Interface
+
+```typescript
+interface DataStore {
+  get<T>(tag: Tag<T, boolean>): T | undefined
+  set<T>(tag: Tag<T, boolean>, value: T): void
+  has<T, H extends boolean>(tag: Tag<T, H>): boolean
+  delete<T, H extends boolean>(tag: Tag<T, H>): boolean
+  clear(): void
+
+  getOrSet<T>(tag: Tag<T, true>): T
+  getOrSet<T>(tag: Tag<T, true>, value: T): T
+  getOrSet<T>(tag: Tag<T, false>, value: T): T
+}
+```
+
+### Mental Model
+
+| Method | Stores? | Uses Default? | Returns |
+|--------|---------|---------------|---------|
+| `get(tag)` | No | No | `T \| undefined` |
+| `set(tag, value)` | Yes | No | `void` |
+| `getOrSet(tag)` | If missing | Yes (if tag has default) | `T` |
+| `getOrSet(tag, value)` | If missing | No (uses provided value) | `T` |
+
+## Changes Across Layers {#adr-014-changes}
+
+### Types (types.ts)
+
+```typescript
+// BEFORE
+interface DataStore {
+  get<T, H extends boolean>(tag: Tag<T, H>): H extends true ? T : T | undefined
+  // ... rest unchanged
+}
+
+// AFTER
+interface DataStore {
+  get<T>(tag: Tag<T, boolean>): T | undefined
+  set<T>(tag: Tag<T, boolean>, value: T): void
+  has<T, H extends boolean>(tag: Tag<T, H>): boolean
+  delete<T, H extends boolean>(tag: Tag<T, H>): boolean
+  clear(): void
+  getOrSet<T>(tag: Tag<T, true>): T
+  getOrSet<T>(tag: Tag<T, true>, value: T): T
+  getOrSet<T>(tag: Tag<T, false>, value: T): T
+}
+```
+
+### Scope Implementation (scope.ts)
+
+```typescript
+class DataStoreImpl implements Lite.DataStore {
+  private readonly map = new Map<symbol, unknown>()
+
+  // CHANGED: No longer uses tag default
+  get<T>(tag: Lite.Tag<T, boolean>): T | undefined {
+    return this.map.get(tag.key) as T | undefined
+  }
+
+  // ... set, has, delete, clear unchanged ...
+
+  // getOrSet unchanged from ADR-012, just add third overload
+  getOrSet<T>(tag: Lite.Tag<T, true>): T
+  getOrSet<T>(tag: Lite.Tag<T, true>, value: T): T
+  getOrSet<T>(tag: Lite.Tag<T, false>, value: T): T
+  getOrSet<T>(tag: Lite.Tag<T, boolean>, value?: T): T {
+    if (this.map.has(tag.key)) {
+      return this.map.get(tag.key) as T
+    }
+    const storedValue = value !== undefined
+      ? value
+      : (tag.hasDefault ? tag.defaultValue as T : undefined as T)
+    this.map.set(tag.key, storedValue)
+    return storedValue
+  }
+}
+```
+
+### Component Docs (c3-202-atom.md)
+
+Update "Per-Atom Private Storage" section:
+
+**Before:**
+```typescript
+const countTag = tag<number>({ label: 'count', default: 0 })
+
+const counterAtom = atom({
+  factory: async (ctx) => {
+    const count = ctx.data.get(countTag)  // number - guaranteed by default!
+    ctx.data.set(countTag, count + 1)
+    return count
+  }
+})
+```
+
+**After:**
+```typescript
+const countTag = tag<number>({ label: 'count', default: 0 })
+
+const counterAtom = atom({
+  factory: async (ctx) => {
+    const count = ctx.data.getOrSet(countTag)  // 0 on first run, stored
+    ctx.data.set(countTag, count + 1)
+    return count
+  }
+})
+```
+
+### Test Updates
+
+```typescript
+describe('DataStore', () => {
+  describe('get()', () => {
+    it('returns undefined when not set, even with default tag', () => {
+      const countTag = tag<number>({ label: 'count', default: 0 })
+      const store = new DataStoreImpl()
+
+      expect(store.get(countTag)).toBe(undefined)
+      expect(store.has(countTag)).toBe(false)
+    })
+
+    it('returns stored value after set', () => {
+      const countTag = tag<number>({ label: 'count', default: 0 })
+      const store = new DataStoreImpl()
+
+      store.set(countTag, 5)
+      expect(store.get(countTag)).toBe(5)
+    })
+  })
+
+  describe('getOrSet()', () => {
+    it('uses tag default when no value provided', () => {
+      const countTag = tag<number>({ label: 'count', default: 0 })
+      const store = new DataStoreImpl()
+
+      expect(store.getOrSet(countTag)).toBe(0)
+      expect(store.has(countTag)).toBe(true)
+      expect(store.get(countTag)).toBe(0)
+    })
+
+    it('uses provided value over tag default', () => {
+      const countTag = tag<number>({ label: 'count', default: 0 })
+      const store = new DataStoreImpl()
+
+      expect(store.getOrSet(countTag, 5)).toBe(5)
+      expect(store.get(countTag)).toBe(5)
+    })
+
+    it('returns existing value without overwriting', () => {
+      const countTag = tag<number>({ label: 'count', default: 0 })
+      const store = new DataStoreImpl()
+
+      store.set(countTag, 10)
+      expect(store.getOrSet(countTag, 5)).toBe(10)  // Existing value preserved
+    })
+
+    it('requires value for tag without default', () => {
+      const userTag = tag<{ name: string }>({ label: 'user' })
+      const store = new DataStoreImpl()
+
+      expect(store.getOrSet(userTag, { name: 'Alice' })).toEqual({ name: 'Alice' })
+    })
+  })
+})
+```
+
+## Verification {#adr-014-verification}
+
+### Type System
+- [ ] `get()` always returns `T | undefined` regardless of tag default
+- [ ] `getOrSet(tagWithDefault)` compiles without second argument
+- [ ] `getOrSet(tagWithDefault, value)` compiles with optional override
+- [ ] `getOrSet(tagWithoutDefault)` is compile error (missing required value)
+- [ ] `getOrSet(tagWithoutDefault, value)` compiles
+
+### Runtime Behavior
+- [ ] `get()` returns undefined when not stored (even with default tag)
+- [ ] `get()` returns stored value when present
+- [ ] `getOrSet()` stores and returns tag default when missing
+- [ ] `getOrSet(tag, value)` stores provided value, not tag default
+- [ ] `getOrSet()` returns existing value without overwriting
+- [ ] `has()` returns true after `getOrSet()`
+
+### Migration
+- [ ] Breaking change: code relying on `get()` returning defaults will break
+- [ ] Migration: replace `get(tagWithDefault)` with `getOrSet(tagWithDefault)`
+
+## Migration Guide {#adr-014-migration}
+
+### Pattern: Relied on get() returning default
+
+**Before:**
+```typescript
+const countTag = tag<number>({ label: 'count', default: 0 })
+const count = ctx.data.get(countTag)  // Was: number
+```
+
+**After:**
+```typescript
+const countTag = tag<number>({ label: 'count', default: 0 })
+const count = ctx.data.getOrSet(countTag)  // Now: number, stored
+```
+
+## Related {#adr-014-related}
+
+- [ADR-010](./adr-010-typed-data-store.md) - Original DataStore design
+- [ADR-012](./adr-012-datastore-api-improvements.md) - Added getOrSet
+- [c3-202](../c3-2-lite/c3-202-atom.md) - Atom and ctx.data documentation

--- a/.changeset/controller-set-update.md
+++ b/.changeset/controller-set-update.md
@@ -1,0 +1,20 @@
+---
+"@pumped-fn/lite": minor
+---
+
+feat(lite): add Controller.set() and Controller.update() for direct value mutation
+
+Adds two new methods to Controller for pushing values directly without re-running the factory:
+
+- `controller.set(value)` - Replace value directly
+- `controller.update(fn)` - Transform value using a function
+
+Both methods:
+- Use the same invalidation queue as `invalidate()`
+- Run cleanups in LIFO order before applying new value
+- Transition through `resolving → resolved` states
+- Notify all subscribed listeners
+
+This enables patterns like WebSocket updates pushing values directly into atoms without triggering factory re-execution.
+
+BREAKING CHANGE: `DataStore.get()` now always returns `T | undefined` (Map-like semantics). Use `getOrSet()` to access default values from tags. This aligns DataStore behavior with standard Map semantics where `get()` is purely a lookup operation.

--- a/packages/lite/README.md
+++ b/packages/lite/README.md
@@ -167,7 +167,9 @@ Reactive handle for observing and controlling atom state.
 - `ctrl.state` — sync access: `'idle' | 'resolving' | 'resolved' | 'failed'`
 - `ctrl.get()` — sync value access (throws if not resolved, returns stale during resolving)
 - `ctrl.resolve()` — async resolution
-- `ctrl.invalidate()` — trigger re-resolution
+- `ctrl.invalidate()` — trigger re-resolution (runs factory)
+- `ctrl.set(value)` — replace value directly (skips factory)
+- `ctrl.update(fn)` — transform value: `fn(currentValue) → newValue` (skips factory)
 - `ctrl.on(event, listener)` — subscribe to `'resolved' | 'resolving' | '*'`
 - Use `controller(atom)` in deps for reactive dependency (unresolved, you control timing)
 
@@ -197,6 +199,31 @@ All types available under the `Lite` namespace:
 
 ```typescript
 import type { Lite } from '@pumped-fn/lite'
+```
+
+## Edge Cases
+
+### Controller.set() / update()
+
+| State | Behavior |
+|-------|----------|
+| `idle` | Throws "Atom not resolved" |
+| `resolving` | Queues, applies after resolution completes |
+| `resolved` | Queues normally |
+| `failed` | Throws the stored error |
+
+Both run cleanups before applying the new value.
+
+### DataStore.get()
+
+`ctx.data.get(tag)` always returns `T | undefined` (Map-like semantics). Use `getOrSet(tag)` when you need the tag's default value.
+
+```typescript
+const countTag = tag<number>({ label: 'count', default: 0 })
+
+ctx.data.get(countTag)       // undefined (not stored)
+ctx.data.getOrSet(countTag)  // 0 (uses default, now stored)
+ctx.data.get(countTag)       // 0 (now stored)
 ```
 
 ## License

--- a/plans/adr-013-014-implementation.md
+++ b/plans/adr-013-014-implementation.md
@@ -1,0 +1,501 @@
+# Implementation Plan: ADR-013 & ADR-014
+
+## Overview
+
+Implement two related changes:
+- **ADR-013**: Add `Controller.set()` and `Controller.update()` for direct value mutation
+- **ADR-014**: Change `DataStore.get()` to Map-like semantics (always returns `T | undefined`)
+
+## Prerequisites
+
+- Branch: `feature/controller-set-update`
+- Worktree: `.worktrees/controller-set-update`
+
+---
+
+## Task 1: Update Type Definitions
+
+**File**: `packages/lite/src/types.ts`
+
+### 1.1 Add Controller.set() and Controller.update()
+
+Find the `Controller` interface inside `namespace Lite` and add:
+
+```typescript
+export interface Controller<T> {
+  readonly [controllerSymbol]: true
+  readonly state: AtomState
+  get(): T
+  resolve(): Promise<T>
+  release(): Promise<void>
+  invalidate(): void
+  set(value: T): void           // ADD THIS
+  update(fn: (prev: T) => T): void  // ADD THIS
+  on(event: ControllerEvent, listener: () => void): () => void
+}
+```
+
+### 1.2 Change DataStore.get() signature
+
+Find the `DataStore` interface and change `get()`:
+
+**Before:**
+```typescript
+export interface DataStore {
+  get<T>(tag: Tag<T, boolean>): T | undefined
+  // ... actually check current signature, it may have conditional type
+}
+```
+
+**After:**
+```typescript
+export interface DataStore {
+  get<T>(tag: Tag<T, boolean>): T | undefined  // Always returns T | undefined
+  set<T>(tag: Tag<T, boolean>, value: T): void
+  has<T, H extends boolean>(tag: Tag<T, H>): boolean
+  delete<T, H extends boolean>(tag: Tag<T, H>): boolean
+  clear(): void
+  getOrSet<T>(tag: Tag<T, true>): T
+  getOrSet<T>(tag: Tag<T, true>, value: T): T  // ADD: new overload
+  getOrSet<T>(tag: Tag<T, false>, value: T): T
+}
+```
+
+---
+
+## Task 2: Implement DataStore.get() Change
+
+**File**: `packages/lite/src/scope.ts`
+
+### 2.1 Modify DataStoreImpl.get()
+
+Find `class DataStoreImpl` and change `get()` to pure lookup:
+
+```typescript
+get<T>(tag: Lite.Tag<T, boolean>): T | undefined {
+  return this.map.get(tag.key) as T | undefined
+}
+```
+
+Remove any default value logic - `get()` is now purely a Map lookup.
+
+---
+
+## Task 3: Implement Controller.set() and Controller.update()
+
+**File**: `packages/lite/src/scope.ts`
+
+### 3.1 Add pendingSet to AtomEntry
+
+Find the `AtomEntry` interface (or inline type) and add:
+
+```typescript
+interface AtomEntry<T> {
+  state: AtomState
+  value?: T
+  hasValue: boolean
+  error?: unknown
+  promise?: Promise<T>
+  cleanups: (() => MaybePromise<void>)[]
+  listeners: Map<string, Set<() => void>>
+  data?: DataStoreImpl
+  pendingInvalidate: boolean
+  pendingSet?: { value: T } | { fn: (prev: T) => T }  // ADD THIS
+}
+```
+
+### 3.2 Add ControllerImpl.set() and ControllerImpl.update()
+
+Find `class ControllerImpl` and add:
+
+```typescript
+set(value: T): void {
+  this.scope.scheduleSet(this.atom, value)
+}
+
+update(fn: (prev: T) => T): void {
+  this.scope.scheduleUpdate(this.atom, fn)
+}
+```
+
+### 3.3 Add ScopeImpl.scheduleSet()
+
+Add to `class ScopeImpl`:
+
+```typescript
+scheduleSet<T>(atom: Lite.Atom<T>, value: T): void {
+  const entry = this.cache.get(atom) as AtomEntry<T> | undefined
+
+  if (!entry || entry.state === 'idle') {
+    throw new Error('Atom not resolved')
+  }
+
+  if (entry.state === 'failed') {
+    throw entry.error
+  }
+
+  entry.pendingSet = { value }
+
+  if (entry.state === 'resolving') {
+    return
+  }
+
+  this.scheduleInvalidation(atom)
+}
+```
+
+### 3.4 Add ScopeImpl.scheduleUpdate()
+
+Add to `class ScopeImpl`:
+
+```typescript
+scheduleUpdate<T>(atom: Lite.Atom<T>, fn: (prev: T) => T): void {
+  const entry = this.cache.get(atom) as AtomEntry<T> | undefined
+
+  if (!entry || entry.state === 'idle') {
+    throw new Error('Atom not resolved')
+  }
+
+  if (entry.state === 'failed') {
+    throw entry.error
+  }
+
+  entry.pendingSet = { fn }
+
+  if (entry.state === 'resolving') {
+    return
+  }
+
+  this.scheduleInvalidation(atom)
+}
+```
+
+### 3.5 Modify doInvalidateSequential() to handle pendingSet
+
+Find `doInvalidateSequential()` and modify to check for `pendingSet` after running cleanups:
+
+```typescript
+private async doInvalidateSequential<T>(atom: Lite.Atom<T>): Promise<void> {
+  const entry = this.cache.get(atom) as AtomEntry<T>
+  if (!entry) return
+
+  const previousValue = entry.value
+
+  // Run cleanups LIFO
+  const cleanups = entry.cleanups.slice().reverse()
+  entry.cleanups = []
+  for (const cleanup of cleanups) {
+    await cleanup()
+  }
+
+  // Check for pendingSet - if present, skip factory
+  const pendingSet = entry.pendingSet
+  entry.pendingSet = undefined
+
+  if (pendingSet) {
+    entry.state = 'resolving'
+    this.emitStateChange('resolving', atom)
+    this.notifyListeners(atom, 'resolving')
+
+    if ('value' in pendingSet) {
+      entry.value = pendingSet.value
+    } else {
+      entry.value = pendingSet.fn(previousValue as T)
+    }
+
+    entry.state = 'resolved'
+    entry.hasValue = true
+    this.emitStateChange('resolved', atom)
+    this.notifyListeners(atom, 'resolved')
+    return
+  }
+
+  // Normal invalidation - run factory
+  // ... existing factory execution code ...
+}
+```
+
+### 3.6 Handle pendingSet after resolution completes
+
+In `doResolve()`, after successful resolution, check if `pendingSet` was added during resolution:
+
+```typescript
+// At end of successful resolution in doResolve():
+if (entry.pendingSet) {
+  this.scheduleInvalidation(atom)
+}
+```
+
+---
+
+## Task 4: Update Tests
+
+**File**: `packages/lite/tests/scope.test.ts`
+
+### 4.1 Fix existing tests that rely on get() returning defaults
+
+Search for `ctx.data.get(` patterns and update to use `getOrSet()` where default values are expected.
+
+Example fix:
+```typescript
+// Before
+const count = ctx.data.get(countTag)  // Was expecting default
+
+// After
+const count = ctx.data.getOrSet(countTag)  // Now explicitly gets default
+```
+
+### 4.2 Add Controller.set() tests
+
+```typescript
+describe('controller.set()', () => {
+  it('replaces value without running factory', async () => {
+    let factoryCount = 0
+    const myAtom = atom({
+      factory: () => {
+        factoryCount++
+        return { name: 'initial' }
+      }
+    })
+
+    const scope = createScope()
+    const ctrl = scope.controller(myAtom)
+    await ctrl.resolve()
+    expect(factoryCount).toBe(1)
+
+    ctrl.set({ name: 'updated' })
+    await scope.flush()
+
+    expect(ctrl.get()).toEqual({ name: 'updated' })
+    expect(factoryCount).toBe(1)  // Factory NOT called again
+  })
+
+  it('runs cleanups before setting', async () => {
+    const cleanups: string[] = []
+    const myAtom = atom({
+      factory: (ctx) => {
+        ctx.cleanup(() => { cleanups.push('cleanup') })
+        return 'value'
+      }
+    })
+
+    const scope = createScope()
+    const ctrl = scope.controller(myAtom)
+    await ctrl.resolve()
+
+    ctrl.set('new value')
+    await scope.flush()
+
+    expect(cleanups).toEqual(['cleanup'])
+  })
+
+  it('notifies listeners', async () => {
+    const myAtom = atom({ factory: () => 'initial' })
+    const scope = createScope()
+    const ctrl = scope.controller(myAtom)
+    await ctrl.resolve()
+
+    const events: string[] = []
+    ctrl.on('resolved', () => { events.push('resolved') })
+
+    ctrl.set('updated')
+    await scope.flush()
+
+    expect(events).toEqual(['resolved'])
+  })
+
+  it('throws when atom is idle', () => {
+    const myAtom = atom({ factory: () => 'value' })
+    const scope = createScope()
+    const ctrl = scope.controller(myAtom)
+
+    expect(() => ctrl.set('value')).toThrow('Atom not resolved')
+  })
+
+  it('queues when atom is resolving', async () => {
+    let resolveFactory: (v: string) => void
+    const myAtom = atom({
+      factory: () => new Promise<string>(r => { resolveFactory = r })
+    })
+
+    const scope = createScope()
+    const ctrl = scope.controller(myAtom)
+    const resolvePromise = ctrl.resolve()
+
+    await Promise.resolve()  // Let factory start
+    ctrl.set('pushed value')
+
+    resolveFactory!('factory value')
+    await resolvePromise
+    await scope.flush()
+
+    expect(ctrl.get()).toBe('pushed value')
+  })
+})
+```
+
+### 4.3 Add Controller.update() tests
+
+```typescript
+describe('controller.update()', () => {
+  it('transforms value using function', async () => {
+    const myAtom = atom({ factory: () => ({ count: 0 }) })
+    const scope = createScope()
+    const ctrl = scope.controller(myAtom)
+    await ctrl.resolve()
+
+    ctrl.update(prev => ({ count: prev.count + 1 }))
+    await scope.flush()
+
+    expect(ctrl.get()).toEqual({ count: 1 })
+  })
+
+  it('runs cleanups before updating', async () => {
+    const cleanups: string[] = []
+    const myAtom = atom({
+      factory: (ctx) => {
+        ctx.cleanup(() => { cleanups.push('cleanup') })
+        return { count: 0 }
+      }
+    })
+
+    const scope = createScope()
+    const ctrl = scope.controller(myAtom)
+    await ctrl.resolve()
+
+    ctrl.update(prev => ({ count: prev.count + 1 }))
+    await scope.flush()
+
+    expect(cleanups).toEqual(['cleanup'])
+  })
+})
+```
+
+---
+
+## Task 5: Update C3 Documentation
+
+### 5.1 Update c3-201-scope.md
+
+**File**: `.c3/c3-2-lite/c3-201-scope.md`
+
+Add `set()` and `update()` to Controller interface in Concepts section.
+
+Add new section "Direct Value Mutation" after "Invalidation" section:
+
+```markdown
+## Direct Value Mutation {#c3-201-set-update}
+
+### Controller.set() and Controller.update()
+
+Push values directly without re-running the factory:
+
+\`\`\`typescript
+const ctrl = scope.controller(userAtom)
+await ctrl.resolve()
+
+// Replace value directly
+ctrl.set({ name: 'Alice' })
+
+// Transform value
+ctrl.update(user => ({ ...user, lastSeen: Date.now() }))
+\`\`\`
+
+### Behavior
+
+Both methods follow the same flow as `invalidate()`:
+1. Queue via same invalidation mechanism
+2. Run cleanups (LIFO)
+3. State: `resolved → resolving → resolved`
+4. Replace value (from argument, not factory)
+5. Notify listeners
+
+### Comparison with invalidate()
+
+| | `invalidate()` | `set(value)` / `update(fn)` |
+|---|---|---|
+| Runs cleanups | Yes | Yes |
+| State transition | resolving → resolved | resolving → resolved |
+| Gets value from | Factory (async) | Argument (sync) |
+| Triggers listeners | Yes | Yes |
+| Uses queue | Yes | Yes |
+
+### Use Cases
+
+| Use Case | Method |
+|----------|--------|
+| External data source pushes value (WebSocket) | `set()` |
+| Transform based on current value | `update()` |
+| Re-fetch from source | `invalidate()` |
+
+### State Requirements
+
+| State | `set()` / `update()` Behavior |
+|-------|-------------------------------|
+| `idle` | Throws "Atom not resolved" |
+| `resolving` | Queues, executes after resolution |
+| `resolved` | Queues normally |
+| `failed` | Throws the stored error |
+```
+
+Add ADR-013 to Related section.
+
+### 5.2 Update c3-202-atom.md
+
+**File**: `.c3/c3-2-lite/c3-202-atom.md`
+
+Update DataStore interface to show new `get()` signature.
+
+Update "Pattern: With Default Value" to use `getOrSet()`.
+
+Add ADR-014 to Related section.
+
+---
+
+## Task 6: Verification
+
+```bash
+pnpm -F @pumped-fn/lite typecheck:full
+pnpm -F @pumped-fn/lite test
+```
+
+---
+
+## Task 7: Create Changeset
+
+**File**: `.changeset/controller-set-update.md`
+
+```markdown
+---
+"@pumped-fn/lite": minor
+---
+
+feat(lite): add Controller.set() and Controller.update() for direct value mutation
+
+Adds two new methods to Controller for pushing values directly without re-running the factory:
+
+- `controller.set(value)` - Replace value directly
+- `controller.update(fn)` - Transform value using a function
+
+Both methods:
+- Use the same invalidation queue as `invalidate()`
+- Run cleanups in LIFO order before applying new value
+- Transition through `resolving → resolved` states
+- Notify all subscribed listeners
+
+This enables patterns like WebSocket updates pushing values directly into atoms without triggering factory re-execution.
+
+BREAKING CHANGE: `DataStore.get()` now always returns `T | undefined` (Map-like semantics). Use `getOrSet()` to access default values from tags. This aligns DataStore behavior with standard Map semantics where `get()` is purely a lookup operation.
+```
+
+---
+
+## Execution Order
+
+1. Task 1 (types) - Foundation
+2. Task 2 (DataStore.get) - Simple change
+3. Task 3 (Controller.set/update) - Main implementation
+4. Task 4 (tests) - Verify behavior
+5. Task 5 (docs) - Update C3 docs
+6. Task 6 (verify) - Run typecheck and tests
+7. Task 7 (changeset) - Prepare for release


### PR DESCRIPTION
## Summary

- Add `Controller.set(value)` and `Controller.update(fn)` methods for pushing values directly without re-running the factory
- Change `DataStore.get()` to Map-like semantics (always returns `T | undefined`)
- Add TSDoc documentation to Controller and DataStore interfaces

## Breaking Change

`DataStore.get()` no longer returns tag defaults. Use `getOrSet()` when you need defaults:

```typescript
// Before
ctx.data.get(tagWithDefault)  // returned default

// After  
ctx.data.get(tagWithDefault)       // returns undefined
ctx.data.getOrSet(tagWithDefault)  // returns default (and stores it)
```

## Test Plan

- [x] All 149 tests pass
- [x] TypeScript compilation passes
- [x] No `any` usage in source
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)