### PR TITLE
feat(lite-golden-bff): BFF tier — view-model shaping over a capstoneClient adapter

### DIFF
--- a/.changeset/lite-golden-bff.md
+++ b/.changeset/lite-golden-bff.md
@@ -1,0 +1,4 @@
+---
+---
+
+examples: add @pumped-fn/lite-golden-bff (BFF tier — view-model shaping over a capstoneClient adapter; private example, no release impact)

--- a/examples/lite-golden-bff/README.md
+++ b/examples/lite-golden-bff/README.md
@@ -1,0 +1,36 @@
+# @pumped-fn/lite-golden-bff
+
+A Backend-For-Frontend tier for the [`lite-golden`](../lite-golden) Service Health Monitor. It talks to
+the backend capstone and reshapes its data into frontend-friendly view-models, so the frontend does
+**interaction, not calculation**.
+
+This is one anchor on the logic-boundary spectrum (see the
+[plan §13](../../tasks/golden-examples-plan.md) if present, or the comparison below): the BFF always owns
+data shaping; the React frontends consume these view-models and observe them.
+
+## The seam
+
+The BFF reaches the backend through a single adapter — the `capstoneClient` port, an atom that wraps
+`fetch`. View-model flows (`dashboardView`, `serviceDetailView`) declare it as a dependency and never
+touch the network themselves. Tests `preset(capstoneClient, fake)` to drive the shaping logic through the
+scope seam — no `msw`, no `fetch-mock`. The one place `fetch` is faked is the adapter's **own** unit test
+(`tests/client.test.ts`), which is below the seam: it verifies the adapter builds the right paths and
+surfaces non-ok responses. Everything above it is tested against the port.
+
+Because all logic lives in flows behind the seam, the package is node-tested (no browser) at 100/100/100/100.
+
+## Shape
+
+- `src/wire.ts` — wire types mirroring the backend Data Model (the BFF re-declares them; packages stay
+  independent).
+- `src/client.ts` — `CapstoneClient` port + the `capstoneClient` fetch adapter + `capstoneBaseUrl` tag.
+- `src/dashboard.ts` — `dashboardView`: counts services by status, counts active incidents, and produces
+  a criticality-sorted attention list. The calculation the frontend is spared.
+- `src/detail.ts` — `serviceDetailView`: formats uptime, maps recent checks, counts open incidents.
+
+## Run
+
+```
+pnpm -F @pumped-fn/lite-golden-bff test       # vitest run --coverage (the gate)
+pnpm -F @pumped-fn/lite-golden-bff typecheck
+```

--- a/examples/lite-golden-bff/package.json
+++ b/examples/lite-golden-bff/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@pumped-fn/lite-golden-bff",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/lite-golden-bff/src/client.ts
+++ b/examples/lite-golden-bff/src/client.ts
@@ -1,0 +1,30 @@
+import { atom, tag, tags } from "@pumped-fn/lite"
+import type { Incident, ServiceDetail, ServiceStatus } from "./wire"
+
+export type Period = "7d" | "30d" | "90d"
+
+export interface CapstoneClient {
+  listServices(): Promise<ServiceStatus[]>
+  activeIncidents(): Promise<Incident[]>
+  uptime(serviceId: string, period: Period): Promise<number>
+  getService(id: string): Promise<ServiceDetail>
+}
+
+export const capstoneBaseUrl = tag<string>({ label: "capstone.baseUrl", default: "http://localhost:3000" })
+
+export const capstoneClient = atom({
+  deps: { baseUrl: tags.required(capstoneBaseUrl) },
+  factory: (_ctx, { baseUrl }): CapstoneClient => {
+    const get = async <T>(path: string): Promise<T> => {
+      const res = await fetch(`${baseUrl}${path}`)
+      if (!res.ok) throw new Error(`capstone ${path} failed: ${res.status}`)
+      return (await res.json()) as T
+    }
+    return {
+      listServices: () => get<ServiceStatus[]>("/services"),
+      activeIncidents: () => get<Incident[]>("/incidents/active"),
+      uptime: (serviceId, period) => get<number>(`/metrics/uptime/${serviceId}?period=${period}`),
+      getService: (id) => get<ServiceDetail>(`/services/${id}`),
+    }
+  },
+})

--- a/examples/lite-golden-bff/src/dashboard.ts
+++ b/examples/lite-golden-bff/src/dashboard.ts
@@ -1,0 +1,46 @@
+import { flow } from "@pumped-fn/lite"
+import { capstoneClient } from "./client"
+import type { Criticality, Status } from "./wire"
+
+export interface AttentionRow {
+  id: string
+  name: string
+  status: Status
+  criticality: Criticality
+}
+
+export interface DashboardView {
+  summary: {
+    total: number
+    healthy: number
+    unhealthy: number
+    unknown: number
+    activeIncidents: number
+  }
+  attention: AttentionRow[]
+}
+
+const rank: Record<Criticality, number> = { critical: 0, high: 1, medium: 2, low: 3 }
+
+export const dashboardView = flow({
+  name: "dashboard-view",
+  deps: { client: capstoneClient },
+  factory: async (_ctx, { client }): Promise<DashboardView> => {
+    const [services, incidents] = await Promise.all([client.listServices(), client.activeIncidents()])
+    const count = (status: Status) => services.filter((s) => s.status === status).length
+    const attention = services
+      .filter((s) => s.status !== "healthy")
+      .sort((a, b) => rank[a.criticality] - rank[b.criticality])
+      .map((s) => ({ id: s.id, name: s.name, status: s.status, criticality: s.criticality }))
+    return {
+      summary: {
+        total: services.length,
+        healthy: count("healthy"),
+        unhealthy: count("unhealthy"),
+        unknown: count("unknown"),
+        activeIncidents: incidents.length,
+      },
+      attention,
+    }
+  },
+})

--- a/examples/lite-golden-bff/src/detail.ts
+++ b/examples/lite-golden-bff/src/detail.ts
@@ -1,0 +1,40 @@
+import { flow, typed } from "@pumped-fn/lite"
+import { capstoneClient, type Period } from "./client"
+import type { Status } from "./wire"
+
+export interface DetailCheck {
+  status: Status
+  responseTime: number | null
+  timestamp: number
+}
+
+export interface ServiceDetailView {
+  id: string
+  name: string
+  status: Status
+  uptimeLabel: string
+  recentChecks: DetailCheck[]
+  openIncidents: number
+}
+
+export const serviceDetailView = flow({
+  name: "service-detail-view",
+  parse: typed<{ serviceId: string; period: Period }>(),
+  deps: { client: capstoneClient },
+  factory: async (ctx, { client }): Promise<ServiceDetailView> => {
+    const detail = await client.getService(ctx.input.serviceId)
+    const uptime = await client.uptime(ctx.input.serviceId, ctx.input.period)
+    return {
+      id: detail.id,
+      name: detail.name,
+      status: detail.status,
+      uptimeLabel: `${uptime.toFixed(2)}%`,
+      recentChecks: detail.recentChecks.map((c) => ({
+        status: c.status,
+        responseTime: c.responseTime,
+        timestamp: c.timestamp,
+      })),
+      openIncidents: detail.incidents.filter((i) => i.recoveredAt === null).length,
+    }
+  },
+})

--- a/examples/lite-golden-bff/src/wire.ts
+++ b/examples/lite-golden-bff/src/wire.ts
@@ -1,0 +1,42 @@
+export type Status = "healthy" | "unhealthy" | "unknown"
+
+export type Criticality = "low" | "medium" | "high" | "critical"
+
+export interface Service {
+  id: string
+  name: string
+  type: "http" | "tcp" | "custom"
+  endpoint: string
+  checkInterval: number
+  timeout: number
+  criticality: Criticality
+  createdAt: number
+  updatedAt: number
+}
+
+export interface ServiceStatus extends Service {
+  status: Status
+}
+
+export interface HealthCheck {
+  id: string
+  serviceId: string
+  status: Status
+  responseTime: number | null
+  error: string | null
+  timestamp: number
+}
+
+export interface Incident {
+  id: string
+  serviceId: string
+  startedAt: number
+  recoveredAt: number | null
+  duration: number | null
+  checksFailedCount: number
+}
+
+export interface ServiceDetail extends ServiceStatus {
+  recentChecks: HealthCheck[]
+  incidents: Incident[]
+}

--- a/examples/lite-golden-bff/tests/client.test.ts
+++ b/examples/lite-golden-bff/tests/client.test.ts
@@ -1,0 +1,41 @@
+import { describe, test, expect, vi, afterEach } from "vitest"
+import { createScope } from "@pumped-fn/lite"
+import { capstoneClient } from "../src/client"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("inside-out", () => {
+  test("IO1: each method hits the right capstone path and parses the body (fetch faked here only — below the seam)", async () => {
+    const calls: string[] = []
+    vi.stubGlobal("fetch", async (url: string) => {
+      calls.push(url)
+      return { ok: true, json: async () => [{ id: "a" }] }
+    })
+
+    const scope = createScope()
+    const client = await scope.resolve(capstoneClient)
+    await client.listServices()
+    await client.activeIncidents()
+    await client.uptime("a", "7d")
+    await client.getService("a")
+
+    expect(calls).toEqual([
+      "http://localhost:3000/services",
+      "http://localhost:3000/incidents/active",
+      "http://localhost:3000/metrics/uptime/a?period=7d",
+      "http://localhost:3000/services/a",
+    ])
+    await scope.dispose()
+  })
+
+  test("IO2: a non-ok response throws with the status", async () => {
+    vi.stubGlobal("fetch", async () => ({ ok: false, status: 503, json: async () => ({}) }))
+
+    const scope = createScope()
+    const client = await scope.resolve(capstoneClient)
+    await expect(client.listServices()).rejects.toThrow("503")
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-bff/tests/dashboard.test.ts
+++ b/examples/lite-golden-bff/tests/dashboard.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect } from "vitest"
+import { createScope, preset } from "@pumped-fn/lite"
+import { capstoneClient, type CapstoneClient } from "../src/client"
+import { dashboardView } from "../src/dashboard"
+import type { Criticality, Incident, ServiceStatus, Status } from "../src/wire"
+
+function fakeClient(over: Partial<CapstoneClient>): CapstoneClient {
+  return {
+    listServices: async () => [],
+    activeIncidents: async () => [],
+    uptime: async () => 100,
+    getService: async () => {
+      throw new Error("not used")
+    },
+    ...over,
+  }
+}
+
+function svc(id: string, status: Status, criticality: Criticality): ServiceStatus {
+  return {
+    id,
+    name: id,
+    type: "http",
+    endpoint: "x",
+    checkInterval: 30,
+    timeout: 1000,
+    criticality,
+    status,
+    createdAt: 0,
+    updatedAt: 0,
+  }
+}
+
+describe("inside-out", () => {
+  test("IO1: summary counts services by status and counts active incidents", async () => {
+    const services = [
+      svc("a", "healthy", "low"),
+      svc("b", "unhealthy", "high"),
+      svc("c", "unknown", "low"),
+      svc("d", "healthy", "low"),
+    ]
+    const incidents: Incident[] = [
+      { id: "i1", serviceId: "b", startedAt: 0, recoveredAt: null, duration: null, checksFailedCount: 2 },
+    ]
+    const scope = createScope({
+      presets: [preset(capstoneClient, fakeClient({ listServices: async () => services, activeIncidents: async () => incidents }))],
+    })
+    const ctx = scope.createContext()
+    const view = await ctx.exec({ flow: dashboardView })
+    expect(view.summary).toEqual({ total: 4, healthy: 2, unhealthy: 1, unknown: 1, activeIncidents: 1 })
+    await ctx.close({ ok: true })
+    await scope.dispose()
+  })
+
+  test("IO2: attention drops healthy services and sorts the rest by criticality", async () => {
+    const services = [
+      svc("a", "healthy", "critical"),
+      svc("b", "unhealthy", "low"),
+      svc("c", "unknown", "critical"),
+    ]
+    const scope = createScope({
+      presets: [preset(capstoneClient, fakeClient({ listServices: async () => services }))],
+    })
+    const ctx = scope.createContext()
+    const view = await ctx.exec({ flow: dashboardView })
+    expect(view.attention.map((r) => r.id)).toEqual(["c", "b"])
+    await ctx.close({ ok: true })
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-bff/tests/detail.test.ts
+++ b/examples/lite-golden-bff/tests/detail.test.ts
@@ -1,0 +1,52 @@
+import { describe, test, expect } from "vitest"
+import { createScope, preset } from "@pumped-fn/lite"
+import { capstoneClient, type CapstoneClient } from "../src/client"
+import { serviceDetailView } from "../src/detail"
+import type { ServiceDetail } from "../src/wire"
+
+const detail: ServiceDetail = {
+  id: "a",
+  name: "api",
+  type: "http",
+  endpoint: "x",
+  checkInterval: 30,
+  timeout: 1000,
+  criticality: "high",
+  status: "unhealthy",
+  createdAt: 0,
+  updatedAt: 0,
+  recentChecks: [
+    { id: "c1", serviceId: "a", status: "healthy", responseTime: 12, error: null, timestamp: 1 },
+    { id: "c2", serviceId: "a", status: "unhealthy", responseTime: null, error: "timeout", timestamp: 2 },
+  ],
+  incidents: [
+    { id: "i1", serviceId: "a", startedAt: 0, recoveredAt: null, duration: null, checksFailedCount: 3 },
+    { id: "i2", serviceId: "a", startedAt: 0, recoveredAt: 5, duration: 5, checksFailedCount: 1 },
+  ],
+}
+
+function fakeClient(): CapstoneClient {
+  return {
+    listServices: async () => [],
+    activeIncidents: async () => [],
+    uptime: async () => 99.9,
+    getService: async () => detail,
+  }
+}
+
+describe("inside-out", () => {
+  test("IO1: shapes a service detail — formatted uptime, mapped checks, open-incident count", async () => {
+    const scope = createScope({ presets: [preset(capstoneClient, fakeClient())] })
+    const ctx = scope.createContext()
+    const view = await ctx.exec({ flow: serviceDetailView, input: { serviceId: "a", period: "30d" } })
+    expect(view.uptimeLabel).toBe("99.90%")
+    expect(view.recentChecks).toEqual([
+      { status: "healthy", responseTime: 12, timestamp: 1 },
+      { status: "unhealthy", responseTime: null, timestamp: 2 },
+    ])
+    expect(view.openIncidents).toBe(1)
+    expect(view.name).toBe("api")
+    await ctx.close({ ok: true })
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-bff/tsconfig.json
+++ b/examples/lite-golden-bff/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/lite-golden-bff/vitest.config.ts
+++ b/examples/lite-golden-bff/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
 
+  examples/lite-golden-bff:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../packages/lite
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.7(vitest@4.1.7)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+
   examples/lite-golden-react:
     dependencies:
       '@pumped-fn/lite':


### PR DESCRIPTION
## What

First increment of the **BFF + tiered-frontend** arc (§13): a Backend-For-Frontend for the [`lite-golden`](../lite-golden) Service Health Monitor. It talks to the backend and reshapes its data into frontend-friendly view-models, so the frontend does **interaction, not calculation**.

This is the highest-value first slice: it's pure node logic (the calculation tier), it's the dependency both frontends will consume, and it proves the thesis cleanly — *the BFF owns the logic, and the logic is fully testable through the scope seam.*

- **`capstoneClient` adapter** — an atom wrapping `fetch` (the HTTP boundary to the backend). View-model flows declare it as a dependency and never touch the network.
- **`dashboardView`** — counts services by status, counts active incidents, produces a criticality-sorted attention list.
- **`serviceDetailView`** — formats uptime, maps recent checks, counts open incidents.
- **Seam discipline** — view-model flows are tested via `preset(capstoneClient, fake)`; `fetch` is faked only in the adapter's *own* unit test (`client.test.ts`), which is below the seam. No `msw`/`fetch-mock`.

## Verification

- `pnpm -F @pumped-fn/lite-golden-bff test` — 3 files, 5 tests, 100/100/100/100 (29 stmts, 2 branches, 15 fns)
- `typecheck` clean; workspace typecheck clean
- Private example package — no release impact; packages stay independent (BFF re-declares wire types)

Next: B2 frontend v1 (FAT — owns auth + derivation), B3 BFF auth + frontend v2 (THIN — projects view-models), B4 comparison README + spectrum diagram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)