### PR TITLE
feat(lite-golden-react): scaffold + env-split structural proof + F01 exemplar

### DIFF
--- a/.changeset/lite-golden-react-foundation.md
+++ b/.changeset/lite-golden-react-foundation.md
@@ -1,0 +1,4 @@
+---
+---
+
+examples: scaffold @pumped-fn/lite-golden-react with the env-split structural proof and first pattern (private example package, no release impact)

--- a/examples/lite-golden-react/README.md
+++ b/examples/lite-golden-react/README.md
@@ -1,0 +1,41 @@
+# @pumped-fn/lite-golden-react
+
+Golden frontend examples for `@pumped-fn/lite` + `@pumped-fn/lite-react`. Same thesis as
+[`lite-golden`](../lite-golden), applied to React: **components observe the atom graph; they never own
+or construct state.** The seam is unchanged — given `createScope({ presets, tags, extensions })` and the
+public API, all logic is testable. React is an adapter layer at the edge.
+
+## The structural proof
+
+Tests run in the **node** environment by default — no DOM, no React renderer. A test of feature logic
+therefore *cannot* reach the browser; it must go through the graph. Only files named `*.dom.test.tsx`
+opt into jsdom (via a `// @vitest-environment jsdom` docblock) to render and observe components.
+`tests/environment-split.test.ts` enforces this: a logic test cannot smuggle the jsdom directive to
+touch the DOM.
+
+Each pattern splits into the **graph** (`after.ts` — atoms, flows, adapters: the logic) and the
+**observer** (`view.tsx` — a thin component). Logic is node-tested to 100%; the component is
+jsdom-tested to 100%. Coverage is gated at 100/100/100/100 across both — provable because the component
+holds no logic to leave uncovered.
+
+No `vi.mock` / `msw` / `fetch-mock`: browser APIs enter through adapter atoms and tests `preset` them —
+the frontend form of "no module mocks". An adapter's own unit test is the one sanctioned place to fake
+the global it wraps (below the seam).
+
+## Run
+
+```
+pnpm -F @pumped-fn/lite-golden-react test       # vitest run --coverage (the gate)
+pnpm -F @pumped-fn/lite-golden-react typecheck
+```
+
+## Index
+
+| # | Smell | Transformation | Lenses |
+|---|---|---|---|
+| F01 | State / derived soup in a component | atoms + derived atom; component observes | IO, OI |
+
+(More patterns and the Service Health Dashboard capstone land incrementally.)
+
+See [`lite-golden/PATTERNS` pointer](../../packages/lite/PATTERNS.md) and the backend
+[`lite-golden`](../lite-golden) for the shared doctrine.

--- a/examples/lite-golden-react/package.json
+++ b/examples/lite-golden-react/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@pumped-fn/lite-golden-react",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-react": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "jsdom": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/lite-golden-react/patterns/F01-state-derived-soup/README.md
+++ b/examples/lite-golden-react/patterns/F01-state-derived-soup/README.md
@@ -1,0 +1,39 @@
+# F01 — State / derived soup → graph + observer
+
+## The smell
+
+A component owns its UI state with `useState`, derives values inline during render, and the derivation
+logic is trapped inside the component. `before.tsx` filters and sorts a product list in the render body,
+keyed off two `useState` cells.
+
+## Harm
+
+The filter/sort logic — the part with actual rules — is only reachable by rendering the component. It
+cannot be unit-tested, cannot be reused, and re-runs in full on every keystroke. As the component grows,
+more state cells and more inline derivations tangle together with no seam to test them through.
+
+## Transformation
+
+State and derivation move into the graph: `query` and `sortBy` are atoms; `products` is the source atom
+(preset in tests); `visibleProducts` is a derived atom that watches `query` and `sortBy` and recomputes
+only when they change. The component (`view.tsx`) becomes a pure observer — it reads `visibleProducts`
+via `useAtom` and writes `query`/`sortBy` via `useController`. It owns no logic.
+
+## Lens coverage
+
+- **inside-out** (`after.test.ts`, node env — no DOM): the filter and sort rules are tested directly
+  against the graph through the scope seam. Preset `products`, drive `query`/`sortBy` controllers, assert
+  `visibleProducts`. The entire logic of the feature is verified without React.
+- **outside-in** (`view.dom.test.tsx`, jsdom): the component is rendered under `ScopeProvider` with the
+  source preset at the edge; interactions go through `fireEvent`, and the projection is asserted from the
+  DOM. This covers wiring (which atom each control reads/writes), not logic.
+- **effect-managed**: folded into the inside-out cascade tests — re-derivation on `query`/`sortBy` change
+  is the only effect, drained with `scope.flush()`; there is no owned resource to tear down.
+
+## Why 100%
+
+`after.ts` branches are the `name`/`price` sort ternary (both covered: IO1 name, IO3 price) and the
+filter predicate (matching and empty results: IO1/IO2/IO4). The `products` default factory is real
+initial state, covered by IO5 resolving it without a preset. `view.tsx` is pure projection — every line
+(the two `onChange` handlers, the fallbacks, the row map) is exercised by the three observer tests. No
+branch exists that a public-API test cannot reach, because no logic lives in the component.

--- a/examples/lite-golden-react/patterns/F01-state-derived-soup/after.test.ts
+++ b/examples/lite-golden-react/patterns/F01-state-derived-soup/after.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from "vitest"
+import { createScope, preset } from "@pumped-fn/lite"
+import { products, query, sortBy, visibleProducts, type Product } from "./after"
+
+const sample: Product[] = [
+  { id: "a", name: "Banana", price: 3 },
+  { id: "b", name: "apple", price: 5 },
+  { id: "c", name: "Cherry", price: 1 },
+]
+
+describe("inside-out", () => {
+  test("IO1: default query empty, sorted by name (case-insensitive)", async () => {
+    const scope = createScope({ presets: [preset(products, sample)] })
+    const visible = await scope.resolve(visibleProducts)
+    expect(visible.map((p) => p.id)).toEqual(["b", "a", "c"])
+    await scope.dispose()
+  })
+
+  test("IO2: setting query re-derives the filtered slice", async () => {
+    const scope = createScope({ presets: [preset(products, sample)] })
+    await scope.resolve(visibleProducts)
+    const control = scope.controller(query)
+    await control.resolve()
+    control.set("an")
+    await scope.flush()
+    const visible = await scope.resolve(visibleProducts)
+    expect(visible.map((p) => p.id)).toEqual(["a"])
+    await scope.dispose()
+  })
+
+  test("IO3: setting sortBy to price re-derives the ordering", async () => {
+    const scope = createScope({ presets: [preset(products, sample)] })
+    await scope.resolve(visibleProducts)
+    const control = scope.controller(sortBy)
+    await control.resolve()
+    control.set("price")
+    await scope.flush()
+    const visible = await scope.resolve(visibleProducts)
+    expect(visible.map((p) => p.id)).toEqual(["c", "a", "b"])
+    await scope.dispose()
+  })
+
+  test("IO4: a query with no match derives an empty slice", async () => {
+    const scope = createScope({ presets: [preset(products, sample)] })
+    const control = scope.controller(query)
+    await control.resolve()
+    control.set("zzz")
+    await scope.flush()
+    const visible = await scope.resolve(visibleProducts)
+    expect(visible).toEqual([])
+    await scope.dispose()
+  })
+
+  test("IO5: the source defaults to empty before any data is loaded", async () => {
+    const scope = createScope()
+    expect(await scope.resolve(products)).toEqual([])
+    expect(await scope.resolve(visibleProducts)).toEqual([])
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/patterns/F01-state-derived-soup/after.ts
+++ b/examples/lite-golden-react/patterns/F01-state-derived-soup/after.ts
@@ -1,0 +1,28 @@
+import { atom, controller } from "@pumped-fn/lite"
+
+export interface Product {
+  id: string
+  name: string
+  price: number
+}
+
+export const products = atom({ factory: (): Product[] => [] })
+
+export const query = atom({ factory: () => "" })
+
+export const sortBy = atom({ factory: (): "name" | "price" => "name" })
+
+export const visibleProducts = atom({
+  deps: {
+    products,
+    query: controller(query, { resolve: true, watch: true }),
+    sortBy: controller(sortBy, { resolve: true, watch: true }),
+  },
+  factory: (_ctx, { products, query, sortBy }) => {
+    const q = query.get().toLowerCase()
+    const order = sortBy.get()
+    return products
+      .filter((p) => p.name.toLowerCase().includes(q))
+      .sort((a, b) => (order === "name" ? a.name.localeCompare(b.name) : a.price - b.price))
+  },
+})

--- a/examples/lite-golden-react/patterns/F01-state-derived-soup/before.tsx
+++ b/examples/lite-golden-react/patterns/F01-state-derived-soup/before.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react"
+
+export interface Product {
+  id: string
+  name: string
+  price: number
+}
+
+export function ProductList({ products }: { products: Product[] }) {
+  const [query, setQuery] = useState("")
+  const [sortBy, setSortBy] = useState<"name" | "price">("name")
+
+  const visible = products
+    .filter((p) => p.name.toLowerCase().includes(query.toLowerCase()))
+    .sort((a, b) => (sortBy === "name" ? a.name.localeCompare(b.name) : a.price - b.price))
+
+  return (
+    <div>
+      <input aria-label="filter" value={query} onChange={(e) => setQuery(e.target.value)} />
+      <select aria-label="sort" value={sortBy} onChange={(e) => setSortBy(e.target.value as "name" | "price")}>
+        <option value="name">name</option>
+        <option value="price">price</option>
+      </select>
+      <ul>
+        {visible.map((p) => (
+          <li key={p.id}>
+            {p.name} — {p.price}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/examples/lite-golden-react/patterns/F01-state-derived-soup/view.dom.test.tsx
+++ b/examples/lite-golden-react/patterns/F01-state-derived-soup/view.dom.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from "vitest"
+import { fireEvent, render, screen, within } from "@testing-library/react"
+import { createScope, preset } from "@pumped-fn/lite"
+import { ScopeProvider } from "@pumped-fn/lite-react"
+import { ProductList } from "./view"
+import { products, type Product } from "./after"
+
+const sample: Product[] = [
+  { id: "a", name: "Banana", price: 3 },
+  { id: "b", name: "apple", price: 5 },
+  { id: "c", name: "Cherry", price: 1 },
+]
+
+function renderList() {
+  const scope = createScope({ presets: [preset(products, sample)] })
+  render(
+    <ScopeProvider scope={scope}>
+      <ProductList />
+    </ScopeProvider>
+  )
+  return scope
+}
+
+async function rowNames(): Promise<string[]> {
+  const list = await screen.findByRole("list")
+  return within(list)
+    .getAllByRole("listitem")
+    .map((li) => li.textContent?.split(" — ")[0] ?? "")
+}
+
+describe("outside-in", () => {
+  test("OI1: the list observes the graph — initial order is by name", async () => {
+    const scope = renderList()
+    expect(await rowNames()).toEqual(["apple", "Banana", "Cherry"])
+    await scope.dispose()
+  })
+
+  test("OI2: typing in the filter narrows the rows", async () => {
+    const scope = renderList()
+    await rowNames()
+    fireEvent.change(screen.getByLabelText("filter"), { target: { value: "an" } })
+    expect(await rowNames()).toEqual(["Banana"])
+    await scope.dispose()
+  })
+
+  test("OI3: changing the sort reorders the rows", async () => {
+    const scope = renderList()
+    await rowNames()
+    fireEvent.change(screen.getByLabelText("sort"), { target: { value: "price" } })
+    expect(await rowNames()).toEqual(["Cherry", "Banana", "apple"])
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/patterns/F01-state-derived-soup/view.tsx
+++ b/examples/lite-golden-react/patterns/F01-state-derived-soup/view.tsx
@@ -1,0 +1,31 @@
+import { useAtom, useController } from "@pumped-fn/lite-react"
+import { query, sortBy, visibleProducts } from "./after"
+
+export function ProductList() {
+  const { data: visible } = useAtom(visibleProducts, { suspense: false, resolve: true })
+  const { data: q } = useAtom(query, { suspense: false, resolve: true })
+  const { data: order } = useAtom(sortBy, { suspense: false, resolve: true })
+  const queryControl = useController(query)
+  const sortControl = useController(sortBy)
+
+  return (
+    <div>
+      <input aria-label="filter" value={q ?? ""} onChange={(e) => queryControl.set(e.target.value)} />
+      <select
+        aria-label="sort"
+        value={order ?? "name"}
+        onChange={(e) => sortControl.set(e.target.value as "name" | "price")}
+      >
+        <option value="name">name</option>
+        <option value="price">price</option>
+      </select>
+      <ul>
+        {(visible ?? []).map((p) => (
+          <li key={p.id}>
+            {p.name} — {p.price}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/examples/lite-golden-react/tests/environment-split.test.ts
+++ b/examples/lite-golden-react/tests/environment-split.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "vitest"
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { join } from "node:path"
+
+const root = process.cwd()
+
+function testFiles(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === "node_modules" || entry === "coverage" || entry.startsWith(".")) continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      out.push(...testFiles(full))
+    } else if (entry.includes(".test.")) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function declaresJsdom(source: string): boolean {
+  const head = source.slice(0, source.search(/^import /m) >>> 0)
+  return /@vitest-environment\s+jsdom/.test(head)
+}
+
+describe("inside-out", () => {
+  test("only *.dom.test.tsx may opt into jsdom — logic tests stay in node, can never touch the DOM", () => {
+    for (const file of testFiles(root)) {
+      if (file.endsWith("environment-split.test.ts")) continue
+      const isDom = file.endsWith(".dom.test.tsx")
+      const optsIn = declaresJsdom(readFileSync(file, "utf8"))
+      if (isDom) {
+        expect(optsIn, `${file} must declare the jsdom environment`).toBe(true)
+      } else {
+        expect(optsIn, `${file} is a logic test and must not opt into jsdom`).toBe(false)
+      }
+    }
+  })
+})

--- a/examples/lite-golden-react/tests/environment.dom.test.tsx
+++ b/examples/lite-golden-react/tests/environment.dom.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { atom, createScope } from "@pumped-fn/lite"
+import { ScopeProvider, useAtom } from "@pumped-fn/lite-react"
+
+describe("outside-in", () => {
+  test("dom tests run in jsdom — a component observes the graph through ScopeProvider", async () => {
+    expect(typeof document).toBe("object")
+
+    const greeting = atom({ factory: () => "hello from the graph" })
+    const scope = createScope()
+
+    function Greeting() {
+      const { data } = useAtom(greeting, { suspense: false, resolve: true })
+      return <span>{data ?? "..."}</span>
+    }
+
+    render(
+      <ScopeProvider scope={scope}>
+        <Greeting />
+      </ScopeProvider>
+    )
+
+    expect(await screen.findByText("hello from the graph")).toBeInTheDocument()
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/tests/environment.test.ts
+++ b/examples/lite-golden-react/tests/environment.test.ts
@@ -1,0 +1,14 @@
+import { describe, test, expect } from "vitest"
+import { atom, createScope } from "@pumped-fn/lite"
+
+describe("inside-out", () => {
+  test("logic tests run in node — no DOM, graph still fully exercisable through the seam", async () => {
+    expect(typeof document).toBe("undefined")
+    expect(typeof window).toBe("undefined")
+
+    const greeting = atom({ factory: () => "hello from the graph" })
+    const scope = createScope()
+    expect(await scope.resolve(greeting)).toBe("hello from the graph")
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/tests/setup.dom.ts
+++ b/examples/lite-golden-react/tests/setup.dom.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest"

--- a/examples/lite-golden-react/tsconfig.json
+++ b/examples/lite-golden-react/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "patterns/**/*", "capstone/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/lite-golden-react/vitest.config.ts
+++ b/examples/lite-golden-react/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    setupFiles: ["./tests/setup.dom.ts"],
+    coverage: {
+      provider: "v8",
+      include: ["patterns/**/after.ts", "patterns/**/view.tsx", "capstone/src/**/*.ts", "capstone/src/**/*.tsx"],
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,52 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
 
+  examples/lite-golden-react:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../packages/lite
+      '@pumped-fn/lite-react':
+        specifier: workspace:*
+        version: link:../../packages/lite-react
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.7(vitest@4.1.7)
+      jsdom:
+        specifier: 'catalog:'
+        version: 29.1.1
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+
   examples/reactivity-bench:
     dependencies:
       prettier:


### PR DESCRIPTION
## What

Foundation for the **frontend** golden examples — same doctrine as [`lite-golden`](../lite-golden) applied to `@pumped-fn/lite-react`: components observe the atom graph, the scope is the single seam, and most logic is testable without the browser.

**The structural proof (the novel, load-bearing part):**
- Tests run in **node** by default — no DOM, no renderer. Only `*.dom.test.tsx` files opt into jsdom via a `// @vitest-environment jsdom` docblock. A feature-logic test therefore *cannot* reach the browser; it must go through the graph.
- `test.projects` was tried and **rejected** — v8 coverage does not merge across projects, so a `.tsx` covered by a "dom" project reported 0% and the whole "100% including components" thesis collapsed. Single project + docblock merges coverage correctly. Verified: a logic-only run shows `view.tsx` at 0% (lines 5–24); the full run reaches 100% — the component is genuinely gated, not silently absent.
- The split is **enforced**, not conventional: `environment-split.test.ts` fails the suite if a logic test smuggles the jsdom directive; `environment.test.ts` asserts node tests see `typeof document === "undefined"`.
- File split: graph logic in `after.ts` (node-tested), observer in `view.tsx` (jsdom-tested), gated 100/100/100/100 across both.

**F01** (`state/derived soup → derived atom + observer`) is the reference shape the remaining patterns mirror: the filter/sort logic is node-tested through the seam, the component is a pure projection jsdom-tested via `fireEvent`.

## Verification

- `pnpm -F @pumped-fn/lite-golden-react test` — 5 files, 11 tests, 100/100/100/100, deterministic across runs
- `typecheck` clean; lite-react's 59 tests unaffected
- Private example package — no release impact

Remaining F02–F12 patterns + the Service Health Dashboard capstone land incrementally on this foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)