### PR TITLE
fix(lite): fix 7 verified triage findings

### DIFF
--- a/.changeset/fix-triage-findings.md
+++ b/.changeset/fix-triage-findings.md
@@ -1,0 +1,13 @@
+---
+"@pumped-fn/lite": patch
+---
+
+Fix 7 verified triage findings:
+
+- **HIGH**: `set()`/`update()` no longer kills watch listeners — pendingSet path skips cleanups since factory doesn't re-run
+- **MED**: `resolvingResources` moved from module-level global to per-scope instance — fixes false circular errors with concurrent scopes
+- **MED**: `notifyListeners`/`emitStateChange` snapshot Sets before iterating — unsub during notification no longer drops siblings
+- **MED**: `release()` now cleans `stateListeners` — no more orphan listener entries
+- **MED**: `dispose()` cancels in-flight invalidation chains — sets `disposed` flag and clears queue
+- **MED**: `service()` now calls `registerAtomToTags` — `tag.atoms()` returns service atoms
+- **LOW-MED**: Resource `seek` uses `seekHas()` to traverse parent chain — correctly finds grandparent `undefined` values

--- a/packages/lite/src/scope.ts
+++ b/packages/lite/src/scope.ts
@@ -18,7 +18,6 @@ function getResourceKey(resource: Lite.Resource<unknown>): symbol {
 }
 
 const inflightResources = new WeakMap<Lite.ContextData, Map<symbol, Promise<unknown>>>()
-const resolvingResources = new Set<symbol>()
 
 type ListenerEvent = 'resolving' | 'resolved' | '*'
 
@@ -55,6 +54,14 @@ class ContextDataImpl implements Lite.ContextData {
       return this.map.get(key)
     }
     return this.parentData?.seek(key)
+  }
+
+  seekHas(key: string | symbol): boolean {
+    if (this.map.has(key)) return true
+    if (this.parentData && this.parentData instanceof ContextDataImpl) {
+      return this.parentData.seekHas(key)
+    }
+    return false
   }
 
   // Tag-based operations
@@ -227,7 +234,9 @@ class ScopeImpl implements Lite.Scope {
   private invalidationChain: Set<Lite.Atom<unknown>> | null = null
   private chainPromise: Promise<void> | null = null
   private initialized = false
+  private disposed = false
   private controllers = new Map<Lite.Atom<unknown>, ControllerImpl<unknown>>()
+  private resolvingResources = new Set<symbol>()
   private gcOptions: Required<Lite.GCOptions>
   readonly extensions: Lite.Extension[]
   readonly tags: Lite.Tagged<any>[]
@@ -257,7 +266,7 @@ class ScopeImpl implements Lite.Scope {
 
   private async processInvalidationChain(): Promise<void> {
     try {
-      while (this.invalidationQueue.size > 0) {
+      while (this.invalidationQueue.size > 0 && !this.disposed) {
         const atom = this.invalidationQueue.values().next().value as Lite.Atom<unknown>
         this.invalidationQueue.delete(atom)
 
@@ -410,15 +419,15 @@ class ScopeImpl implements Lite.Scope {
     if (!entry) return
 
     const eventListeners = entry.listeners.get(event)
-    if (eventListeners) {
-      for (const listener of eventListeners) {
+    if (eventListeners?.size) {
+      for (const listener of Array.from(eventListeners)) {
         listener()
       }
     }
 
     const allListeners = entry.listeners.get('*')
-    if (allListeners) {
-      for (const listener of allListeners) {
+    if (allListeners?.size) {
+      for (const listener of Array.from(allListeners)) {
         listener()
       }
     }
@@ -429,8 +438,8 @@ class ScopeImpl implements Lite.Scope {
     if (!entry) return
 
     const allListeners = entry.listeners.get('*')
-    if (allListeners) {
-      for (const listener of allListeners) {
+    if (allListeners?.size) {
+      for (const listener of Array.from(allListeners)) {
         listener()
       }
     }
@@ -440,8 +449,8 @@ class ScopeImpl implements Lite.Scope {
     const stateMap = this.stateListeners.get(state)
     if (stateMap) {
       const listeners = stateMap.get(atom)
-      if (listeners) {
-        for (const listener of listeners) {
+      if (listeners?.size) {
+        for (const listener of Array.from(listeners)) {
           listener()
         }
       }
@@ -712,13 +721,13 @@ class ScopeImpl implements Lite.Scope {
           continue
         }
 
-        const existingSeek = ctx.data.seek(resourceKey)
-        if (existingSeek !== undefined || ctx.data.has(resourceKey)) {
-          result[key] = existingSeek
+        const ctxData = ctx.data as ContextDataImpl
+        if (ctxData.seekHas(resourceKey)) {
+          result[key] = ctxData.seek(resourceKey)
           continue
         }
 
-        if (resolvingResources.has(resourceKey)) {
+        if (this.resolvingResources.has(resourceKey)) {
           throw new Error(`Circular resource dependency detected: ${resource.name ?? "anonymous"}`)
         }
 
@@ -735,7 +744,7 @@ class ScopeImpl implements Lite.Scope {
         }
 
         const resolve = async () => {
-          resolvingResources.add(resourceKey)
+          this.resolvingResources.add(resourceKey)
           try {
             const resourceDeps = await this.resolveDeps(resource.deps, ctx)
 
@@ -760,7 +769,7 @@ class ScopeImpl implements Lite.Scope {
             storeCtx.data.set(resourceKey, value)
             return value
           } finally {
-            resolvingResources.delete(resourceKey)
+            this.resolvingResources.delete(resourceKey)
           }
         }
 
@@ -881,6 +890,28 @@ class ScopeImpl implements Lite.Scope {
     const pendingSet = entry.pendingSet
     entry.pendingSet = undefined
 
+    if (pendingSet) {
+      entry.state = "resolving"
+      entry.value = previousValue
+      entry.error = undefined
+      entry.pendingInvalidate = false
+      this.pending.delete(atom)
+      this.resolving.delete(atom)
+      this.emitStateChange("resolving", atom)
+      this.notifyListeners(atom, "resolving")
+
+      if ('value' in pendingSet) {
+        entry.value = pendingSet.value
+      } else {
+        entry.value = pendingSet.fn(previousValue as T)
+      }
+      entry.state = 'resolved'
+      entry.hasValue = true
+      this.emitStateChange('resolved', atom)
+      this.notifyListeners(atom, 'resolved')
+      return
+    }
+
     for (let i = entry.cleanups.length - 1; i >= 0; i--) {
       const cleanup = entry.cleanups[i]
       if (cleanup) await cleanup()
@@ -895,19 +926,6 @@ class ScopeImpl implements Lite.Scope {
     this.resolving.delete(atom)
     this.emitStateChange("resolving", atom)
     this.notifyListeners(atom, "resolving")
-
-    if (pendingSet) {
-      if ('value' in pendingSet) {
-        entry.value = pendingSet.value
-      } else {
-        entry.value = pendingSet.fn(previousValue as T)
-      }
-      entry.state = 'resolved'
-      entry.hasValue = true
-      this.emitStateChange('resolved', atom)
-      this.notifyListeners(atom, 'resolved')
-      return
-    }
 
     await this.resolve(atom)
   }
@@ -928,9 +946,19 @@ class ScopeImpl implements Lite.Scope {
 
     this.cache.delete(atom)
     this.controllers.delete(atom)
+
+    for (const [state, stateMap] of this.stateListeners) {
+      stateMap.delete(atom)
+      if (stateMap.size === 0) this.stateListeners.delete(state)
+    }
   }
 
   async dispose(): Promise<void> {
+    this.disposed = true
+    this.invalidationQueue.clear()
+    this.invalidationChain = null
+    this.chainPromise = null
+
     for (const ext of this.extensions) {
       if (ext.dispose) {
         await ext.dispose(this)

--- a/packages/lite/src/service.ts
+++ b/packages/lite/src/service.ts
@@ -1,4 +1,5 @@
 import { atomSymbol } from "./symbols"
+import { registerAtomToTags } from "./tag"
 import type { Lite, MaybePromise } from "./types"
 
 /** Creates an atom with methods constrained to (ctx: ExecutionContext, ...args) => result. */
@@ -22,10 +23,16 @@ export function service<T extends Lite.ServiceMethods, D extends Record<string, 
   factory: Lite.AtomFactory<T, D>
   tags?: Lite.Tagged<any>[]
 }): Lite.Atom<T> {
-  return {
+  const atomInstance: Lite.Atom<T> = {
     [atomSymbol]: true,
     factory: config.factory as unknown as Lite.AtomFactory<T, Record<string, Lite.Dependency>>,
     deps: config.deps as unknown as Record<string, Lite.Dependency> | undefined,
     tags: config.tags,
   }
+
+  if (config.tags?.length) {
+    registerAtomToTags(atomInstance, config.tags)
+  }
+
+  return atomInstance
 }

--- a/packages/lite/tests/scope.test.ts
+++ b/packages/lite/tests/scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest"
 import { createScope } from "../src/scope"
 import { atom, controller } from "../src/atom"
+import { service } from "../src/service"
 import { preset } from "../src/preset"
 import { tag, tags } from "../src/tag"
 import { flow, typed } from "../src/flow"
@@ -1203,7 +1204,7 @@ describe("ExecutionContext", () => {
       expect(notifications).toEqual(["resolved"])
     })
 
-    it("runs cleanups before setting", async () => {
+    it("does not run cleanups on set (factory does not re-run)", async () => {
       const scope = createScope()
       const cleanups: string[] = []
       const myAtom = atom({
@@ -1219,7 +1220,8 @@ describe("ExecutionContext", () => {
       ctrl.set({ name: "Alice" })
       await scope.flush()
 
-      expect(cleanups).toEqual(["cleanup"])
+      expect(cleanups).toEqual([])
+      expect(ctrl.get()).toEqual({ name: "Alice" })
     })
 
     it("throws when atom not resolved", () => {
@@ -2677,6 +2679,192 @@ describe("controller dep with watch: true", () => {
 
     expect(factoryCount).toBe(3)
 
+    await scope.dispose()
+  })
+})
+
+describe("Triage regression tests", () => {
+  it("Fix 1: watch survives set() and subsequent changes", async () => {
+    let derivedCount = 0
+
+    const sourceAtom = atom({ factory: () => "initial" })
+    const derivedAtom = atom({
+      deps: { src: controller(sourceAtom, { resolve: true, watch: true }) },
+      factory: (_ctx: any, { src }: any) => {
+        derivedCount++
+        return `derived:${src.get()}`
+      },
+    })
+
+    const scope = createScope()
+    await scope.resolve(derivedAtom)
+    expect(derivedCount).toBe(1)
+
+    scope.controller(sourceAtom).set("after-set-1")
+    await scope.flush()
+    expect(derivedCount).toBe(2)
+    expect(scope.controller(derivedAtom).get()).toBe("derived:after-set-1")
+
+    scope.controller(sourceAtom).set("after-set-2")
+    await scope.flush()
+    expect(derivedCount).toBe(3)
+    expect(scope.controller(derivedAtom).get()).toBe("derived:after-set-2")
+
+    scope.controller(sourceAtom).set("after-set-3")
+    await scope.flush()
+    expect(derivedCount).toBe(4)
+    expect(scope.controller(derivedAtom).get()).toBe("derived:after-set-3")
+
+    await scope.dispose()
+  })
+
+  it("Fix 2: two scopes resolving same resource concurrently — no false circular", async () => {
+    let callCount = 0
+    const sharedResource = resource({
+      factory: async () => {
+        callCount++
+        await new Promise(r => setTimeout(r, 10))
+        return "shared-value"
+      },
+    })
+
+    const myFlow = flow({
+      deps: { res: sharedResource },
+      factory: (_ctx: any, { res }: any) => res,
+    })
+
+    const scope1 = createScope()
+    const scope2 = createScope()
+    const ctx1 = scope1.createContext()
+    const ctx2 = scope2.createContext()
+
+    const [r1, r2] = await Promise.all([
+      ctx1.exec({ flow: myFlow }),
+      ctx2.exec({ flow: myFlow }),
+    ])
+
+    expect(r1).toBe("shared-value")
+    expect(r2).toBe("shared-value")
+    expect(callCount).toBe(2)
+
+    await ctx1.close()
+    await ctx2.close()
+    await scope1.dispose()
+    await scope2.dispose()
+  })
+
+  it("Fix 3: listener that unsubscribes during notification — sibling fires", async () => {
+    const scope = createScope()
+    const myAtom = atom({ factory: () => 1 })
+    await scope.resolve(myAtom)
+
+    const ctrl = scope.controller(myAtom)
+    const events: string[] = []
+
+    let unsub1: (() => void) | undefined
+    unsub1 = ctrl.on("resolved", () => {
+      events.push("first")
+      unsub1!()
+    })
+
+    ctrl.on("resolved", () => {
+      events.push("second")
+    })
+
+    ctrl.set(2)
+    await scope.flush()
+
+    expect(events).toContain("first")
+    expect(events).toContain("second")
+
+    await scope.dispose()
+  })
+
+  it("Fix 4: release cleans stateListeners", async () => {
+    const scope = createScope()
+    const myAtom = atom({ factory: () => 42 })
+    await scope.resolve(myAtom)
+
+    const events: string[] = []
+    const unsub = scope.on("resolved", myAtom, () => events.push("resolved"))
+
+    ctrl_set_and_flush: {
+      scope.controller(myAtom).set(99)
+      await scope.flush()
+      expect(events).toEqual(["resolved"])
+    }
+
+    await scope.release(myAtom)
+
+    await scope.resolve(myAtom)
+    expect(events).toEqual(["resolved"])
+
+    unsub()
+    await scope.dispose()
+  })
+
+  it("Fix 5: dispose during active invalidation chain — no errors", async () => {
+    let factoryCount = 0
+
+    const slowAtom = atom({
+      factory: async () => {
+        factoryCount++
+        await new Promise(r => setTimeout(r, 50))
+        return factoryCount
+      },
+    })
+
+    const scope = createScope()
+    await scope.resolve(slowAtom)
+    expect(factoryCount).toBe(1)
+
+    scope.controller(slowAtom).invalidate()
+
+    await scope.dispose()
+
+    expect(factoryCount).toBeLessThanOrEqual(2)
+  })
+
+  it("Fix 6: service with tags — tag.atoms() returns the service atom", () => {
+    const myTag = tag<string>({ label: "svc-tag" })
+    const svcAtom = service({
+      tags: [myTag("svc-value")],
+      factory: () => ({
+        greet: async (_ctx: Lite.ExecutionContext, name: string) => `hello ${name}`,
+      }),
+    })
+
+    const atoms = myTag.atoms()
+    expect(atoms).toContain(svcAtom)
+  })
+
+  it("Fix 7: resource returning undefined — grandparent seek finds it", async () => {
+    const undefinedResource = resource({
+      name: "undef-resource",
+      factory: () => undefined,
+    })
+
+    const innerFlow = flow({
+      deps: { val: undefinedResource },
+      factory: (_ctx: any, { val }: any) => ({ found: true, value: val }),
+    })
+
+    const outerFlow = flow({
+      deps: { val: undefinedResource },
+      factory: async (ctx) => {
+        const inner = await ctx.exec({ flow: innerFlow })
+        return inner
+      },
+    })
+
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const result = await ctx.exec({ flow: outerFlow }) as any
+
+    expect(result.found).toBe(true)
+    expect(result.value).toBeUndefined()
+
+    await ctx.close()
     await scope.dispose()
   })
 })


### PR DESCRIPTION
## Summary

Fixes 7 verified findings from adversarial triage (4-run, max-tension, depth=3):

- **HIGH** — `set()`/`update()` killed watch listeners: pendingSet path now skips cleanups since factory doesn't re-run
- **MED** — `resolvingResources` was module-level global: moved to per-scope instance field (fixes false circular errors with concurrent scopes)
- **MED** — `notifyListeners` iterated live Set: snapshots via `Array.from()` before iterating (unsub during notification no longer drops siblings)
- **MED** — `release()` left orphan `stateListeners` entries: now cleans up on release
- **MED** — `dispose()` didn't cancel in-flight invalidation chains: adds `disposed` flag, clears queue/chain
- **MED** — `service()` with tags never called `registerAtomToTags`: `tag.atoms()` now returns service atoms
- **LOW-MED** — Resource `seek` couldn't distinguish "not found" from "found undefined" in grandparents: added `seekHas()` traversal

## Test plan

- [x] 7 new regression tests added (279 total, all pass)
- [x] 1 existing test updated to match corrected behavior (`set()` no longer runs cleanups)
- [x] Full monorepo `pnpm build && pnpm test && pnpm typecheck` passes
- [x] Changeset included (`@pumped-fn/lite` patch → 2.1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)