### PR TITLE
feat(lite-golden-react): fat frontend (v1) — frontend owns auth, BFF owns shaping

### DIFF
--- a/.changeset/lite-golden-react-fat.md
+++ b/.changeset/lite-golden-react-fat.md
@@ -1,0 +1,4 @@
+---
+---
+
+examples: add fat frontend (v1) to lite-golden-react capstone — frontend owns auth, BFF owns shaping (private example)

--- a/examples/lite-golden-react/capstone/fat/README.md
+++ b/examples/lite-golden-react/capstone/fat/README.md
@@ -1,0 +1,28 @@
+# BFF Capstone — FAT Frontend (v1)
+
+## The story
+
+The fat frontend owns auth. It holds credentials, authenticates against the auth endpoint, carries the session token, and gates every data load on that session. The BFF owns data shaping: it returns a `DashboardView` that is already summarized and sorted — the frontend projects it without recalculation.
+
+This is one point on the logic-boundary spectrum: auth logic lives in frontend node tests; shaping logic lives in BFF node tests; observers live in jsdom tests.
+
+## Seam
+
+The scope is the single seam.
+
+- `authProvider` and `bffClient` are adapter atoms. Their factories call `fetch`. In graph logic tests they are preset with typed fakes — the graph is tested without a network. In adapter-own tests (`auth-provider.test.ts`, `bff-client.test.ts`), `vi.stubGlobal` fakes `fetch` below the seam — the sole sanctioned global-fake site per module.
+- `session` is preset directly in tests that need an already-authed graph state (e.g. the dashboard DOM test skips login entirely).
+- Components observe atoms via `useAtom`/`useScope`; they exec flows on user interaction. The observer tests wrap components in `<ScopeProvider scope={scope}>` and interact via `fireEvent`.
+
+## Lens coverage
+
+| File | Inside-out | Outside-in | Effect-managed |
+|---|---|---|---|
+| `auth.ts` | `auth.test.ts` (login, isAuthed, logout, failure) | `LoginForm.dom.test.tsx` (full login→logout cycle) | absent — auth atoms own no cleanup resources |
+| `app.ts` | `app.test.ts` (null session, loaded, watch re-load) | `DashboardScreen.dom.test.tsx` (authed + data renders) | absent — dashboard atom is derived, no cleanup |
+| `LoginForm.tsx` | — (logic in graph) | `LoginForm.dom.test.tsx` (all branches: login, logout, error, fallback) | — |
+| `DashboardScreen.tsx` | — (logic in graph) | `DashboardScreen.dom.test.tsx` (unauthed, authed+data) | — |
+
+Adapter-own tests (below the seam, faking `fetch`):
+- `auth-provider.test.ts` — POST /login, ok parse, non-ok throw
+- `bff-client.test.ts` — GET /dashboard with Bearer header, ok parse, non-ok throw

--- a/examples/lite-golden-react/capstone/fat/src/DashboardScreen.tsx
+++ b/examples/lite-golden-react/capstone/fat/src/DashboardScreen.tsx
@@ -1,0 +1,34 @@
+import { useAtom } from "@pumped-fn/lite-react"
+import { isAuthed } from "./auth"
+import { dashboard } from "./app"
+import { LoginForm } from "./LoginForm"
+
+export function DashboardScreen() {
+  const { data: authed } = useAtom(isAuthed, { suspense: false, resolve: true })
+  const { data: dash } = useAtom(dashboard, { suspense: false, resolve: true })
+
+  if (!authed) return <LoginForm />
+
+  if (dash === null || dash === undefined) return <div>loading</div>
+
+  return (
+    <div>
+      <section aria-label="summary">
+        <span>total {dash.summary.total}</span>
+        <span>healthy {dash.summary.healthy}</span>
+        <span>unhealthy {dash.summary.unhealthy}</span>
+        <span>unknown {dash.summary.unknown}</span>
+        <span>incidents {dash.summary.activeIncidents}</span>
+      </section>
+      <ul aria-label="attention">
+        {dash.attention.map((row) => (
+          <li key={row.id}>
+            <span>{row.name}</span>
+            <span>{row.status}</span>
+            <span>{row.criticality}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/examples/lite-golden-react/capstone/fat/src/LoginForm.tsx
+++ b/examples/lite-golden-react/capstone/fat/src/LoginForm.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react"
+import { useAtom, useScope } from "@pumped-fn/lite-react"
+import { isAuthed, login, logout } from "./auth"
+
+export function LoginForm() {
+  const { data: authed } = useAtom(isAuthed, { suspense: false, resolve: true })
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [error, setError] = useState<string | null>(null)
+  const scope = useScope()
+
+  if (authed) {
+    return (
+      <button
+        onClick={async () => {
+          const ctx = scope.createContext()
+          await ctx.exec({ flow: logout, input: undefined })
+          await ctx.close({ ok: true })
+        }}
+      >
+        logout
+      </button>
+    )
+  }
+
+  return (
+    <form
+      onSubmit={async (e) => {
+        e.preventDefault()
+        setError(null)
+        try {
+          const ctx = scope.createContext()
+          await ctx.exec({ flow: login, input: { email, password } })
+          await ctx.close({ ok: true })
+        } catch (err) {
+          setError(err instanceof Error ? err.message : "login failed")
+        }
+      }}
+    >
+      <label>
+        email
+        <input aria-label="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      </label>
+      <label>
+        password
+        <input
+          aria-label="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </label>
+      {error && <div role="alert">{error}</div>}
+      <button type="submit">login</button>
+    </form>
+  )
+}

--- a/examples/lite-golden-react/capstone/fat/src/app.ts
+++ b/examples/lite-golden-react/capstone/fat/src/app.ts
@@ -1,0 +1,50 @@
+import { atom, controller, tag, tags } from "@pumped-fn/lite"
+import { session } from "./auth"
+
+export type Status = "healthy" | "unhealthy" | "unknown"
+export type Criticality = "low" | "medium" | "high" | "critical"
+
+export interface DashboardView {
+  summary: {
+    total: number
+    healthy: number
+    unhealthy: number
+    unknown: number
+    activeIncidents: number
+  }
+  attention: Array<{ id: string; name: string; status: Status; criticality: Criticality }>
+}
+
+export interface BffClient {
+  dashboard(token: string): Promise<DashboardView>
+}
+
+export const bffBaseUrl = tag<string>({ label: "bff.baseUrl", default: "http://localhost:4001" })
+
+export const bffClient = atom({
+  deps: { baseUrl: tags.required(bffBaseUrl) },
+  factory: (_ctx, { baseUrl }): BffClient => {
+    const get = async <T>(path: string, token: string): Promise<T> => {
+      const res = await fetch(`${baseUrl}${path}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!res.ok) throw new Error(`bff ${path} failed: ${res.status}`)
+      return (await res.json()) as T
+    }
+    return {
+      dashboard: (token) => get<DashboardView>("/dashboard", token),
+    }
+  },
+})
+
+export const dashboard = atom({
+  deps: {
+    client: bffClient,
+    sessionControl: controller(session, { resolve: true, watch: true }),
+  },
+  factory: async (_ctx, { client, sessionControl }) => {
+    const s = sessionControl.get()
+    if (s === null) return null
+    return client.dashboard(s.token)
+  },
+})

--- a/examples/lite-golden-react/capstone/fat/src/auth.ts
+++ b/examples/lite-golden-react/capstone/fat/src/auth.ts
@@ -1,0 +1,62 @@
+import { atom, controller, flow, tag, tags, typed } from "@pumped-fn/lite"
+
+export interface User {
+  id: string
+  name: string
+}
+
+export interface Session {
+  token: string
+  user: User
+}
+
+export interface AuthProvider {
+  authenticate(email: string, password: string): Promise<Session>
+}
+
+export const authBaseUrl = tag<string>({ label: "auth.baseUrl", default: "http://localhost:4000" })
+
+export const authProvider = atom({
+  deps: { baseUrl: tags.required(authBaseUrl) },
+  factory: (_ctx, { baseUrl }): AuthProvider => {
+    const post = async <T>(path: string, body: unknown): Promise<T> => {
+      const res = await fetch(`${baseUrl}${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      if (!res.ok) throw new Error("invalid credentials")
+      return (await res.json()) as T
+    }
+    return {
+      authenticate: (email, password) => post<Session>("/login", { email, password }),
+    }
+  },
+})
+
+export const session = atom({ factory: (): Session | null => null })
+
+export const login = flow({
+  name: "login",
+  parse: typed<{ email: string; password: string }>(),
+  deps: { provider: authProvider, sessionControl: controller(session, { resolve: true }) },
+  factory: async (ctx, { provider, sessionControl }) => {
+    const s = await provider.authenticate(ctx.input.email, ctx.input.password)
+    sessionControl.set(s)
+    return s
+  },
+})
+
+export const isAuthed = atom({
+  deps: { sessionControl: controller(session, { resolve: true, watch: true }) },
+  factory: (_ctx, { sessionControl }) => sessionControl.get() !== null,
+})
+
+export const logout = flow({
+  name: "logout",
+  parse: typed<undefined>(),
+  deps: { sessionControl: controller(session, { resolve: true }) },
+  factory: (_ctx, { sessionControl }) => {
+    sessionControl.set(null)
+  },
+})

--- a/examples/lite-golden-react/capstone/fat/tests/DashboardScreen.dom.test.tsx
+++ b/examples/lite-golden-react/capstone/fat/tests/DashboardScreen.dom.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { createScope, preset } from "@pumped-fn/lite"
+import { ScopeProvider } from "@pumped-fn/lite-react"
+import { authProvider, session, type AuthProvider, type Session } from "../src/auth"
+import { bffClient, type BffClient, type DashboardView } from "../src/app"
+import { DashboardScreen } from "../src/DashboardScreen"
+
+const aSession: Session = { token: "tok-1", user: { id: "u1", name: "Alice" } }
+
+const stubAuth: AuthProvider = { authenticate: async () => aSession }
+
+const fakeDashboard: DashboardView = {
+  summary: { total: 5, healthy: 3, unhealthy: 1, unknown: 1, activeIncidents: 2 },
+  attention: [
+    { id: "s1", name: "api-gateway", status: "unhealthy", criticality: "critical" },
+    { id: "s2", name: "cache", status: "unknown", criticality: "high" },
+  ],
+}
+
+const fakeClient: BffClient = { dashboard: async () => fakeDashboard }
+
+describe("outside-in", () => {
+  test("OI1: not authed — login form visible", async () => {
+    const scope = createScope({ presets: [preset(authProvider, stubAuth)] })
+    render(
+      <ScopeProvider scope={scope}>
+        <DashboardScreen />
+      </ScopeProvider>
+    )
+    expect(await screen.findByLabelText("email")).toBeTruthy()
+    await scope.dispose()
+  })
+
+  test("OI2: authed + dashboard loaded — summary counts and attention rows render", async () => {
+    const scope = createScope({
+      presets: [preset(session, aSession), preset(bffClient, fakeClient)],
+    })
+    render(
+      <ScopeProvider scope={scope}>
+        <DashboardScreen />
+      </ScopeProvider>
+    )
+    expect(await screen.findByText(/total.*5/i)).toBeTruthy()
+    expect(screen.getByText(/healthy.*3/i)).toBeTruthy()
+    expect(screen.getByText(/unhealthy.*1/i)).toBeTruthy()
+    expect(screen.getByText(/unknown.*1/i)).toBeTruthy()
+    expect(screen.getByText(/incidents.*2/i)).toBeTruthy()
+    expect(screen.getByText("api-gateway")).toBeTruthy()
+    expect(screen.getByText("cache")).toBeTruthy()
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/capstone/fat/tests/LoginForm.dom.test.tsx
+++ b/examples/lite-golden-react/capstone/fat/tests/LoginForm.dom.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, test, expect } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { createScope, preset } from "@pumped-fn/lite"
+import { ScopeProvider } from "@pumped-fn/lite-react"
+import { authProvider, type AuthProvider, type Session } from "../src/auth"
+import { LoginForm } from "../src/LoginForm"
+
+const aSession: Session = { token: "tok-1", user: { id: "u1", name: "Alice" } }
+
+const successAuth: AuthProvider = { authenticate: async () => aSession }
+const failingAuth: AuthProvider = {
+  authenticate: async () => {
+    throw new Error("invalid credentials")
+  },
+}
+
+async function fillAndSubmit(email: string, password: string) {
+  fireEvent.change(screen.getByLabelText("email"), { target: { value: email } })
+  fireEvent.change(screen.getByLabelText("password"), { target: { value: password } })
+  fireEvent.click(screen.getByRole("button", { name: "login" }))
+}
+
+describe("outside-in", () => {
+  test("OI1: renders email and password inputs when not authed", async () => {
+    const scope = createScope({ presets: [preset(authProvider, successAuth)] })
+    render(
+      <ScopeProvider scope={scope}>
+        <LoginForm />
+      </ScopeProvider>
+    )
+    expect(await screen.findByLabelText("email")).toBeTruthy()
+    expect(screen.getByLabelText("password")).toBeTruthy()
+    expect(screen.getByRole("button", { name: "login" })).toBeTruthy()
+    await scope.dispose()
+  })
+
+  test("OI2: successful login transitions to authed state (logout button appears)", async () => {
+    const scope = createScope({ presets: [preset(authProvider, successAuth)] })
+    render(
+      <ScopeProvider scope={scope}>
+        <LoginForm />
+      </ScopeProvider>
+    )
+    await screen.findByLabelText("email")
+    await fillAndSubmit("a@b.com", "pass")
+    expect(await screen.findByRole("button", { name: "logout" })).toBeTruthy()
+    await scope.dispose()
+  })
+
+  test("OI3: clicking logout returns to login form", async () => {
+    const scope = createScope({ presets: [preset(authProvider, successAuth)] })
+    render(
+      <ScopeProvider scope={scope}>
+        <LoginForm />
+      </ScopeProvider>
+    )
+    await screen.findByLabelText("email")
+    await fillAndSubmit("a@b.com", "pass")
+    const logoutBtn = await screen.findByRole("button", { name: "logout" })
+    fireEvent.click(logoutBtn)
+    expect(await screen.findByLabelText("email")).toBeTruthy()
+    await scope.dispose()
+  })
+
+  test("OI4: failed login shows error message and stays on form (spec OI3)", async () => {
+    const scope = createScope({ presets: [preset(authProvider, failingAuth)] })
+    render(
+      <ScopeProvider scope={scope}>
+        <LoginForm />
+      </ScopeProvider>
+    )
+    await screen.findByLabelText("email")
+    await fillAndSubmit("x@y.com", "wrong")
+    expect(await screen.findByRole("alert")).toBeTruthy()
+    expect(screen.getByLabelText("email")).toBeTruthy()
+    await scope.dispose()
+  })
+
+  test("OI5: non-Error thrown by auth shows fallback 'login failed' message", async () => {
+    const stringThrowAuth: AuthProvider = { authenticate: async () => { throw "oops" } }
+    const scope = createScope({ presets: [preset(authProvider, stringThrowAuth)] })
+    render(
+      <ScopeProvider scope={scope}>
+        <LoginForm />
+      </ScopeProvider>
+    )
+    await screen.findByLabelText("email")
+    await fillAndSubmit("x@y.com", "wrong")
+    const alert = await screen.findByRole("alert")
+    expect(alert.textContent).toBe("login failed")
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/capstone/fat/tests/app.test.ts
+++ b/examples/lite-golden-react/capstone/fat/tests/app.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "vitest"
+import { createScope, preset } from "@pumped-fn/lite"
+import { session, authProvider, login, type AuthProvider, type Session } from "../src/auth"
+import { bffClient, dashboard, type BffClient, type DashboardView } from "../src/app"
+
+const aSession: Session = { token: "tok-1", user: { id: "u1", name: "Alice" } }
+
+const fakeDashboard: DashboardView = {
+  summary: { total: 3, healthy: 2, unhealthy: 1, unknown: 0, activeIncidents: 1 },
+  attention: [{ id: "s1", name: "api", status: "unhealthy", criticality: "high" }],
+}
+
+const fakeClient: BffClient = {
+  dashboard: async (_token) => fakeDashboard,
+}
+
+const fakeAuth: AuthProvider = {
+  authenticate: async () => aSession,
+}
+
+describe("inside-out", () => {
+  test("IO1: dashboard is null when session is null", async () => {
+    const scope = createScope({ presets: [preset(bffClient, fakeClient)] })
+    const result = await scope.resolve(dashboard)
+    expect(result).toBeNull()
+    await scope.dispose()
+  })
+
+  test("IO2: dashboard loads via preset bffClient when authed", async () => {
+    const scope = createScope({ presets: [preset(bffClient, fakeClient), preset(session, aSession)] })
+    const result = await scope.resolve(dashboard)
+    expect(result).toEqual(fakeDashboard)
+    await scope.dispose()
+  })
+
+  test("IO3: dashboard re-loads when session changes (login → watch cascade)", async () => {
+    const tokenCalls: string[] = []
+    const trackingClient: BffClient = {
+      dashboard: async (token) => {
+        tokenCalls.push(token)
+        return fakeDashboard
+      },
+    }
+    const scope = createScope({
+      presets: [preset(bffClient, trackingClient), preset(authProvider, fakeAuth)],
+    })
+    expect(await scope.resolve(dashboard)).toBeNull()
+
+    const ctx = scope.createContext()
+    await ctx.exec({ flow: login, input: { email: "a@b.com", password: "pass" } })
+    await ctx.close({ ok: true })
+    await scope.flush()
+
+    const result = await scope.resolve(dashboard)
+    expect(result).toEqual(fakeDashboard)
+    expect(tokenCalls).toContain("tok-1")
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/capstone/fat/tests/auth-provider.test.ts
+++ b/examples/lite-golden-react/capstone/fat/tests/auth-provider.test.ts
@@ -1,0 +1,38 @@
+import { describe, test, expect, vi, afterEach } from "vitest"
+import { createScope } from "@pumped-fn/lite"
+import { authProvider } from "../src/auth"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("inside-out", () => {
+  test("IO1: POST /login with correct path returns parsed Session on ok", async () => {
+    const calls: { url: string; method: string; body: string }[] = []
+    vi.stubGlobal("fetch", async (url: string, init: RequestInit) => {
+      calls.push({ url, method: init.method ?? "GET", body: init.body as string })
+      return { ok: true, json: async () => ({ token: "t", user: { id: "u1", name: "Alice" } }) }
+    })
+
+    const scope = createScope()
+    const provider = await scope.resolve(authProvider)
+    const result = await provider.authenticate("a@b.com", "pass")
+
+    expect(calls).toHaveLength(1)
+    const call = calls[0]!
+    expect(call.url).toBe("http://localhost:4000/login")
+    expect(call.method).toBe("POST")
+    expect(JSON.parse(call.body)).toEqual({ email: "a@b.com", password: "pass" })
+    expect(result).toEqual({ token: "t", user: { id: "u1", name: "Alice" } })
+    await scope.dispose()
+  })
+
+  test("IO2: non-ok response throws 'invalid credentials'", async () => {
+    vi.stubGlobal("fetch", async () => ({ ok: false, status: 401, json: async () => ({}) }))
+
+    const scope = createScope()
+    const provider = await scope.resolve(authProvider)
+    await expect(provider.authenticate("a@b.com", "wrong")).rejects.toThrow("invalid credentials")
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/capstone/fat/tests/auth.test.ts
+++ b/examples/lite-golden-react/capstone/fat/tests/auth.test.ts
@@ -1,0 +1,66 @@
+import { describe, test, expect } from "vitest"
+import { createScope, preset } from "@pumped-fn/lite"
+import { authProvider, session, login, isAuthed, logout, type AuthProvider, type Session } from "../src/auth"
+
+const aSession: Session = { token: "tok-1", user: { id: "u1", name: "Alice" } }
+
+const fakeAuth: AuthProvider = {
+  authenticate: async (_email, _password) => aSession,
+}
+
+const throwingAuth: AuthProvider = {
+  authenticate: async () => {
+    throw new Error("invalid credentials")
+  },
+}
+
+describe("inside-out", () => {
+  test("IO1: login flow sets session via preset authProvider", async () => {
+    const scope = createScope({ presets: [preset(authProvider, fakeAuth)] })
+    const ctx = scope.createContext()
+    await ctx.exec({ flow: login, input: { email: "a@b.com", password: "pass" } })
+    await ctx.close({ ok: true })
+    const s = await scope.resolve(session)
+    expect(s).toEqual(aSession)
+    await scope.dispose()
+  })
+
+  test("IO2: isAuthed is false before login and true after", async () => {
+    const scope = createScope({ presets: [preset(authProvider, fakeAuth)] })
+    expect(await scope.resolve(isAuthed)).toBe(false)
+    const ctx = scope.createContext()
+    await ctx.exec({ flow: login, input: { email: "a@b.com", password: "pass" } })
+    await ctx.close({ ok: true })
+    await scope.flush()
+    expect(await scope.resolve(isAuthed)).toBe(true)
+    await scope.dispose()
+  })
+
+  test("IO3: login failure propagates and session stays null", async () => {
+    const scope = createScope({ presets: [preset(authProvider, throwingAuth)] })
+    const ctx = scope.createContext()
+    await expect(
+      ctx.exec({ flow: login, input: { email: "x@y.com", password: "wrong" } })
+    ).rejects.toThrow("invalid credentials")
+    await ctx.close({ ok: false, error: new Error("invalid credentials") })
+    expect(await scope.resolve(session)).toBeNull()
+    await scope.dispose()
+  })
+
+  test("IO4: logout resets session to null", async () => {
+    const scope = createScope({ presets: [preset(authProvider, fakeAuth)] })
+    const loginCtx = scope.createContext()
+    await loginCtx.exec({ flow: login, input: { email: "a@b.com", password: "pass" } })
+    await loginCtx.close({ ok: true })
+    await scope.flush()
+    expect(await scope.resolve(isAuthed)).toBe(true)
+
+    const logoutCtx = scope.createContext()
+    await logoutCtx.exec({ flow: logout, input: undefined })
+    await logoutCtx.close({ ok: true })
+    await scope.flush()
+    expect(await scope.resolve(session)).toBeNull()
+    expect(await scope.resolve(isAuthed)).toBe(false)
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/capstone/fat/tests/bff-client.test.ts
+++ b/examples/lite-golden-react/capstone/fat/tests/bff-client.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect, vi, afterEach } from "vitest"
+import { createScope } from "@pumped-fn/lite"
+import { bffClient } from "../src/app"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("inside-out", () => {
+  test("IO1: GET /dashboard with Bearer token returns parsed DashboardView on ok", async () => {
+    const calls: { url: string; auth: string }[] = []
+    const payload = {
+      summary: { total: 1, healthy: 1, unhealthy: 0, unknown: 0, activeIncidents: 0 },
+      attention: [],
+    }
+    vi.stubGlobal("fetch", async (url: string, init: RequestInit) => {
+      const auth = (init.headers as Record<string, string>)["Authorization"] ?? ""
+      calls.push({ url, auth })
+      return { ok: true, json: async () => payload }
+    })
+
+    const scope = createScope()
+    const client = await scope.resolve(bffClient)
+    const result = await client.dashboard("my-token")
+
+    expect(calls).toHaveLength(1)
+    const call = calls[0]!
+    expect(call.url).toBe("http://localhost:4001/dashboard")
+    expect(call.auth).toBe("Bearer my-token")
+    expect(result).toEqual(payload)
+    await scope.dispose()
+  })
+
+  test("IO2: non-ok response throws", async () => {
+    vi.stubGlobal("fetch", async () => ({ ok: false, status: 403, json: async () => ({}) }))
+
+    const scope = createScope()
+    const client = await scope.resolve(bffClient)
+    await expect(client.dashboard("bad-token")).rejects.toThrow()
+    await scope.dispose()
+  })
+})

--- a/examples/lite-golden-react/vitest.config.ts
+++ b/examples/lite-golden-react/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     setupFiles: ["./tests/setup.dom.ts"],
     coverage: {
       provider: "v8",
-      include: ["patterns/**/after.ts", "patterns/**/view.tsx", "capstone/src/**/*.ts", "capstone/src/**/*.tsx"],
+      include: ["patterns/**/after.ts", "patterns/**/view.tsx", "capstone/**/src/**/*.ts", "capstone/**/src/**/*.tsx"],
       thresholds: {
         statements: 100,
         branches: 100,


### PR DESCRIPTION
## What

B2 of the BFF arc (§13.2): the **fat** frontend — the medium anchor of the logic-boundary spectrum. A handcooked frontend with a real dependency graph, demonstrating why the handcooked version earns its place: it owns auth.

- **Auth in the frontend graph**: `authProvider` adapter (wraps `fetch` POST /login), `session` atom, `login`/`logout` flows, `isAuthed` derived via a watch cascade.
- **App derived from auth**: `bffClient` adapter (GET /dashboard with Bearer token), `dashboard` atom auth-gated on `session` (null when logged out), re-loading via watch when the session changes.
- **Observers** `LoginForm` + `DashboardScreen`: pure projection + interaction. The dashboard summary is computed in the BFF; the component just reads `dash.summary.*`.

The whole graph is tested through the seam: auth and gating logic node-tested by presetting the adapters; `fetch` faked only in the two adapter-own tests (below the seam); components jsdom-tested.

## Verification

- `pnpm -F @pumped-fn/lite-golden-react test` — 11 files, 29 tests, 100/100/100/100 (82 stmts, 26 branches, 28 fns)
- typecheck clean; env-split guard green (dom tests carry the jsdom docblock, logic tests don't)
- vetted: no `atom<T>` generics, no `vi.mock`/`msw`, no browser globals in graph, `stubGlobal` only in adapter tests, components hold no calculation

Next: B3 (BFF auth flows + thin frontend that projects fully-shaped view-models), B4 (comparison README quantifying the v1-vs-v2 logic-test delta + spectrum diagram).

🤖 Generated with [Claude Code](https://claude.com/claude-code)