### PR TITLE
fix(lite): improve ExecutionContext and ExecFlowOptions type inference

### DIFF
--- a/.changeset/fix-execution-context-types.md
+++ b/.changeset/fix-execution-context-types.md
@@ -1,0 +1,27 @@
+---
+"@pumped-fn/lite": patch
+---
+
+fix(lite): improve ExecutionContext and ExecFlowOptions type inference
+
+**Type System Improvements:**
+- Remove unnecessary `TInput` generic from `ExecutionContext` interface
+- Add proper output/input type inference to `ExecFlowOptions<Output, Input>`
+- Make `input` property optional for void/undefined/null input flows
+- Update `FlowFactory` to use intersection type for input typing
+- Simplify `Extension.wrapResolve` and `wrapExec` to use `unknown`
+- Flows without `parse` now return `Flow<Output, void>` for better DX
+
+**DX Improvements:**
+```typescript
+// No input needed for void flows - clean DX
+ctx.exec({ flow: voidFlow })
+
+// Input required and type-checked for typed flows
+ctx.exec({ flow: inputFlow, input: "hello" })
+```
+
+**Test Consolidation:**
+- Reduced test count from 149 to 130 (-13%)
+- Removed duplicate and superficial tests
+- Consolidated similar test patterns

--- a/packages/lite/src/flow.ts
+++ b/packages/lite/src/flow.ts
@@ -20,14 +20,14 @@ export function typed<T>(): Lite.Typed<T> {
 }
 
 export interface FlowConfig<
-  TOutput,
-  TInput,
+  Output,
+  Input,
   D extends Record<string, Lite.Dependency>,
 > {
   name?: string
-  parse?: ((raw: unknown) => MaybePromise<TInput>) | Lite.Typed<TInput>
+  parse?: ((raw: unknown) => MaybePromise<Input>) | Lite.Typed<Input>
   deps?: D
-  factory: Lite.FlowFactory<TOutput, TInput, D>
+  factory: Lite.FlowFactory<Output, Input, D>
   tags?: Lite.Tagged<unknown>[]
 }
 
@@ -53,13 +53,13 @@ export function flow<TOutput>(config: {
   deps?: undefined
   factory: (ctx: Lite.ExecutionContext) => MaybePromise<TOutput>
   tags?: Lite.Tagged<unknown>[]
-}): Lite.Flow<TOutput, unknown>
+}): Lite.Flow<TOutput, void>
 
 export function flow<TOutput, TInput>(config: {
   name?: string
   parse: (raw: unknown) => MaybePromise<TInput>
   deps?: undefined
-  factory: (ctx: Lite.ExecutionContext<NoInfer<TInput>>) => MaybePromise<TOutput>
+  factory: (ctx: Lite.ExecutionContext & { readonly input: NoInfer<TInput> }) => MaybePromise<TOutput>
   tags?: Lite.Tagged<unknown>[]
 }): Lite.Flow<TOutput, TInput>
 
@@ -67,7 +67,7 @@ export function flow<TOutput, TInput>(config: {
   name?: string
   parse: Lite.Typed<TInput>
   deps?: undefined
-  factory: (ctx: Lite.ExecutionContext<NoInfer<TInput>>) => MaybePromise<TOutput>
+  factory: (ctx: Lite.ExecutionContext & { readonly input: NoInfer<TInput> }) => MaybePromise<TOutput>
   tags?: Lite.Tagged<unknown>[]
 }): Lite.Flow<TOutput, TInput>
 
@@ -80,7 +80,7 @@ export function flow<
   deps: D
   factory: (ctx: Lite.ExecutionContext, deps: Lite.InferDeps<D>) => MaybePromise<TOutput>
   tags?: Lite.Tagged<unknown>[]
-}): Lite.Flow<TOutput, unknown>
+}): Lite.Flow<TOutput, void>
 
 export function flow<
   TOutput,
@@ -90,7 +90,7 @@ export function flow<
   name?: string
   parse: (raw: unknown) => MaybePromise<TInput>
   deps: D
-  factory: (ctx: Lite.ExecutionContext<NoInfer<TInput>>, deps: Lite.InferDeps<D>) => MaybePromise<TOutput>
+  factory: (ctx: Lite.ExecutionContext & { readonly input: NoInfer<TInput> }, deps: Lite.InferDeps<D>) => MaybePromise<TOutput>
   tags?: Lite.Tagged<unknown>[]
 }): Lite.Flow<TOutput, TInput>
 
@@ -102,7 +102,7 @@ export function flow<
   name?: string
   parse: Lite.Typed<TInput>
   deps: D
-  factory: (ctx: Lite.ExecutionContext<NoInfer<TInput>>, deps: Lite.InferDeps<D>) => MaybePromise<TOutput>
+  factory: (ctx: Lite.ExecutionContext & { readonly input: NoInfer<TInput> }, deps: Lite.InferDeps<D>) => MaybePromise<TOutput>
   tags?: Lite.Tagged<unknown>[]
 }): Lite.Flow<TOutput, TInput>
 

--- a/packages/lite/tests/atom.test.ts
+++ b/packages/lite/tests/atom.test.ts
@@ -2,36 +2,26 @@ import { describe, it, expect } from "vitest"
 import { atom, isAtom, controller, isControllerDep } from "../src/atom"
 
 describe("Atom", () => {
-  describe("atom()", () => {
-    it("creates an atom without deps", () => {
-      const myAtom = atom({
-        factory: () => 42,
-      })
-
-      expect(isAtom(myAtom)).toBe(true)
-      expect(myAtom.deps).toBeUndefined()
+  it("preserves config and identifies via type guards", () => {
+    const simpleAtom = atom({ factory: () => 42 })
+    const configAtom = atom({ factory: () => ({ port: 3000 }) })
+    const withDeps = atom({
+      deps: { cfg: configAtom },
+      factory: (ctx, { cfg }) => cfg.port,
     })
 
-    it("creates an atom with deps", () => {
-      const configAtom = atom({ factory: () => ({ port: 3000 }) })
-      const serverAtom = atom({
-        deps: { cfg: configAtom },
-        factory: (ctx, { cfg }) => ({ server: true, port: cfg.port }),
-      })
+    expect(isAtom(simpleAtom)).toBe(true)
+    expect(simpleAtom.deps).toBeUndefined()
 
-      expect(isAtom(serverAtom)).toBe(true)
-      expect(serverAtom.deps).toEqual({ cfg: configAtom })
-    })
-
+    expect(isAtom(withDeps)).toBe(true)
+    expect(withDeps.deps).toHaveProperty("cfg")
   })
 
-  describe("controller()", () => {
-    it("wraps an atom as controller dep", () => {
-      const myAtom = atom({ factory: () => 42 })
-      const ctrlDep = controller(myAtom)
+  it("controller() wraps atom as controller dep", () => {
+    const myAtom = atom({ factory: () => 42 })
+    const ctrlDep = controller(myAtom)
 
-      expect(isControllerDep(ctrlDep)).toBe(true)
-      expect(ctrlDep.atom).toBe(myAtom)
-    })
+    expect(isControllerDep(ctrlDep)).toBe(true)
+    expect(ctrlDep.atom).toBe(myAtom)
   })
 })

--- a/packages/lite/tests/errors.test.ts
+++ b/packages/lite/tests/errors.test.ts
@@ -2,34 +2,20 @@ import { describe, it, expect } from "vitest"
 import { ParseError } from "../src/errors"
 
 describe("ParseError", () => {
-  it("creates error with tag phase", () => {
-    const cause = new Error("Invalid UUID")
-    const error = new ParseError(
-      'Failed to parse tag "userId"',
-      "tag",
-      "userId",
-      cause
-    )
+  it("preserves all properties for different phases", () => {
+    const tagCause = new Error("Invalid UUID")
+    const tagError = new ParseError('Failed to parse tag "userId"', "tag", "userId", tagCause)
 
-    expect(error).toBeInstanceOf(Error)
-    expect(error).toBeInstanceOf(ParseError)
-    expect(error.name).toBe("ParseError")
-    expect(error.message).toBe('Failed to parse tag "userId"')
-    expect(error.phase).toBe("tag")
-    expect(error.label).toBe("userId")
-    expect(error.cause).toBe(cause)
-  })
+    expect(tagError).toBeInstanceOf(Error)
+    expect(tagError).toBeInstanceOf(ParseError)
+    expect(tagError.name).toBe("ParseError")
+    expect(tagError.message).toBe('Failed to parse tag "userId"')
+    expect(tagError.phase).toBe("tag")
+    expect(tagError.label).toBe("userId")
+    expect(tagError.cause).toBe(tagCause)
 
-  it("creates error with flow-input phase", () => {
-    const cause = new Error("Expected string")
-    const error = new ParseError(
-      'Failed to parse flow input "createUser"',
-      "flow-input",
-      "createUser",
-      cause
-    )
-
-    expect(error.phase).toBe("flow-input")
-    expect(error.label).toBe("createUser")
+    const flowError = new ParseError('Failed to parse "createUser"', "flow-input", "createUser", new Error())
+    expect(flowError.phase).toBe("flow-input")
+    expect(flowError.label).toBe("createUser")
   })
 })

--- a/packages/lite/tests/flow.test.ts
+++ b/packages/lite/tests/flow.test.ts
@@ -5,49 +5,23 @@ import { tag, tags } from "../src/tag";
 
 describe("Flow", () => {
   describe("flow()", () => {
-    it("creates a flow without deps", () => {
-      const myFlow = flow({
-        factory: (ctx) => ctx.input,
-      });
-
-      expect(isFlow(myFlow)).toBe(true);
-      expect(myFlow.deps).toBeUndefined();
-    });
-
-    it("creates a flow with deps", () => {
+    it("preserves all config properties", () => {
       const dbAtom = atom({ factory: () => ({ query: () => [] }) });
       const requestId = tag<string>({ label: "requestId" });
+      const parse = (raw: unknown): string => String(raw);
 
       const myFlow = flow({
+        name: "myFlow",
+        parse,
         deps: { db: dbAtom, reqId: tags.required(requestId) },
-        factory: (ctx, { db, reqId }) => {
-          return { db, reqId, input: ctx.input };
-        },
+        factory: (ctx, { db }) => db.query(),
       });
 
       expect(isFlow(myFlow)).toBe(true);
-      expect(myFlow.deps).toBeDefined();
-    });
-
-    it("creates a flow with name", () => {
-      const myFlow = flow({
-        name: "myFlow",
-        factory: (ctx) => ctx.input,
-      });
-
       expect(myFlow.name).toBe("myFlow");
-    });
-
-    it("creates a flow with parse function", () => {
-      const myFlow = flow({
-        parse: (raw: unknown): string => {
-          if (typeof raw !== "string") throw new Error("Must be string");
-          return raw;
-        },
-        factory: (ctx) => ctx.input.toUpperCase(),
-      });
-
-      expect(myFlow.parse).toBeDefined();
+      expect(myFlow.parse).toBe(parse);
+      expect(myFlow.deps).toHaveProperty("db");
+      expect(myFlow.deps).toHaveProperty("reqId");
     });
   });
 });

--- a/packages/lite/tests/preset.test.ts
+++ b/packages/lite/tests/preset.test.ts
@@ -3,21 +3,17 @@ import { atom } from "../src/atom"
 import { preset, isPreset } from "../src/preset"
 
 describe("Preset", () => {
-  it("creates preset with static value", () => {
-    const configAtom = atom({ factory: () => ({ port: 3000 }) })
-    const p = preset(configAtom, { port: 8080 })
-
-    expect(isPreset(p)).toBe(true)
-    expect(p.atom).toBe(configAtom)
-    expect(p.value).toEqual({ port: 8080 })
-  })
-
-  it("creates preset with another atom", () => {
+  it("creates preset with static value or atom reference", () => {
     const configAtom = atom({ factory: () => ({ port: 3000 }) })
     const testConfigAtom = atom({ factory: () => ({ port: 9999 }) })
-    const p = preset(configAtom, testConfigAtom)
 
-    expect(p.atom).toBe(configAtom)
-    expect(p.value).toBe(testConfigAtom)
+    const staticPreset = preset(configAtom, { port: 8080 })
+    expect(isPreset(staticPreset)).toBe(true)
+    expect(staticPreset.atom).toBe(configAtom)
+    expect(staticPreset.value).toEqual({ port: 8080 })
+
+    const atomPreset = preset(configAtom, testConfigAtom)
+    expect(atomPreset.atom).toBe(configAtom)
+    expect(atomPreset.value).toBe(testConfigAtom)
   })
 })

--- a/packages/lite/tests/types.test.ts
+++ b/packages/lite/tests/types.test.ts
@@ -152,7 +152,7 @@ describe("Type Inference", () => {
         },
       })
 
-      type QueryFlowType = typeof queryFlow extends Lite.Flow<infer T, unknown> ? T : never
+      type QueryFlowType = typeof queryFlow extends Lite.Flow<infer T, infer _> ? T : never
       expectTypeOf<QueryFlowType>().toEqualTypeOf<never[]>()
     })
 
@@ -181,7 +181,7 @@ describe("Type Inference", () => {
         },
       })
 
-      type MixedFlowType = typeof mixedFlow extends Lite.Flow<infer T, unknown> ? T : never
+      type MixedFlowType = typeof mixedFlow extends Lite.Flow<infer T, infer _> ? T : never
       expectTypeOf<MixedFlowType>().toEqualTypeOf<{ input: unknown }>()
     })
   })
@@ -239,7 +239,7 @@ describe("Type Inference", () => {
         await ctx.close()
       })
 
-      it("ctx.input is unknown without parse", async () => {
+      it("ctx.input is void without parse (no input required)", async () => {
         const myFlow = flow({
           factory: (ctx) => {
             return String(ctx.input)
@@ -249,12 +249,12 @@ describe("Type Inference", () => {
         type FlowInputType = typeof myFlow extends Lite.Flow<unknown, infer TInput>
           ? TInput
           : never
-        expectTypeOf<FlowInputType>().toEqualTypeOf<unknown>()
+        expectTypeOf<FlowInputType>().toEqualTypeOf<void>()
 
         const scope = createScope()
         const ctx = scope.createContext()
-        const result = await ctx.exec({ flow: myFlow, input: "test" })
-        expect(result).toBe("test")
+        const result = await ctx.exec({ flow: myFlow })
+        expect(result).toBe("undefined")
         await ctx.close()
       })
 


### PR DESCRIPTION
## Summary

- Fix ExecutionContext having unnecessary TInput generic parameter
- Fix ExecFlowOptions missing output type inference - results were typed as `unknown`
- Improve DX for void input flows (no need to pass `input` property)
- Consolidate and clean up test suite

## Type System Changes

| Type | Before | After |
|------|--------|-------|
| `ExecutionContext` | `ExecutionContext<TInput = unknown>` | `ExecutionContext` (no generic) |
| `ExecFlowOptions` | `ExecFlowOptions<T>` | `ExecFlowOptions<Output, Input>` with conditional input |
| `FlowFactory` | Uses `ExecutionContext<TInput>` | Uses `ExecutionContext & { readonly input: Input }` |
| `Extension.wrapResolve/wrapExec` | Generic `<T>` | Uses `unknown` |
| Flows without `parse` | `Flow<Output, unknown>` | `Flow<Output, void>` |

## DX Improvements

```typescript
// No input needed for void flows - clean DX
ctx.exec({ flow: voidFlow })

// Input required and type-checked for typed flows  
ctx.exec({ flow: inputFlow, input: "hello" })

// null also works for void flows
ctx.exec({ flow: voidFlow, input: null })
```

## Test Consolidation

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Total Tests | 149 | 130 | -19 (-13%) |

- Removed duplicate tests (e.g., controller.get() throws, LIFO cleanup)
- Consolidated superficial tests that just checked type guards
- Merged similar test patterns (tag retrieval methods, error phases)

## Test plan

- [x] `pnpm -F @pumped-fn/lite typecheck` passes
- [x] `pnpm -F @pumped-fn/lite typecheck:full` passes (includes tests)
- [x] `pnpm -F @pumped-fn/lite test` passes (130 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)