### PR TITLE
Add lite-native agent workflow surface

### DIFF
--- a/.changeset/modern-agents-run.md
+++ b/.changeset/modern-agents-run.md
@@ -6,4 +6,4 @@
 
 Ship the agent workflow surface over lite primitives.
 
-Adds concise agent authoring helpers, workflow-backed turns, skills, tools, subagents, sessions, run inspection, Fetch request adapters, eval summaries, and in-memory test runtime helpers.
+Adds concise agent authoring helpers, workflow-backed turns, skills, tools, subagents, sessions, run inspection, Fetch request adapters, eval summaries, in-memory test runtime helpers, and isolated Codex/Claude CLI model harnesses.

--- a/.changeset/modern-agents-run.md
+++ b/.changeset/modern-agents-run.md
@@ -1,0 +1,9 @@
+---
+"@pumped-fn/lite-extension-suspense": minor
+"@pumped-fn/agent-sdk": minor
+"@pumped-fn/agent-sdk-test": minor
+---
+
+Ship the agent workflow surface over lite primitives.
+
+Adds concise agent authoring helpers, workflow-backed turns, skills, tools, subagents, sessions, run inspection, Fetch request adapters, eval summaries, and in-memory test runtime helpers.

--- a/.changeset/modern-agents-run.md
+++ b/.changeset/modern-agents-run.md
@@ -1,9 +1,12 @@
 ---
 "@pumped-fn/lite-extension-suspense": minor
 "@pumped-fn/agent-sdk": minor
+"@pumped-fn/agent-sdk-codex": minor
+"@pumped-fn/agent-sdk-claude": minor
+"@pumped-fn/agent-sdk-just-bash": minor
 "@pumped-fn/agent-sdk-test": minor
 ---
 
 Ship the agent workflow surface over lite primitives.
 
-Adds concise agent authoring helpers, workflow-backed turns, skills, tools, subagents, sessions, run inspection, Fetch request adapters, eval summaries, in-memory test runtime helpers, and isolated Codex/Claude CLI model harnesses.
+Adds concise agent authoring helpers, workflow-backed turns, skills, tools, subagents, sessions, run inspection, Fetch request adapters, eval summaries, in-memory test runtime helpers, isolated Codex/Claude CLI model harnesses, lazy Codex/Claude provider packages, and a lazy just-bash sandbox provider package.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Extensions wrap execution. React is an observer layer.
 | `@pumped-fn/lite-devtools` | Devtools transports and observability helpers |
 | `@pumped-fn/lite-hmr` | HMR helpers for preserving atom state during development |
 | `@pumped-fn/lite-extension-otel` | OpenTelemetry integration |
-| `@pumped-fn/lite-extension-suspense` | Suspense-oriented extension support |
+| `@pumped-fn/lite-extension-suspense` | Replay and external-resolution extension support |
+| `@pumped-fn/agent-sdk` | Agent workflows, tools, skills, sessions, evals, HTTP adapters, and run inspection over lite |
+| `@pumped-fn/agent-sdk-test` | In-memory agent workflow logs, fake routing, and test helpers |
 | `@pumped-fn/codemod` | Migration helpers for older pumped-fn code |
 
 ## Mental Model
@@ -65,6 +67,12 @@ execution context
   flows: input/output work
   resources: transactions, request loggers, form drafts, spans
   tags: tenant, locale, trace id, runtime config
+        |
+        v
+agent workflow
+  model provider atom/service
+  tools and subagents as ctx.exec flow steps
+  events as a boundary resource
 ```
 
 The same seam works for backend and frontend:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Extensions wrap execution. React is an observer layer.
 | `@pumped-fn/lite-extension-otel` | OpenTelemetry integration |
 | `@pumped-fn/lite-extension-suspense` | Replay and external-resolution extension support |
 | `@pumped-fn/agent-sdk` | Agent workflows, tools, skills, sessions, evals, HTTP adapters, and run inspection over lite |
+| `@pumped-fn/agent-sdk-codex` | Lazy Codex CLI model provider tag for agent-sdk |
+| `@pumped-fn/agent-sdk-claude` | Lazy Claude CLI model provider tag for agent-sdk |
+| `@pumped-fn/agent-sdk-just-bash` | Lazy just-bash sandbox provider tag for agent-sdk |
 | `@pumped-fn/agent-sdk-test` | In-memory agent workflow logs, fake routing, and test helpers |
 | `@pumped-fn/codemod` | Migration helpers for older pumped-fn code |
 
@@ -70,7 +73,7 @@ execution context
         |
         v
 agent workflow
-  model provider atom/service
+  model and sandbox providers as tags
   tools and subagents as ctx.exec flow steps
   events as a boundary resource
 ```

--- a/benchmarks/lite-perf/vitest.config.ts
+++ b/benchmarks/lite-perf/vitest.config.ts
@@ -1,7 +1,15 @@
+import { fileURLToPath } from "node:url"
 import { playwright } from "@vitest/browser-playwright"
 import { configDefaults, defineConfig } from "vitest/config"
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@pumped-fn/lite-react": fileURLToPath(new URL("../../packages/lite-react/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite": fileURLToPath(new URL("../../packages/lite/src/index.ts", import.meta.url)),
+    },
+    dedupe: ["react", "react-dom"],
+  },
   test: {
     projects: [
       {

--- a/examples/agent-practical/README.md
+++ b/examples/agent-practical/README.md
@@ -1,0 +1,19 @@
+# Agent Practical
+
+Runnable `@pumped-fn/agent-sdk` example.
+
+It proves:
+
+- local agent turn with tools, skill loading, and subagent delegation
+- workflow run inspection through `RunLog`
+- Fetch `http()` adapter
+- continuing `session()` material
+- eval `summary()` artifact with two judges
+- sandbox swap through the `sandbox` tag
+
+Run it:
+
+```sh
+pnpm -F @pumped-fn/agent-practical test
+pnpm -F @pumped-fn/agent-practical typecheck
+```

--- a/examples/agent-practical/README.md
+++ b/examples/agent-practical/README.md
@@ -10,6 +10,8 @@ It proves:
 - continuing `session()` material
 - eval `summary()` artifact with two judges
 - sandbox swap through the `sandbox` tag
+- lazy Codex and Claude provider packages swapped through the `model` tag
+- just-bash workspace sandbox swapped through the `sandbox` tag
 
 Run it:
 

--- a/examples/agent-practical/package.json
+++ b/examples/agent-practical/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pumped-fn/agent-practical",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/agent-sdk": "workspace:*",
+    "@pumped-fn/agent-sdk-test": "workspace:*",
+    "@pumped-fn/lite": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/agent-practical/package.json
+++ b/examples/agent-practical/package.json
@@ -9,6 +9,9 @@
   },
   "dependencies": {
     "@pumped-fn/agent-sdk": "workspace:*",
+    "@pumped-fn/agent-sdk-claude": "workspace:*",
+    "@pumped-fn/agent-sdk-codex": "workspace:*",
+    "@pumped-fn/agent-sdk-just-bash": "workspace:*",
     "@pumped-fn/agent-sdk-test": "workspace:*",
     "@pumped-fn/lite": "workspace:*"
   },

--- a/examples/agent-practical/src/agent.ts
+++ b/examples/agent-practical/src/agent.ts
@@ -6,6 +6,7 @@ import {
   includes,
   inspect,
   judge,
+  model as agentModel,
   runEval,
   sandbox,
   schedule,
@@ -53,13 +54,13 @@ const summarizeModel: Model = {
 
 const summarize = agent({
   name: "summarize",
-  model: summarizeModel,
+  tags: [agentModel(summarizeModel)],
 })
 
-export function triage(model: Model) {
+export function triage(provider: Model) {
   return agent({
     name: "triage",
-    model,
+    tags: [agentModel(provider)],
     instructions: "Triage support tickets with tools, skills, and delegated summaries.",
     skills: [
       skill({

--- a/examples/agent-practical/src/agent.ts
+++ b/examples/agent-practical/src/agent.ts
@@ -98,7 +98,7 @@ export const model: Model = {
       },
 }
 
-export const box = sandbox({
+export const local = sandbox({
   readFile: (path) => `file:${path}`,
   writeFile: () => undefined,
   exec: (command, args = []) => ({
@@ -113,7 +113,7 @@ export async function runLocal() {
   const { extensions, log } = kit()
   const scope = createScope({
     extensions,
-    tags: [box],
+    tags: [local],
   })
   const ctx = scope.createContext({
     tags: [workflowRun({ taskId: "ticket-42", runId: "run-1" })],
@@ -131,7 +131,7 @@ export async function runLocal() {
 
 export async function runThread() {
   const target = triage(model)
-  const scope = createScope({ tags: [box] })
+  const scope = createScope({ tags: [local] })
   const ctx = scope.createContext()
   const thread = session("support-thread")
   await send(ctx, thread, target, { prompt: "one" })
@@ -143,7 +143,7 @@ export async function runThread() {
 }
 
 export async function runHttp() {
-  const scope = createScope({ tags: [box] })
+  const scope = createScope({ tags: [local] })
   const ctx = scope.createContext()
   const handle = http({ agent: triage(model) })
   const response = await ctx.exec({
@@ -182,7 +182,7 @@ export async function runSuite(targetLog?: RunLog) {
     judges: [accepts, grounded],
   })
   const { extensions } = kit({ log: targetLog })
-  const scope = createScope({ extensions, tags: [box] })
+  const scope = createScope({ extensions, tags: [local] })
   const ctx = scope.createContext()
   const report = await runEval(ctx, evaluation)
   await ctx.close()

--- a/examples/agent-practical/src/agent.ts
+++ b/examples/agent-practical/src/agent.ts
@@ -1,0 +1,190 @@
+import { createScope, flow, tags, typed } from "@pumped-fn/lite"
+import {
+  agent,
+  events,
+  http,
+  includes,
+  inspect,
+  judge,
+  runEval,
+  sandbox,
+  schedule,
+  session,
+  send,
+  skill,
+  sub,
+  suite,
+  summary,
+  tool,
+  turn,
+  used,
+  workflowRun,
+  type Model,
+  type RunLog,
+  type Sandbox,
+} from "@pumped-fn/agent-sdk"
+import { kit } from "@pumped-fn/agent-sdk-test"
+
+const loadTicket = tool({
+  description: "Load ticket details.",
+  flow: flow({
+    name: "load-ticket",
+    parse: typed<{ id: string }>(),
+    factory: (ctx) => ({ id: ctx.input.id, title: `ticket:${ctx.input.id}` }),
+  }),
+})
+
+const readWorkspace = tool({
+  description: "Read a workspace file.",
+  flow: flow({
+    name: "read-workspace",
+    parse: typed<{ path: string }>(),
+    deps: { sandbox: tags.required(sandbox) },
+    factory: (ctx, deps) => deps.sandbox.readFile(ctx.input.path),
+  }),
+})
+
+const summarizeModel: Model = {
+  complete: (_ctx, request) => ({
+    content: `summary:${request.messages.at(-1)?.content ?? ""}`,
+    stop: true,
+  }),
+}
+
+const summarize = agent({
+  name: "summarize",
+  model: summarizeModel,
+})
+
+export function triage(model: Model) {
+  return agent({
+    name: "triage",
+    model,
+    instructions: "Triage support tickets with tools, skills, and delegated summaries.",
+    skills: [
+      skill({
+        name: "policy",
+        description: "Ticket routing policy.",
+        content: "Escalate unclear incidents.",
+      }),
+    ],
+    tools: [loadTicket, readWorkspace],
+    subagents: [
+      sub({
+        description: "Summarizes ticket context.",
+        agent: summarize,
+      }),
+    ],
+  })
+}
+
+export const model: Model = {
+  complete: (_ctx, request) => request.loadedSkills.length === 0
+    ? {
+        content: "loading policy",
+        skillCalls: [{ name: "policy" }],
+      }
+    : request.round === 1
+    ? {
+        content: "checking",
+        toolCalls: [
+          { name: "load-ticket", input: { id: "42" } },
+          { name: "read-workspace", input: { path: "README.md" } },
+        ],
+        subagentCalls: [{ name: "summarize", input: { prompt: "ticket 42" } }],
+      }
+    : {
+        content: `ready:${request.messages.filter((message) => message.role !== "assistant").map((message) => message.content).join("|")}`,
+        stop: true,
+      },
+}
+
+export const box: Sandbox = {
+  readFile: (path) => `file:${path}`,
+  writeFile: () => undefined,
+  exec: (command, args = []) => ({
+    stdout: [command, ...args].join(" "),
+    stderr: "",
+    exitCode: 0,
+  }),
+}
+
+export async function runLocal() {
+  const target = triage(model)
+  const { extensions, log } = kit()
+  const scope = createScope({
+    extensions,
+    tags: [sandbox(box)],
+  })
+  const ctx = scope.createContext({
+    tags: [workflowRun({ taskId: "ticket-42", runId: "run-1" })],
+  })
+  const result = await turn(ctx, target, { prompt: "triage ticket 42" })
+  const trace = await ctx.resolve(events)
+  const run = await inspect(log, { taskId: "ticket-42", runId: "run-1" })
+  await ctx.close()
+  await scope.dispose()
+  return { result, trace: trace.events, run }
+}
+
+export async function runThread() {
+  const target = triage(model)
+  const scope = createScope({ tags: [sandbox(box)] })
+  const ctx = scope.createContext()
+  const thread = session("support-thread")
+  await send(ctx, thread, target, { prompt: "one" })
+  const result = await send(ctx, thread, target, { prompt: "two" })
+  const state = ctx.scope.controller(thread).get().state
+  await ctx.close()
+  await scope.dispose()
+  return { result, state }
+}
+
+export async function runHttp() {
+  const scope = createScope({ tags: [sandbox(box)] })
+  const handle = http({ scope, agent: triage(model) })
+  const response = await handle(new Request("https://agent.local/run", {
+    method: "POST",
+    body: JSON.stringify({ prompt: "triage ticket 42" }),
+  }))
+  const body = await response.json()
+  await scope.dispose()
+  return body
+}
+
+export async function runSuite(targetLog?: RunLog) {
+  const target = triage(model)
+  const accepts = judge({
+    name: "accepts",
+    evaluate: () => ({ name: "accepts", passed: true, score: 1 }),
+  })
+  const grounded = judge({
+    name: "grounded",
+    evaluate: () => ({ name: "grounded", passed: true, score: 1 }),
+  })
+  const evaluation = suite({
+    name: "triage",
+    agent: target,
+    cases: [
+      {
+        name: "uses tools and answers",
+        input: { prompt: "triage ticket 42" },
+        checks: [used("load-ticket"), includes("ready")],
+      },
+    ],
+    judges: [accepts, grounded],
+  })
+  const { extensions } = kit({ log: targetLog })
+  const scope = createScope({ extensions, tags: [sandbox(box)] })
+  const ctx = scope.createContext()
+  const report = await runEval(ctx, evaluation)
+  await ctx.close()
+  await scope.dispose()
+  return summary(report)
+}
+
+export const daily = schedule({
+  name: "daily-triage",
+  agent: triage(model),
+  input: () => ({ prompt: "triage daily queue" }),
+})

--- a/examples/agent-practical/src/agent.ts
+++ b/examples/agent-practical/src/agent.ts
@@ -1,4 +1,7 @@
 import { createScope, flow, tags, typed } from "@pumped-fn/lite"
+import { claude, type ClaudeOptions } from "@pumped-fn/agent-sdk-claude"
+import { codex, type CodexOptions } from "@pumped-fn/agent-sdk-codex"
+import { sandbox as bash } from "@pumped-fn/agent-sdk-just-bash"
 import {
   agent,
   events,
@@ -43,42 +46,36 @@ const readWorkspace = tool({
   }),
 })
 
-const summarizeModel: Model = {
-  complete: (_ctx, request) => ({
-    content: `summary:${request.messages.at(-1)?.content ?? ""}`,
-    stop: true,
-  }),
-}
-
 const summarize = agent({
   name: "summarize",
-  tags: [agentModel(summarizeModel)],
 })
 
-export function triage(provider: Model) {
-  return agent({
-    name: "triage",
-    tags: [agentModel(provider)],
-    instructions: "Triage support tickets with tools, skills, and delegated summaries.",
-    skills: [
-      skill({
-        name: "policy",
-        description: "Ticket routing policy.",
-        content: "Escalate unclear incidents.",
-      }),
-    ],
-    tools: [loadTicket, readWorkspace],
-    subagents: [
-      sub({
-        description: "Summarizes ticket context.",
-        agent: summarize,
-      }),
-    ],
-  })
-}
+export const triage = agent({
+  name: "triage",
+  instructions: "Triage support tickets with tools, skills, and delegated summaries.",
+  skills: [
+    skill({
+      name: "policy",
+      description: "Ticket routing policy.",
+      content: "Escalate unclear incidents.",
+    }),
+  ],
+  tools: [loadTicket, readWorkspace],
+  subagents: [
+    sub({
+      description: "Summarizes ticket context.",
+      agent: summarize,
+    }),
+  ],
+})
 
 export const model: Model = {
-  complete: (_ctx, request) => request.loadedSkills.length === 0
+  complete: (_ctx, request) => request.agentName === "summarize"
+    ? {
+        content: `summary:${request.messages.at(-1)?.content ?? ""}`,
+        stop: true,
+      }
+    : request.loadedSkills.length === 0
     ? {
         content: "loading policy",
         skillCalls: [{ name: "policy" }],
@@ -108,18 +105,26 @@ export const local = sandbox({
   }),
 })
 
-export async function runLocal() {
-  const target = triage(model)
+export const workspace = bash({
+  options: {
+    files: {
+      "/workspace/README.md": "file:README.md",
+    },
+    cwd: "/workspace",
+  },
+})
+
+export async function runLocal(provider = agentModel(model), environment = local) {
   const { extensions, log } = kit()
   const scope = createScope({
     extensions,
-    tags: [local],
+    tags: [environment, provider],
   })
   const ctx = scope.createContext({
     tags: [workflowRun({ taskId: "ticket-42", runId: "run-1" })],
   })
   const result = await ctx.exec({
-    flow: target.turn,
+    flow: triage.turn,
     input: { prompt: "triage ticket 42" },
   })
   const trace = await ctx.resolve(events)
@@ -129,23 +134,30 @@ export async function runLocal() {
   return { result, trace: trace.events, run }
 }
 
-export async function runThread() {
-  const target = triage(model)
-  const scope = createScope({ tags: [local] })
+export function runCodex(options: CodexOptions = {}) {
+  return runLocal(codex(options), workspace)
+}
+
+export function runClaude(options: ClaudeOptions = {}) {
+  return runLocal(claude(options), workspace)
+}
+
+export async function runThread(provider = agentModel(model), environment = local) {
+  const scope = createScope({ tags: [environment, provider] })
   const ctx = scope.createContext()
   const thread = session("support-thread")
-  await send(ctx, thread, target, { prompt: "one" })
-  const result = await send(ctx, thread, target, { prompt: "two" })
+  await send(ctx, thread, triage, { prompt: "one" })
+  const result = await send(ctx, thread, triage, { prompt: "two" })
   const state = ctx.scope.controller(thread).get().state
   await ctx.close()
   await scope.dispose()
   return { result, state }
 }
 
-export async function runHttp() {
-  const scope = createScope({ tags: [local] })
+export async function runHttp(provider = agentModel(model), environment = local) {
+  const scope = createScope({ tags: [environment, provider] })
   const ctx = scope.createContext()
-  const handle = http({ agent: triage(model) })
+  const handle = http({ agent: triage })
   const response = await ctx.exec({
     flow: handle,
     input: new Request("https://agent.local/run", {
@@ -159,8 +171,7 @@ export async function runHttp() {
   return body
 }
 
-export async function runSuite(targetLog?: RunLog) {
-  const target = triage(model)
+export async function runSuite(targetLog?: RunLog, provider = agentModel(model), environment = local) {
   const accepts = judge({
     name: "accepts",
     evaluate: () => ({ name: "accepts", passed: true, score: 1 }),
@@ -171,7 +182,7 @@ export async function runSuite(targetLog?: RunLog) {
   })
   const evaluation = suite({
     name: "triage",
-    agent: target,
+    agent: triage,
     cases: [
       {
         name: "uses tools and answers",
@@ -182,7 +193,7 @@ export async function runSuite(targetLog?: RunLog) {
     judges: [accepts, grounded],
   })
   const { extensions } = kit({ log: targetLog })
-  const scope = createScope({ extensions, tags: [local] })
+  const scope = createScope({ extensions, tags: [environment, provider] })
   const ctx = scope.createContext()
   const report = await runEval(ctx, evaluation)
   await ctx.close()
@@ -192,6 +203,6 @@ export async function runSuite(targetLog?: RunLog) {
 
 export const daily = schedule({
   name: "daily-triage",
-  agent: triage(model),
+  agent: triage,
   input: () => ({ prompt: "triage daily queue" }),
 })

--- a/examples/agent-practical/src/agent.ts
+++ b/examples/agent-practical/src/agent.ts
@@ -17,12 +17,10 @@ import {
   suite,
   summary,
   tool,
-  turn,
   used,
   workflowRun,
   type Model,
   type RunLog,
-  type Sandbox,
 } from "@pumped-fn/agent-sdk"
 import { kit } from "@pumped-fn/agent-sdk-test"
 
@@ -100,7 +98,7 @@ export const model: Model = {
       },
 }
 
-export const box: Sandbox = {
+export const box = sandbox({
   readFile: (path) => `file:${path}`,
   writeFile: () => undefined,
   exec: (command, args = []) => ({
@@ -108,19 +106,22 @@ export const box: Sandbox = {
     stderr: "",
     exitCode: 0,
   }),
-}
+})
 
 export async function runLocal() {
   const target = triage(model)
   const { extensions, log } = kit()
   const scope = createScope({
     extensions,
-    tags: [sandbox(box)],
+    tags: [box],
   })
   const ctx = scope.createContext({
     tags: [workflowRun({ taskId: "ticket-42", runId: "run-1" })],
   })
-  const result = await turn(ctx, target, { prompt: "triage ticket 42" })
+  const result = await ctx.exec({
+    flow: target.turn,
+    input: { prompt: "triage ticket 42" },
+  })
   const trace = await ctx.resolve(events)
   const run = await inspect(log, { taskId: "ticket-42", runId: "run-1" })
   await ctx.close()
@@ -130,7 +131,7 @@ export async function runLocal() {
 
 export async function runThread() {
   const target = triage(model)
-  const scope = createScope({ tags: [sandbox(box)] })
+  const scope = createScope({ tags: [box] })
   const ctx = scope.createContext()
   const thread = session("support-thread")
   await send(ctx, thread, target, { prompt: "one" })
@@ -142,7 +143,7 @@ export async function runThread() {
 }
 
 export async function runHttp() {
-  const scope = createScope({ tags: [sandbox(box)] })
+  const scope = createScope({ tags: [box] })
   const ctx = scope.createContext()
   const handle = http({ agent: triage(model) })
   const response = await ctx.exec({
@@ -181,7 +182,7 @@ export async function runSuite(targetLog?: RunLog) {
     judges: [accepts, grounded],
   })
   const { extensions } = kit({ log: targetLog })
-  const scope = createScope({ extensions, tags: [sandbox(box)] })
+  const scope = createScope({ extensions, tags: [box] })
   const ctx = scope.createContext()
   const report = await runEval(ctx, evaluation)
   await ctx.close()

--- a/examples/agent-practical/src/agent.ts
+++ b/examples/agent-practical/src/agent.ts
@@ -142,12 +142,17 @@ export async function runThread() {
 
 export async function runHttp() {
   const scope = createScope({ tags: [sandbox(box)] })
-  const handle = http({ scope, agent: triage(model) })
-  const response = await handle(new Request("https://agent.local/run", {
-    method: "POST",
-    body: JSON.stringify({ prompt: "triage ticket 42" }),
-  }))
+  const ctx = scope.createContext()
+  const handle = http({ agent: triage(model) })
+  const response = await ctx.exec({
+    flow: handle,
+    input: new Request("https://agent.local/run", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "triage ticket 42" }),
+    }),
+  })
   const body = await response.json()
+  await ctx.close()
   await scope.dispose()
   return body
 }

--- a/examples/agent-practical/tests/agent.test.ts
+++ b/examples/agent-practical/tests/agent.test.ts
@@ -1,6 +1,37 @@
 import { createScope } from "@pumped-fn/lite"
+import { model as agentModel } from "@pumped-fn/agent-sdk"
 import { expect, it } from "vitest"
-import { daily, local, runHttp, runLocal, runSuite, runThread } from "../src/agent"
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { daily, local, model, runClaude, runCodex, runHttp, runLocal, runSuite, runThread } from "../src/agent"
+
+async function modelCommand() {
+  const dir = await mkdtemp(join(tmpdir(), "pumped-fn-agent-model-"))
+  const command = join(dir, "model")
+  await writeFile(command, `#!/bin/sh
+for last do :; done
+case "$last" in
+  *"Agent: summarize"*)
+    printf '%s' '{"content":"summary:ticket 42","stop":true}'
+    ;;
+  *"Round: 0"*)
+    printf '%s' '{"content":"loading policy","skillCalls":[{"name":"policy"}],"stop":false}'
+    ;;
+  *"Round: 1"*)
+    printf '%s' '{"content":"checking","toolCalls":[{"name":"load-ticket","input":{"id":"42"}},{"name":"read-workspace","input":{"path":"README.md"}}],"subagentCalls":[{"name":"summarize","input":{"prompt":"ticket 42"}}],"stop":false}'
+    ;;
+  *)
+    printf '%s' '{"content":"ready:external provider","stop":true}'
+    ;;
+esac
+`)
+  await chmod(command, 0o755)
+  return {
+    command,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  }
+}
 
 it("runs locally with trace and run inspection", async () => {
   const run = await runLocal()
@@ -50,8 +81,33 @@ it("writes json-safe eval reports", async () => {
   })
 })
 
+it("runs through the Codex provider package with a just-bash workspace", async () => {
+  const command = await modelCommand()
+  const run = await runCodex({ command: command.command, isolate: false, guard: false })
+
+  expect(run.result.content).toBe("ready:external provider")
+  expect(run.result.toolResults.map((call) => call.output)).toEqual([
+    { id: "42", title: "ticket:42" },
+    "file:README.md",
+  ])
+  expect(run.result.subagentResults[0]?.output.content).toBe("summary:ticket 42")
+
+  await command.cleanup()
+})
+
+it("runs through the Claude provider package with a just-bash workspace", async () => {
+  const command = await modelCommand()
+  const run = await runClaude({ command: command.command, isolate: false, guard: false })
+
+  expect(run.result.content).toBe("ready:external provider")
+  expect(run.result.toolResults.map((call) => call.name)).toEqual(["load-ticket", "read-workspace"])
+  expect(run.result.skillResults.map((call) => call.name)).toEqual(["policy"])
+
+  await command.cleanup()
+})
+
 it("runs schedule adapters through the same scope seam", async () => {
-  const scope = createScope({ tags: [local] })
+  const scope = createScope({ tags: [local, agentModel(model)] })
   const ctx = scope.createContext()
 
   await expect(ctx.exec({ flow: daily })).resolves.toMatchObject({

--- a/examples/agent-practical/tests/agent.test.ts
+++ b/examples/agent-practical/tests/agent.test.ts
@@ -1,6 +1,6 @@
 import { createScope } from "@pumped-fn/lite"
 import { expect, it } from "vitest"
-import { box, daily, runHttp, runLocal, runSuite, runThread } from "../src/agent"
+import { daily, local, runHttp, runLocal, runSuite, runThread } from "../src/agent"
 
 it("runs locally with trace and run inspection", async () => {
   const run = await runLocal()
@@ -51,7 +51,7 @@ it("writes json-safe eval reports", async () => {
 })
 
 it("runs schedule adapters through the same scope seam", async () => {
-  const scope = createScope({ tags: [box] })
+  const scope = createScope({ tags: [local] })
   const ctx = scope.createContext()
 
   await expect(ctx.exec({ flow: daily })).resolves.toMatchObject({

--- a/examples/agent-practical/tests/agent.test.ts
+++ b/examples/agent-practical/tests/agent.test.ts
@@ -1,0 +1,65 @@
+import { createScope } from "@pumped-fn/lite"
+import { expect, it } from "vitest"
+import { sandbox } from "@pumped-fn/agent-sdk"
+import { box, daily, runHttp, runLocal, runSuite, runThread } from "../src/agent"
+
+it("runs locally with trace and run inspection", async () => {
+  const run = await runLocal()
+
+  expect(run.result.content).toContain("ready:")
+  expect(run.result.toolResults.map((call) => call.name)).toEqual(["load-ticket", "read-workspace"])
+  expect(run.trace.map((event) => event.type)).toContain("agent_tool_end")
+  expect(run.run.status).toBe("completed")
+  expect(run.run.steps.map((step) => step.targetName)).toContain("triage")
+})
+
+it("serves the same agent through fetch", async () => {
+  await expect(runHttp()).resolves.toMatchObject({
+    agentName: "triage",
+    content: expect.stringContaining("ready:"),
+  })
+})
+
+it("stores a continuing session", async () => {
+  const thread = await runThread()
+
+  expect(thread.state.messages.map((message) => message.content)).toEqual([
+    "one",
+    "loading policy",
+    "Escalate unclear incidents.",
+    "checking",
+    '{"id":"42","title":"ticket:42"}',
+    "file:README.md",
+    "summary:ticket 42",
+    expect.stringContaining("ready:"),
+    "two",
+    "loading policy",
+    "Escalate unclear incidents.",
+    "checking",
+    '{"id":"42","title":"ticket:42"}',
+    "file:README.md",
+    "summary:ticket 42",
+    expect.stringContaining("ready:"),
+  ])
+})
+
+it("writes json-safe eval reports", async () => {
+  await expect(runSuite()).resolves.toMatchObject({
+    name: "triage",
+    passed: true,
+    cases: [{ name: "uses tools and answers", passed: true }],
+  })
+})
+
+it("runs schedule adapters through the same scope seam", async () => {
+  const scope = createScope({ tags: [sandbox(box)] })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({ flow: daily })).resolves.toMatchObject({
+    agentName: "triage",
+    content: expect.stringContaining("ready:"),
+  })
+
+  await ctx.close()
+  await scope.dispose()
+})

--- a/examples/agent-practical/tests/agent.test.ts
+++ b/examples/agent-practical/tests/agent.test.ts
@@ -1,6 +1,5 @@
 import { createScope } from "@pumped-fn/lite"
 import { expect, it } from "vitest"
-import { sandbox } from "@pumped-fn/agent-sdk"
 import { box, daily, runHttp, runLocal, runSuite, runThread } from "../src/agent"
 
 it("runs locally with trace and run inspection", async () => {
@@ -52,7 +51,7 @@ it("writes json-safe eval reports", async () => {
 })
 
 it("runs schedule adapters through the same scope seam", async () => {
-  const scope = createScope({ tags: [sandbox(box)] })
+  const scope = createScope({ tags: [box] })
   const ctx = scope.createContext()
 
   await expect(ctx.exec({ flow: daily })).resolves.toMatchObject({

--- a/examples/agent-practical/tsconfig.json
+++ b/examples/agent-practical/tsconfig.json
@@ -14,6 +14,9 @@
     "typeRoots": ["./node_modules/@types", "../../packages/lite/node_modules/@types"],
     "paths": {
       "@pumped-fn/agent-sdk": ["../../packages/agent-sdk/src/index.ts"],
+      "@pumped-fn/agent-sdk-claude": ["../../packages/agent-sdk-claude/src/index.ts"],
+      "@pumped-fn/agent-sdk-codex": ["../../packages/agent-sdk-codex/src/index.ts"],
+      "@pumped-fn/agent-sdk-just-bash": ["../../packages/agent-sdk-just-bash/src/index.ts"],
       "@pumped-fn/agent-sdk-test": ["../../packages/agent-sdk-test/src/index.ts"],
       "@pumped-fn/lite-extension-suspense": ["../../packages/lite-extension-suspense/src/index.ts"],
       "@pumped-fn/lite": ["../../packages/lite/src/index.ts"]

--- a/examples/agent-practical/tsconfig.json
+++ b/examples/agent-practical/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "typeRoots": ["./node_modules/@types", "../../packages/lite/node_modules/@types"],
+    "paths": {
+      "@pumped-fn/agent-sdk": ["../../packages/agent-sdk/src/index.ts"],
+      "@pumped-fn/agent-sdk-test": ["../../packages/agent-sdk-test/src/index.ts"],
+      "@pumped-fn/lite-extension-suspense": ["../../packages/lite-extension-suspense/src/index.ts"],
+      "@pumped-fn/lite": ["../../packages/lite/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/examples/agent-practical/vitest.config.ts
+++ b/examples/agent-practical/vitest.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
   resolve: {
     alias: {
       "@pumped-fn/agent-sdk": fileURLToPath(new URL("../../packages/agent-sdk/src/index.ts", import.meta.url)),
+      "@pumped-fn/agent-sdk-claude": fileURLToPath(new URL("../../packages/agent-sdk-claude/src/index.ts", import.meta.url)),
+      "@pumped-fn/agent-sdk-codex": fileURLToPath(new URL("../../packages/agent-sdk-codex/src/index.ts", import.meta.url)),
+      "@pumped-fn/agent-sdk-just-bash": fileURLToPath(new URL("../../packages/agent-sdk-just-bash/src/index.ts", import.meta.url)),
       "@pumped-fn/agent-sdk-test": fileURLToPath(new URL("../../packages/agent-sdk-test/src/index.ts", import.meta.url)),
       "@pumped-fn/lite-extension-suspense": fileURLToPath(new URL("../../packages/lite-extension-suspense/src/index.ts", import.meta.url)),
       "@pumped-fn/lite": fileURLToPath(new URL("../../packages/lite/src/index.ts", import.meta.url)),

--- a/examples/agent-practical/vitest.config.ts
+++ b/examples/agent-practical/vitest.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from "node:url"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@pumped-fn/agent-sdk": fileURLToPath(new URL("../../packages/agent-sdk/src/index.ts", import.meta.url)),
+      "@pumped-fn/agent-sdk-test": fileURLToPath(new URL("../../packages/agent-sdk-test/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite-extension-suspense": fileURLToPath(new URL("../../packages/lite-extension-suspense/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite": fileURLToPath(new URL("../../packages/lite/src/index.ts", import.meta.url)),
+    },
+  },
+})

--- a/examples/lite-react-practical/vitest.config.ts
+++ b/examples/lite-react-practical/vitest.config.ts
@@ -2,6 +2,16 @@ import { playwright } from "@vitest/browser-playwright"
 import { configDefaults, defineConfig } from "vitest/config"
 
 export default defineConfig({
+  optimizeDeps: {
+    include: [
+      "@testing-library/jest-dom/vitest",
+      "@testing-library/react",
+      "react",
+      "react-dom/client",
+      "react/jsx-dev-runtime",
+      "react/jsx-runtime",
+    ],
+  },
   test: {
     projects: [
       {

--- a/packages/agent-sdk-claude/LICENSE
+++ b/packages/agent-sdk-claude/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pumped-fn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-sdk-claude/README.md
+++ b/packages/agent-sdk-claude/README.md
@@ -1,0 +1,17 @@
+# @pumped-fn/agent-sdk-claude
+
+Claude CLI model provider for `@pumped-fn/agent-sdk`.
+
+```ts
+import { createScope } from "@pumped-fn/lite"
+import { agent } from "@pumped-fn/agent-sdk"
+import { claude } from "@pumped-fn/agent-sdk-claude"
+
+const triage = agent({ name: "triage" })
+const scope = createScope({ tags: [claude()] })
+const ctx = scope.createContext()
+
+await ctx.exec({ flow: triage.turn, input: { prompt: "Triage this ticket." } })
+```
+
+`claude()` returns a lazy `model` tag. The Claude harness is created only when the model is first used, and the agent can be run with `codex()` or `model(fake)` instead without changing the graph.

--- a/packages/agent-sdk-claude/package.json
+++ b/packages/agent-sdk-claude/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@pumped-fn/agent-sdk-claude",
+  "version": "1.0.0",
+  "private": false,
+  "description": "Claude CLI model provider for @pumped-fn/agent-sdk",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown --config-loader tsx",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@pumped-fn/agent-sdk": "^1.0.0",
+    "@pumped-fn/lite": "^3.1.0"
+  },
+  "devDependencies": {
+    "@pumped-fn/agent-sdk": "workspace:*",
+    "@pumped-fn/lite": "workspace:*",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "directory": "packages/agent-sdk-claude",
+    "url": "git+https://github.com/pumped-fn/pumped-fn.git"
+  }
+}

--- a/packages/agent-sdk-claude/src/index.ts
+++ b/packages/agent-sdk-claude/src/index.ts
@@ -1,0 +1,20 @@
+import { claudeHarness, model, type CliHarnessOptions, type Model } from "@pumped-fn/agent-sdk"
+import type { Lite } from "@pumped-fn/lite"
+
+export type ClaudeOptions = CliHarnessOptions
+
+export function claude(options: ClaudeOptions = {}): Lite.Tagged<Model> {
+  return model(lazyModel(() => claudeHarness(options)))
+}
+
+function lazyModel(create: () => Model): Model {
+  let target: Model | undefined
+  return {
+    complete(ctx, request) {
+      target ??= create()
+      return target.complete(ctx, request)
+    },
+  }
+}
+
+export { claudeCliWorker, claudeHarness, type ClaudeCliWorkerOptions, type CliHarnessOptions } from "@pumped-fn/agent-sdk"

--- a/packages/agent-sdk-claude/tests/claude.test.ts
+++ b/packages/agent-sdk-claude/tests/claude.test.ts
@@ -1,0 +1,79 @@
+import { createScope } from "@pumped-fn/lite"
+import { agent, model, type Model } from "@pumped-fn/agent-sdk"
+import { expect, it } from "vitest"
+import { claude } from "../src/index"
+
+it("provides Claude through a lazy agent model tag", async () => {
+  const target = agent({ name: "planner" })
+  const scope = createScope({
+    tags: [
+      claude({
+        command: "echo",
+        isolate: false,
+        prompt: (request) => `provider=claude agent=${request.agentName}`,
+      }),
+    ],
+  })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({
+    flow: target.turn,
+    input: { prompt: "plan" },
+  })).resolves.toMatchObject({
+    content: "-p --no-session-persistence -- provider=claude agent=planner",
+  })
+
+  await ctx.close()
+  await scope.dispose()
+})
+
+it("defers Claude harness validation until the model is used", async () => {
+  const target = agent({ name: "planner" })
+  const scope = createScope({
+    tags: [claude({ command: "echo", isolate: false, extraArgs: ["--bare"] })],
+  })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({
+    flow: target.turn,
+    input: { prompt: "plan" },
+  })).rejects.toThrow("Claude harness must not use --bare")
+
+  await ctx.close({ ok: false, error: new Error("expected") })
+  await scope.dispose()
+})
+
+it("can be replaced per execution context without rebuilding the agent", async () => {
+  const target = agent({ name: "planner" })
+  const replacement: Model = {
+    complete: () => ({ content: "provider=fake", stop: true }),
+  }
+  const scope = createScope({
+    tags: [
+      claude({
+        command: "echo",
+        isolate: false,
+        prompt: () => "provider=claude",
+      }),
+    ],
+  })
+  const claudeCtx = scope.createContext()
+  const fakeCtx = scope.createContext({ tags: [model(replacement)] })
+
+  await expect(claudeCtx.exec({
+    flow: target.turn,
+    input: { prompt: "plan" },
+  })).resolves.toMatchObject({
+    content: "-p --no-session-persistence -- provider=claude",
+  })
+  await expect(fakeCtx.exec({
+    flow: target.turn,
+    input: { prompt: "plan" },
+  })).resolves.toMatchObject({
+    content: "provider=fake",
+  })
+
+  await claudeCtx.close()
+  await fakeCtx.close()
+  await scope.dispose()
+})

--- a/packages/agent-sdk-claude/tsconfig.json
+++ b/packages/agent-sdk-claude/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "..",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "typeRoots": ["./node_modules/@types", "../lite/node_modules/@types"],
+    "paths": {
+      "@pumped-fn/agent-sdk": ["../agent-sdk/src/index.ts"],
+      "@pumped-fn/lite-extension-suspense": ["../lite-extension-suspense/src/index.ts"],
+      "@pumped-fn/lite": ["../lite/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/agent-sdk-claude/tsdown.config.ts
+++ b/packages/agent-sdk-claude/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  format: ["cjs", "esm"],
+  clean: true,
+});

--- a/packages/agent-sdk-claude/vitest.config.ts
+++ b/packages/agent-sdk-claude/vitest.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@pumped-fn/agent-sdk": fileURLToPath(new URL("../agent-sdk/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite-extension-suspense": fileURLToPath(new URL("../lite-extension-suspense/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite": fileURLToPath(new URL("../lite/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/packages/agent-sdk-codex/LICENSE
+++ b/packages/agent-sdk-codex/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pumped-fn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-sdk-codex/README.md
+++ b/packages/agent-sdk-codex/README.md
@@ -1,0 +1,17 @@
+# @pumped-fn/agent-sdk-codex
+
+Codex CLI model provider for `@pumped-fn/agent-sdk`.
+
+```ts
+import { createScope } from "@pumped-fn/lite"
+import { agent } from "@pumped-fn/agent-sdk"
+import { codex } from "@pumped-fn/agent-sdk-codex"
+
+const triage = agent({ name: "triage" })
+const scope = createScope({ tags: [codex()] })
+const ctx = scope.createContext()
+
+await ctx.exec({ flow: triage.turn, input: { prompt: "Triage this ticket." } })
+```
+
+`codex()` returns a lazy `model` tag. The Codex harness is created only when the model is first used, and the agent can be run with `claude()` or `model(fake)` instead without changing the graph.

--- a/packages/agent-sdk-codex/package.json
+++ b/packages/agent-sdk-codex/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@pumped-fn/agent-sdk-codex",
+  "version": "1.0.0",
+  "private": false,
+  "description": "Codex CLI model provider for @pumped-fn/agent-sdk",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown --config-loader tsx",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@pumped-fn/agent-sdk": "^1.0.0",
+    "@pumped-fn/lite": "^3.1.0"
+  },
+  "devDependencies": {
+    "@pumped-fn/agent-sdk": "workspace:*",
+    "@pumped-fn/lite": "workspace:*",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "directory": "packages/agent-sdk-codex",
+    "url": "git+https://github.com/pumped-fn/pumped-fn.git"
+  }
+}

--- a/packages/agent-sdk-codex/src/index.ts
+++ b/packages/agent-sdk-codex/src/index.ts
@@ -1,0 +1,20 @@
+import { codexHarness, model, type CodexHarnessOptions, type Model } from "@pumped-fn/agent-sdk"
+import type { Lite } from "@pumped-fn/lite"
+
+export type CodexOptions = CodexHarnessOptions
+
+export function codex(options: CodexOptions = {}): Lite.Tagged<Model> {
+  return model(lazyModel(() => codexHarness(options)))
+}
+
+function lazyModel(create: () => Model): Model {
+  let target: Model | undefined
+  return {
+    complete(ctx, request) {
+      target ??= create()
+      return target.complete(ctx, request)
+    },
+  }
+}
+
+export { codexCliWorker, codexHarness, type CodexCliWorkerOptions, type CodexHarnessOptions } from "@pumped-fn/agent-sdk"

--- a/packages/agent-sdk-codex/tests/codex.test.ts
+++ b/packages/agent-sdk-codex/tests/codex.test.ts
@@ -1,0 +1,63 @@
+import { createScope } from "@pumped-fn/lite"
+import { agent, model, type Model } from "@pumped-fn/agent-sdk"
+import { expect, it } from "vitest"
+import { codex } from "../src/index"
+
+it("provides Codex through a lazy agent model tag", async () => {
+  const target = agent({ name: "review" })
+  const scope = createScope({
+    tags: [
+      codex({
+        command: "echo",
+        isolate: false,
+        prompt: (request) => `provider=codex agent=${request.agentName}`,
+      }),
+    ],
+  })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({
+    flow: target.turn,
+    input: { prompt: "check" },
+  })).resolves.toMatchObject({
+    content: "exec -s read-only --ephemeral --ignore-user-config -- provider=codex agent=review",
+  })
+
+  await ctx.close()
+  await scope.dispose()
+})
+
+it("can be replaced per execution context without rebuilding the agent", async () => {
+  const target = agent({ name: "review" })
+  const replacement: Model = {
+    complete: () => ({ content: "provider=fake", stop: true }),
+  }
+  const scope = createScope({
+    tags: [
+      codex({
+        command: "echo",
+        isolate: false,
+        prompt: () => "provider=codex",
+      }),
+    ],
+  })
+  const codexCtx = scope.createContext()
+  const fakeCtx = scope.createContext({ tags: [model(replacement)] })
+
+  await expect(codexCtx.exec({
+    flow: target.turn,
+    input: { prompt: "check" },
+  })).resolves.toMatchObject({
+    content: "exec -s read-only --ephemeral --ignore-user-config -- provider=codex",
+  })
+  await expect(fakeCtx.exec({
+    flow: target.turn,
+    input: { prompt: "check" },
+  })).resolves.toMatchObject({
+    content: "provider=fake",
+  })
+
+  await codexCtx.close()
+  await fakeCtx.close()
+  await scope.dispose()
+})

--- a/packages/agent-sdk-codex/tsconfig.json
+++ b/packages/agent-sdk-codex/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "..",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "typeRoots": ["./node_modules/@types", "../lite/node_modules/@types"],
+    "paths": {
+      "@pumped-fn/agent-sdk": ["../agent-sdk/src/index.ts"],
+      "@pumped-fn/lite-extension-suspense": ["../lite-extension-suspense/src/index.ts"],
+      "@pumped-fn/lite": ["../lite/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/agent-sdk-codex/tsdown.config.ts
+++ b/packages/agent-sdk-codex/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  format: ["cjs", "esm"],
+  clean: true,
+});

--- a/packages/agent-sdk-codex/vitest.config.ts
+++ b/packages/agent-sdk-codex/vitest.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@pumped-fn/agent-sdk": fileURLToPath(new URL("../agent-sdk/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite-extension-suspense": fileURLToPath(new URL("../lite-extension-suspense/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite": fileURLToPath(new URL("../lite/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/packages/agent-sdk-just-bash/LICENSE
+++ b/packages/agent-sdk-just-bash/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pumped-fn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/agent-sdk-just-bash/README.md
+++ b/packages/agent-sdk-just-bash/README.md
@@ -1,0 +1,21 @@
+# @pumped-fn/agent-sdk-just-bash
+
+`just-bash` sandbox provider for `@pumped-fn/agent-sdk`.
+
+```ts
+import { createScope } from "@pumped-fn/lite"
+import { sandbox } from "@pumped-fn/agent-sdk-just-bash"
+
+const scope = createScope({
+  tags: [
+    sandbox({
+      options: {
+        files: { "/workspace/README.md": "ship it" },
+        cwd: "/workspace",
+      },
+    }),
+  ],
+})
+```
+
+`sandbox()` returns a lazy `agent.sandbox` tag. The `Bash` runtime is created only when a sandbox capability is first used, and the flow can be run with any other `agent-sdk` sandbox tag instead.

--- a/packages/agent-sdk-just-bash/package.json
+++ b/packages/agent-sdk-just-bash/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@pumped-fn/agent-sdk-just-bash",
+  "version": "1.0.0",
+  "private": false,
+  "description": "just-bash sandbox provider for @pumped-fn/agent-sdk",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown --config-loader tsx",
+    "typecheck": "tsgo --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@pumped-fn/agent-sdk": "^1.0.0",
+    "@pumped-fn/lite": "^3.1.0"
+  },
+  "dependencies": {
+    "just-bash": "catalog:"
+  },
+  "devDependencies": {
+    "@pumped-fn/agent-sdk": "workspace:*",
+    "@pumped-fn/lite": "workspace:*",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "directory": "packages/agent-sdk-just-bash",
+    "url": "git+https://github.com/pumped-fn/pumped-fn.git"
+  }
+}

--- a/packages/agent-sdk-just-bash/src/index.ts
+++ b/packages/agent-sdk-just-bash/src/index.ts
@@ -1,0 +1,47 @@
+import { Bash } from "just-bash"
+import { sandbox as agentSandbox, type Sandbox } from "@pumped-fn/agent-sdk"
+import type { Lite } from "@pumped-fn/lite"
+import { dirname } from "node:path/posix"
+
+export type BashOptions = ConstructorParameters<typeof Bash>[0]
+
+export interface JustBashOptions {
+  bash?: Bash
+  create?: () => Bash
+  options?: BashOptions
+}
+
+export function sandbox(options: JustBashOptions = {}): Lite.Tagged<Sandbox> {
+  return agentSandbox(createSandbox(options))
+}
+
+export function createSandbox(options: JustBashOptions = {}): Sandbox {
+  let bash: Bash | undefined
+  const run = () => {
+    bash ??= options.bash ?? options.create?.() ?? new Bash(options.options)
+    return bash
+  }
+  return {
+    async readFile(path) {
+      const result = await run().exec(`cat ${quote(path)}`)
+      if (result.exitCode !== 0) throw new Error(result.stderr.trim() || `readFile failed for ${path}`)
+      return result.stdout
+    },
+    async writeFile(path, content) {
+      const result = await run().exec(`mkdir -p ${quote(dirname(path))} && cat > ${quote(path)}`, { stdin: content })
+      if (result.exitCode !== 0) throw new Error(result.stderr.trim() || `writeFile failed for ${path}`)
+    },
+    async exec(command, args = []) {
+      const result = await run().exec([command, ...args].map(quote).join(" "))
+      return {
+        stdout: result.stdout,
+        stderr: result.stderr,
+        exitCode: result.exitCode,
+      }
+    },
+  }
+}
+
+function quote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}

--- a/packages/agent-sdk-just-bash/tests/just-bash.test.ts
+++ b/packages/agent-sdk-just-bash/tests/just-bash.test.ts
@@ -1,0 +1,90 @@
+import { Bash } from "just-bash"
+import { createScope, flow, tags, typed } from "@pumped-fn/lite"
+import { sandbox as agentSandbox } from "@pumped-fn/agent-sdk"
+import { expect, it } from "vitest"
+import { createSandbox, sandbox } from "../src/index"
+
+it("provides sandbox capabilities through a lazy agent sandbox tag", async () => {
+  const readPackage = flow({
+    name: "read-package",
+    parse: typed<{ path: string }>(),
+    deps: { sandbox: tags.required(agentSandbox) },
+    factory: (ctx, deps) => deps.sandbox.readFile(ctx.input.path),
+  })
+  const scope = createScope({
+    tags: [
+      sandbox({
+        options: {
+          files: {
+            "/workspace/package.json": "{\"name\":\"demo\"}\n",
+          },
+          cwd: "/workspace",
+        },
+      }),
+    ],
+  })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({
+    flow: readPackage,
+    input: { path: "package.json" },
+  })).resolves.toBe("{\"name\":\"demo\"}\n")
+
+  await ctx.close()
+  await scope.dispose()
+})
+
+it("does not create Bash until a sandbox capability is used", async () => {
+  let created = 0
+  const target = createSandbox({
+    create: () => {
+      created++
+      return new Bash({ files: { "/workspace/value.txt": "ready" }, cwd: "/workspace" })
+    },
+  })
+
+  expect(created).toBe(0)
+  await expect(target.readFile("value.txt")).resolves.toBe("ready")
+  expect(created).toBe(1)
+  await expect(target.exec("printf", ["ok"])).resolves.toMatchObject({ stdout: "ok" })
+  expect(created).toBe(1)
+})
+
+it("can be replaced per execution context without rebuilding flows", async () => {
+  const runCheck = flow({
+    name: "run-check",
+    parse: typed<{ command: string; args?: readonly string[] }>(),
+    deps: { sandbox: tags.required(agentSandbox) },
+    factory: async (ctx, deps) => (await deps.sandbox.exec(ctx.input.command, ctx.input.args)).stdout,
+  })
+  const scope = createScope({
+    tags: [
+      sandbox({
+        options: { cwd: "/workspace" },
+      }),
+    ],
+  })
+  const realCtx = scope.createContext()
+  const fakeCtx = scope.createContext({
+    tags: [
+      agentSandbox({
+        readFile: () => "",
+        writeFile: () => undefined,
+        exec: () => ({ stdout: "fake\n", stderr: "", exitCode: 0 }),
+      }),
+    ],
+  })
+
+  await expect(realCtx.exec({
+    flow: runCheck,
+    input: { command: "printf", args: ["real"] },
+  })).resolves.toBe("real")
+  await expect(fakeCtx.exec({
+    flow: runCheck,
+    input: { command: "printf", args: ["real"] },
+  })).resolves.toBe("fake\n")
+
+  await realCtx.close()
+  await fakeCtx.close()
+  await scope.dispose()
+})

--- a/packages/agent-sdk-just-bash/tsconfig.json
+++ b/packages/agent-sdk-just-bash/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "..",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "typeRoots": ["./node_modules/@types", "../lite/node_modules/@types"],
+    "paths": {
+      "@pumped-fn/agent-sdk": ["../agent-sdk/src/index.ts"],
+      "@pumped-fn/lite-extension-suspense": ["../lite-extension-suspense/src/index.ts"],
+      "@pumped-fn/lite": ["../lite/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/agent-sdk-just-bash/tsdown.config.ts
+++ b/packages/agent-sdk-just-bash/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  format: ["cjs", "esm"],
+  clean: true,
+});

--- a/packages/agent-sdk-just-bash/vitest.config.ts
+++ b/packages/agent-sdk-just-bash/vitest.config.ts
@@ -1,0 +1,12 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@pumped-fn/agent-sdk": fileURLToPath(new URL("../agent-sdk/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite-extension-suspense": fileURLToPath(new URL("../lite-extension-suspense/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite": fileURLToPath(new URL("../lite/src/index.ts", import.meta.url)),
+    },
+  },
+});

--- a/packages/agent-sdk-test/LICENSE
+++ b/packages/agent-sdk-test/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2025 Duke
+
+Permission is hereby granted, free of
+charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/agent-sdk-test/README.md
+++ b/packages/agent-sdk-test/README.md
@@ -1,0 +1,16 @@
+# @pumped-fn/agent-sdk-test
+
+In-memory test helpers for `@pumped-fn/agent-sdk`.
+
+Use `kit()` to install the agent workflow extensions with a `MemoryWorkflowLog`. The helper keeps the normal pumped-fn seam: tests still exercise public APIs through `createScope({ presets, tags, extensions })`.
+
+```ts
+import { createScope } from "@pumped-fn/lite"
+import { kit } from "@pumped-fn/agent-sdk-test"
+
+const { extensions, log } = kit()
+const scope = createScope({ extensions })
+const ctx = scope.createContext()
+```
+
+`localRemoteRunner` executes remote-tagged steps in process for tests. `MemoryWorkflowLog` implements the same `RunLog` contract used by `inspect()`.

--- a/packages/agent-sdk-test/examples/dev-workflow.ts
+++ b/packages/agent-sdk-test/examples/dev-workflow.ts
@@ -1,7 +1,7 @@
 import { createScope, flow, tags, typed } from "@pumped-fn/lite"
 import {
   SuspendSignal,
-  agent as agentRuntime,
+  runtime,
   workflowRun,
   step,
   workflow as workflowRuntime,
@@ -11,7 +11,7 @@ import {
 } from "@pumped-fn/agent-sdk"
 import {
   MemoryWorkflowLog,
-  agent as testAgent,
+  kit,
 } from "../src/index"
 
 export interface DevRequest {
@@ -109,12 +109,12 @@ export async function runDevWorkflow(
     ],
     deps: {
       workflow: tags.required(workflowRuntime),
-      agent: tags.required(agentRuntime),
+      runtime: tags.required(runtime),
       runFeatureTests,
       waitForProductReview,
     },
-    factory: async (ctx, { workflow, agent, runFeatureTests, waitForProductReview }): Promise<DevResult> => {
-      const patch = await agent.delegate<Patch, DevRequest>("implement-feature", ctx.input)
+    factory: async (ctx, { workflow, runtime, runFeatureTests, waitForProductReview }): Promise<DevResult> => {
+      const patch = await runtime.delegate<Patch, DevRequest>("implement-feature", ctx.input)
       const tests = await runFeatureTests.exec({ input: { patch } })
       const approval = await waitForProductReview.exec()
       return {
@@ -130,7 +130,7 @@ export async function runDevWorkflow(
   })
 
   const log = new MemoryWorkflowLog()
-  const { extensions } = testAgent({ log })
+  const { extensions } = kit({ log })
   const scope = createScope({ extensions })
   await scope.ready
 

--- a/packages/agent-sdk-test/package.json
+++ b/packages/agent-sdk-test/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pumped-fn/agent-sdk-test",
   "version": "1.0.0",
-  "private": true,
+  "private": false,
   "description": "In-memory test helpers for @pumped-fn/agent-sdk",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -20,7 +20,9 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "README.md",
+    "LICENSE"
   ],
   "publishConfig": {
     "access": "public"
@@ -33,10 +35,10 @@
   },
   "peerDependencies": {
     "@pumped-fn/agent-sdk": "^1.0.0",
-    "@pumped-fn/lite": "^3.0.0"
+    "@pumped-fn/lite": "^3.1.0"
   },
   "dependencies": {
-    "@pumped-fn/lite-extension-suspense": "workspace:*"
+    "@pumped-fn/lite-extension-suspense": "workspace:^"
   },
   "devDependencies": {
     "@pumped-fn/agent-sdk": "workspace:*",

--- a/packages/agent-sdk-test/src/index.ts
+++ b/packages/agent-sdk-test/src/index.ts
@@ -1,8 +1,10 @@
 import {
   extension as agentExtension,
   workflowExtension,
-  type AgentExtensionOptions,
-  type AgentRemoteRunner,
+  type ExtensionOptions,
+  type RemoteRunner,
+  type RunLog,
+  type RunQuery,
   type WorkflowEventLog,
   type WorkflowExtensionOptions,
 } from "@pumped-fn/agent-sdk"
@@ -42,15 +44,17 @@ export class MemorySuspenseLog implements SuspenseEventLog {
     })
   }
 
-  entries(): SuspenseStepEntry[] {
-    return [...this.store.values()]
+  entries(query: Partial<RunQuery> = {}): SuspenseStepEntry[] {
+    return [...this.store.values()].filter((entry) =>
+      (query.taskId === undefined || entry.key.taskId === query.taskId) &&
+      (query.runId === undefined || entry.key.runId === query.runId)
+    )
   }
 }
 
-export class MemoryWorkflowLog extends MemorySuspenseLog implements WorkflowEventLog {}
+export class MemoryWorkflowLog extends MemorySuspenseLog implements WorkflowEventLog, RunLog {}
 
-/** Test runner that executes remote-tagged steps in-process. */
-export const localRemoteRunner: AgentRemoteRunner = {
+export const localRemoteRunner: RemoteRunner = {
   run: (_event, next) => next(),
 }
 
@@ -67,9 +71,9 @@ export function suspense(
   }
 }
 
-export function agent(
-  options: AgentExtensionOptions & Omit<WorkflowExtensionOptions, "log"> & { log?: WorkflowEventLog } = {}
-): { extensions: Lite.Extension[]; log: WorkflowEventLog } {
+export function kit(
+  options: ExtensionOptions & Omit<WorkflowExtensionOptions, "log"> & { log?: RunLog } = {}
+): { extensions: Lite.Extension[]; log: RunLog } {
   const log = options.log ?? new MemoryWorkflowLog()
   return {
     log,

--- a/packages/agent-sdk-test/tests/agent-runtime.test.ts
+++ b/packages/agent-sdk-test/tests/agent-runtime.test.ts
@@ -458,17 +458,22 @@ describe("agent application runtime", () => {
       model,
     })
     const scope = createScope()
-    const handle = http({ scope, agent: target })
+    const ctx = scope.createContext()
+    const handle = http({ agent: target })
 
-    const response = await handle(new Request("https://agent.local/run", {
-      method: "POST",
-      body: JSON.stringify({ prompt: "ping" }),
-    }))
+    const response = await ctx.exec({
+      flow: handle,
+      input: new Request("https://agent.local/run", {
+        method: "POST",
+        body: JSON.stringify({ prompt: "ping" }),
+      }),
+    })
 
     await expect(response.json()).resolves.toMatchObject({
       agentName: "http-agent",
       content: "http:ping",
     })
+    await ctx.close()
     await scope.dispose()
   })
 

--- a/packages/agent-sdk-test/tests/agent-runtime.test.ts
+++ b/packages/agent-sdk-test/tests/agent-runtime.test.ts
@@ -1,0 +1,623 @@
+import { createScope, flow, tags, typed } from "@pumped-fn/lite"
+import { describe, expect, it } from "vitest"
+import {
+  events,
+  session,
+  channel,
+  agent,
+  http,
+  inspect,
+  suite,
+  judge,
+  schedule,
+  skill,
+  sub,
+  tool,
+  includes,
+  runEval,
+  summary,
+  turn,
+  send,
+  sandbox,
+  loaded,
+  step,
+  delegated,
+  used,
+  type Model,
+} from "@pumped-fn/agent-sdk"
+import { kit, MemoryWorkflowLog } from "../src/index"
+
+describe("agent application runtime", () => {
+  it("runs tools, subagents, and model rounds through one lite execution seam", async () => {
+    const lookup = tool({
+      description: "Loads a ticket title",
+      flow: flow({
+        name: "lookup-ticket",
+        parse: typed<{ id: string }>(),
+        factory: (ctx) => ({ id: ctx.input.id, title: `ticket:${ctx.input.id}` }),
+      }),
+    })
+    const summarizeModel: Model = {
+      complete: (_ctx, request) => ({
+        content: `summary:${request.messages.at(-1)?.content ?? ""}`,
+        stop: true,
+      }),
+    }
+    const summarize = agent({
+      name: "summarize-ticket",
+      instructions: "Summarize ticket context.",
+      model: summarizeModel,
+    })
+    const triageModel: Model = {
+      complete: (_ctx, request) => {
+        if (request.round === 0) {
+          return {
+            content: "checking",
+            toolCalls: [{ name: "lookup-ticket", input: { id: "42" } }],
+            subagentCalls: [{ name: "summarize-ticket", input: { prompt: "ticket 42" } }],
+          }
+        }
+        return {
+          content: `ready:${request.messages.map((message) => message.content).join("|")}`,
+          stop: true,
+        }
+      },
+    }
+    const triage = agent({
+      name: "triage-ticket",
+      instructions: "Triage tickets with tools and delegated summaries.",
+      model: triageModel,
+      tools: [lookup],
+      skills: [
+        skill({
+          name: "triage-policy",
+          description: "Ticket triage policy",
+          content: "Escalate unclear incidents.",
+        }),
+      ],
+      subagents: [
+        sub({
+          description: "Summarizes ticket context.",
+          agent: summarize,
+        }),
+      ],
+    })
+    const { extensions, log } = kit()
+    const scope = createScope({ extensions })
+    const ctx = scope.createContext()
+
+    const result = await turn(ctx, triage, { prompt: "triage FEAT-42" })
+    const buffer = await ctx.resolve(events)
+
+    expect(result.content).toContain("ready:")
+    expect(result.toolResults).toEqual([
+      {
+        name: "lookup-ticket",
+        input: { id: "42" },
+        output: { id: "42", title: "ticket:42" },
+      },
+    ])
+    expect(result.subagentResults[0]?.output.content).toBe("summary:ticket 42")
+    expect(result.subagentResults[0]?.output.events.map((event) => event.type)).toEqual([
+      "agent_start",
+      "agent_model_start",
+      "agent_model_end",
+      "agent_end",
+    ])
+    expect(result.events.map((event) => event.type)).toEqual(buffer.events.map((event) => event.type))
+    expect(buffer.events.map((event) => event.type)).toEqual([
+      "agent_start",
+      "agent_model_start",
+      "agent_model_end",
+      "agent_tool_start",
+      "agent_tool_end",
+      "agent_subagent_start",
+      "agent_start",
+      "agent_model_start",
+      "agent_model_end",
+      "agent_end",
+      "agent_subagent_end",
+      "agent_model_start",
+      "agent_model_end",
+      "agent_end",
+    ])
+    expect(log.entries().filter((entry) => entry.status === "completed").map((entry) => entry.targetName)).toEqual([
+      "lookup-ticket",
+      "summarize-ticket",
+      "triage-ticket",
+    ])
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("runs evals with deterministic checks and a judge quorum", async () => {
+    const model: Model = {
+      complete: () => ({
+        content: "approved after lookup",
+        stop: true,
+      }),
+    }
+    const reviewer = agent({
+      name: "reviewer",
+      model,
+    })
+    const accepts = judge({
+      name: "accepts",
+      evaluate: () => ({ name: "accepts", passed: true, score: 1 }),
+    })
+    const grounded = judge({
+      name: "grounded",
+      evaluate: () => ({ name: "grounded", passed: true, score: 1 }),
+    })
+    const evaluation = suite({
+      name: "reviewer-quality",
+      agent: reviewer,
+      cases: [
+        {
+          name: "answers with approval",
+          input: { prompt: "review" },
+          checks: [includes("approved")],
+        },
+      ],
+      judges: [accepts, grounded],
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+
+    await expect(runEval(ctx, evaluation)).resolves.toMatchObject({
+      name: "reviewer-quality",
+      passed: true,
+      cases: [
+        {
+          name: "answers with approval",
+          passed: true,
+          checks: [{ passed: true }],
+          judges: [{ passed: true }, { passed: true }],
+        },
+      ],
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("rejects a single judge as a quality gate", async () => {
+    const model: Model = {
+      complete: () => ({ content: "ok", stop: true }),
+    }
+    const target = agent({ name: "single-judge-target", model })
+    const single = judge({
+      name: "single",
+      evaluate: () => ({ name: "single", passed: true }),
+    })
+
+    expect(() => suite({
+      name: "single-judge",
+      agent: target,
+      cases: [{ name: "case", input: { prompt: "x" } }],
+      judges: [single],
+    })).toThrow("Agent evals require zero judges or at least two judges")
+    const scope = createScope()
+    const ctx = scope.createContext()
+
+    await expect(runEval(ctx, {
+      name: "single-judge",
+      agent: target,
+      cases: [{ name: "case", input: { prompt: "x" } }],
+      judges: [single],
+    })).rejects.toThrow("Agent evals require zero judges or at least two judges")
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("loads skills on model request through a replayable step", async () => {
+    const model: Model = {
+      complete: (_ctx, request) => request.loadedSkills.length === 0
+        ? {
+            content: "need policy",
+            skillCalls: [{ name: "policy" }],
+          }
+        : {
+            content: `policy:${request.loadedSkills[0]?.content}`,
+            stop: true,
+          },
+    }
+    const target = agent({
+      name: "skill-agent",
+      model,
+      skills: [
+        skill({
+          name: "policy",
+          description: "Routing policy",
+          load: () => "route to support",
+        }),
+      ],
+    })
+    const { extensions, log } = kit()
+    const scope = createScope({ extensions })
+    const ctx = scope.createContext()
+
+    const result = await turn(ctx, target, { prompt: "route" })
+
+    expect(result.content).toBe("policy:route to support")
+    expect(result.skillResults).toEqual([{ name: "policy", content: "route to support" }])
+    expect(log.entries().filter((entry) => entry.status === "completed").map((entry) => entry.targetName)).toEqual([
+      "policy",
+      "skill-agent",
+    ])
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("preserves tool step routing config when executing through an agent", async () => {
+    const remoteTool = tool({
+      description: "Runs remotely",
+      flow: flow({
+        name: "remote-tool",
+        parse: typed<{ id: string }>(),
+        tags: [step({ remote: true, timeoutMs: 500, kind: "code" })],
+        factory: () => {
+          throw new Error("remote tool should route")
+        },
+      }),
+    })
+    const model: Model = {
+      complete: (_ctx, request) => request.round === 0
+        ? {
+            content: "routing",
+            toolCalls: [{ name: "remote-tool", input: { id: "42" } }],
+          }
+        : {
+            content: `done:${request.messages.at(-1)?.content ?? ""}`,
+            stop: true,
+          },
+    }
+    const target = agent({
+      name: "remote-agent",
+      model,
+      tools: [remoteTool],
+    })
+    const routed: unknown[] = []
+    const { extensions, log } = kit({
+      remoteRunner: {
+        run: (event) => {
+          routed.push(event.ctx.data.seekTag(step))
+          return { route: event.targetName }
+        },
+      },
+    })
+    const scope = createScope({ extensions })
+    const ctx = scope.createContext()
+
+    await expect(turn(ctx, target, { prompt: "route" }))
+      .resolves.toMatchObject({
+        content: 'done:{"route":"remote-tool"}',
+        toolResults: [{ output: { route: "remote-tool" } }],
+      })
+    expect(routed).toEqual([{ workflow: true, remote: true, timeoutMs: 500, kind: "code" }])
+    expect(log.entries().filter((entry) => entry.status === "completed").map((entry) => entry.targetName)).toEqual([
+      "remote-tool",
+      "remote-agent",
+    ])
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("keeps tool message content string-safe for void and non-json outputs", async () => {
+    const returnsVoid = tool({
+      description: "Returns void",
+      flow: flow({
+        name: "returns-void",
+        parse: typed<Record<string, never>>(),
+        factory: () => undefined,
+      }),
+    })
+    const returnsCyclic = tool({
+      description: "Returns a cyclic object",
+      flow: flow({
+        name: "returns-cyclic",
+        parse: typed<Record<string, never>>(),
+        factory: () => {
+          const value: { count: bigint; self?: unknown } = { count: 1n }
+          value.self = value
+          return value
+        },
+      }),
+    })
+    const model: Model = {
+      complete: (_ctx, request) => request.round === 0
+        ? {
+            content: "collecting",
+            toolCalls: [
+              { name: "returns-void", input: {} },
+              { name: "returns-cyclic", input: {} },
+            ],
+          }
+        : {
+            content: `done:${request.messages.filter((message) => message.role === "tool").map((message) => message.content).join("|")}`,
+            stop: true,
+          },
+    }
+    const target = agent({
+      name: "string-safe-agent",
+      model,
+      tools: [returnsVoid, returnsCyclic],
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+
+    await expect(turn(ctx, target, { prompt: "collect" }))
+      .resolves.toMatchObject({
+        content: 'done:undefined|{"count":"1","self":"[Circular]"}',
+      })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("exposes deterministic check helpers for tools, skills, and subagents", () => {
+    expect(used("load")({
+      agentName: "agent",
+      content: "",
+      messages: [],
+      skillResults: [],
+      toolResults: [{ name: "load", input: {}, output: {} }],
+      subagentResults: [],
+      rounds: 1,
+      events: [],
+    })).toEqual({ name: 'tool used "load"', passed: true })
+    expect(delegated("review")({
+      agentName: "agent",
+      content: "",
+      messages: [],
+      skillResults: [],
+      toolResults: [],
+      subagentResults: [{
+        name: "review",
+        input: { prompt: "x" },
+        output: {
+          agentName: "review",
+          content: "ok",
+          messages: [],
+          skillResults: [],
+          toolResults: [],
+          subagentResults: [],
+          rounds: 1,
+          events: [],
+        },
+      }],
+      rounds: 1,
+      events: [],
+    })).toEqual({ name: 'subagent used "review"', passed: true })
+    expect(loaded("policy")({
+      agentName: "agent",
+      content: "",
+      messages: [],
+      skillResults: [{ name: "policy", content: "rules" }],
+      toolResults: [],
+      subagentResults: [],
+      rounds: 1,
+      events: [],
+    })).toEqual({ name: 'skill loaded "policy"', passed: true })
+  })
+
+  it("routes channel and schedule adapters through agent turns", async () => {
+    const model: Model = {
+      complete: (_ctx, request) => ({
+        content: `seen:${request.messages.at(-1)?.content ?? ""}`,
+        stop: true,
+      }),
+    }
+    const target = agent({
+      name: "channel-target",
+      model,
+    })
+    const slack = channel({
+      name: "slack-message",
+      parse: typed<{ text: string }>(),
+      agent: target,
+      input: (ctx) => ({ prompt: ctx.input.text }),
+    })
+    const daily = schedule({
+      name: "daily-digest",
+      agent: target,
+      input: () => ({ prompt: "daily digest" }),
+    })
+    const { extensions, log } = kit()
+    const scope = createScope({ extensions })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: slack, input: { text: "hello" } }))
+      .resolves.toMatchObject({ content: "seen:hello" })
+    await expect(ctx.exec({ flow: daily }))
+      .resolves.toMatchObject({ content: "seen:daily digest" })
+    expect(log.entries().filter((entry) => entry.status === "completed").map((entry) => entry.targetName)).toEqual([
+      "channel-target",
+      "slack-message",
+      "channel-target",
+      "daily-digest",
+    ])
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("adapts fetch requests into agent turns", async () => {
+    const model: Model = {
+      complete: (_ctx, request) => ({
+        content: `http:${request.messages.at(-1)?.content ?? ""}`,
+        stop: true,
+      }),
+    }
+    const target = agent({
+      name: "http-agent",
+      model,
+    })
+    const scope = createScope()
+    const handle = http({ scope, agent: target })
+
+    const response = await handle(new Request("https://agent.local/run", {
+      method: "POST",
+      body: JSON.stringify({ prompt: "ping" }),
+    }))
+
+    await expect(response.json()).resolves.toMatchObject({
+      agentName: "http-agent",
+      content: "http:ping",
+    })
+    await scope.dispose()
+  })
+
+  it("inspects workflow log runs and filters by run id", async () => {
+    const log = new MemoryWorkflowLog()
+    await log.putPending({
+      status: "pending",
+      key: { taskId: "task-a", runId: "run-a", step: 0 },
+      targetName: "approval",
+      input: { id: "1" },
+      kind: "review",
+    })
+    await log.putCompleted({
+      status: "completed",
+      key: { taskId: "task-a", runId: "run-b", step: 0 },
+      targetName: "other",
+      result: "done",
+    })
+
+    await expect(inspect(log, { taskId: "task-a", runId: "run-a" })).resolves.toEqual({
+      taskId: "task-a",
+      runId: "run-a",
+      status: "pending",
+      steps: [
+        {
+          key: { taskId: "task-a", runId: "run-a", step: 0 },
+          status: "pending",
+          targetName: "approval",
+          input: { id: "1" },
+          kind: "review",
+        },
+      ],
+    })
+  })
+
+  it("injects sandbox capability through the scope seam", async () => {
+    const readWorkspace = tool({
+      description: "Reads a workspace file",
+      flow: flow({
+        name: "read-workspace",
+        parse: typed<{ path: string }>(),
+        deps: { sandbox: tags.required(sandbox) },
+        factory: (ctx, deps) => deps.sandbox.readFile(ctx.input.path),
+      }),
+    })
+    const model: Model = {
+      complete: (_ctx, request) => request.round === 0
+        ? {
+            content: "reading",
+            toolCalls: [{ name: "read-workspace", input: { path: "README.md" } }],
+          }
+        : {
+            content: `read:${request.messages.at(-1)?.content ?? ""}`,
+            stop: true,
+          },
+    }
+    const target = agent({
+      name: "sandbox-agent",
+      model,
+      tools: [readWorkspace],
+    })
+    const scope = createScope({
+      tags: [
+        sandbox({
+          readFile: (path) => `file:${path}`,
+          writeFile: () => undefined,
+          exec: (command, args = []) => ({
+            stdout: [command, ...args].join(" "),
+            stderr: "",
+            exitCode: 0,
+          }),
+        }),
+      ],
+    })
+    const ctx = scope.createContext()
+
+    await expect(turn(ctx, target, { prompt: "read" }))
+      .resolves.toMatchObject({
+        content: "read:file:README.md",
+        toolResults: [{ output: "file:README.md" }],
+      })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("stores continuing session messages as a material", async () => {
+    const model: Model = {
+      complete: (_ctx, request) => ({
+        content: `turn:${request.messages.at(-1)?.content ?? ""}`,
+        stop: true,
+      }),
+    }
+    const target = agent({
+      name: "session-agent",
+      model,
+    })
+    const thread = session("session")
+    const scope = createScope()
+    const ctx = scope.createContext()
+
+    await send(ctx, thread, target, { prompt: "one" })
+    await send(ctx, thread, target, { prompt: "two" })
+
+    expect(ctx.scope.controller(thread).get()).toEqual({
+      name: "session",
+      kind: "json",
+      revision: 2,
+      state: {
+        messages: [
+          { role: "user", content: "one" },
+          { role: "assistant", content: "turn:one" },
+          { role: "user", content: "two" },
+          { role: "assistant", content: "turn:two" },
+        ],
+      },
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("summarizes eval reports as json-safe artifacts", async () => {
+    const model: Model = {
+      complete: () => ({
+        content: "ready",
+        stop: true,
+      }),
+    }
+    const target = agent({
+      name: "summary-agent",
+      model,
+    })
+    const evaluation = suite({
+      name: "summary-suite",
+      agent: target,
+      cases: [{ name: "case", input: { prompt: "go" }, checks: [includes("ready")] }],
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const report = await runEval(ctx, evaluation)
+
+    expect(summary(report)).toMatchObject({
+      name: "summary-suite",
+      passed: true,
+      cases: [{ name: "case", output: "ready", passed: true }],
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+})

--- a/packages/agent-sdk-test/tests/agent-runtime.test.ts
+++ b/packages/agent-sdk-test/tests/agent-runtime.test.ts
@@ -17,7 +17,6 @@ import {
   model as agentModel,
   runEval,
   summary,
-  turn,
   send,
   sandbox,
   loaded,
@@ -87,7 +86,10 @@ describe("agent application runtime", () => {
     const scope = createScope({ extensions })
     const ctx = scope.createContext()
 
-    const result = await turn(ctx, triage, { prompt: "triage FEAT-42" })
+    const result = await ctx.exec({
+      flow: triage.turn,
+      input: { prompt: "triage FEAT-42" },
+    })
     const buffer = await ctx.resolve(events)
 
     expect(result.content).toContain("ready:")
@@ -152,7 +154,10 @@ describe("agent application runtime", () => {
     const scope = createScope()
     const ctx = scope.createContext()
 
-    await expect(turn(ctx, target, { prompt: "default" })).resolves.toMatchObject({
+    await expect(ctx.exec({
+      flow: target.turn,
+      input: { prompt: "default" },
+    })).resolves.toMatchObject({
       content: "tagged:default",
     })
     await expect(ctx.exec({
@@ -279,7 +284,10 @@ describe("agent application runtime", () => {
     const scope = createScope({ extensions })
     const ctx = scope.createContext()
 
-    const result = await turn(ctx, target, { prompt: "route" })
+    const result = await ctx.exec({
+      flow: target.turn,
+      input: { prompt: "route" },
+    })
 
     expect(result.content).toBe("policy:route to support")
     expect(result.skillResults).toEqual([{ name: "policy", content: "route to support" }])
@@ -332,7 +340,10 @@ describe("agent application runtime", () => {
     const scope = createScope({ extensions })
     const ctx = scope.createContext()
 
-    await expect(turn(ctx, target, { prompt: "route" }))
+    await expect(ctx.exec({
+      flow: target.turn,
+      input: { prompt: "route" },
+    }))
       .resolves.toMatchObject({
         content: 'done:{"route":"remote-tool"}',
         toolResults: [{ output: { route: "remote-tool" } }],
@@ -390,7 +401,10 @@ describe("agent application runtime", () => {
     const scope = createScope()
     const ctx = scope.createContext()
 
-    await expect(turn(ctx, target, { prompt: "collect" }))
+    await expect(ctx.exec({
+      flow: target.turn,
+      input: { prompt: "collect" },
+    }))
       .resolves.toMatchObject({
         content: 'done:undefined|{"count":"1","self":"[Circular]"}',
       })
@@ -590,7 +604,10 @@ describe("agent application runtime", () => {
     })
     const ctx = scope.createContext()
 
-    await expect(turn(ctx, target, { prompt: "read" }))
+    await expect(ctx.exec({
+      flow: target.turn,
+      input: { prompt: "read" },
+    }))
       .resolves.toMatchObject({
         content: "read:file:README.md",
         toolResults: [{ output: "file:README.md" }],

--- a/packages/agent-sdk-test/tests/agent-runtime.test.ts
+++ b/packages/agent-sdk-test/tests/agent-runtime.test.ts
@@ -14,6 +14,7 @@ import {
   sub,
   tool,
   includes,
+  model as agentModel,
   runEval,
   summary,
   turn,
@@ -46,7 +47,7 @@ describe("agent application runtime", () => {
     const summarize = agent({
       name: "summarize-ticket",
       instructions: "Summarize ticket context.",
-      model: summarizeModel,
+      tags: [agentModel(summarizeModel)],
     })
     const triageModel: Model = {
       complete: (_ctx, request) => {
@@ -66,7 +67,7 @@ describe("agent application runtime", () => {
     const triage = agent({
       name: "triage-ticket",
       instructions: "Triage tickets with tools and delegated summaries.",
-      model: triageModel,
+      tags: [agentModel(triageModel)],
       tools: [lookup],
       skills: [
         skill({
@@ -131,6 +132,42 @@ describe("agent application runtime", () => {
     await scope.dispose()
   })
 
+  it("reads model providers from tags", async () => {
+    const taggedModel: Model = {
+      complete: (_ctx, request) => ({
+        content: `tagged:${request.messages.at(-1)?.content ?? ""}`,
+        stop: true,
+      }),
+    }
+    const overrideModel: Model = {
+      complete: (_ctx, request) => ({
+        content: `override:${request.messages.at(-1)?.content ?? ""}`,
+        stop: true,
+      }),
+    }
+    const target = agent({
+      name: "tagged-model-agent",
+      tags: [agentModel(taggedModel)],
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+
+    await expect(turn(ctx, target, { prompt: "default" })).resolves.toMatchObject({
+      content: "tagged:default",
+    })
+    await expect(ctx.exec({
+      flow: target.turn,
+      input: { prompt: "local" },
+      name: target.name,
+      tags: [agentModel(overrideModel)],
+    })).resolves.toMatchObject({
+      content: "override:local",
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
   it("runs evals with deterministic checks and a judge quorum", async () => {
     const model: Model = {
       complete: () => ({
@@ -140,7 +177,7 @@ describe("agent application runtime", () => {
     }
     const reviewer = agent({
       name: "reviewer",
-      model,
+      tags: [agentModel(model)],
     })
     const accepts = judge({
       name: "accepts",
@@ -186,7 +223,10 @@ describe("agent application runtime", () => {
     const model: Model = {
       complete: () => ({ content: "ok", stop: true }),
     }
-    const target = agent({ name: "single-judge-target", model })
+    const target = agent({
+      name: "single-judge-target",
+      tags: [agentModel(model)],
+    })
     const single = judge({
       name: "single",
       evaluate: () => ({ name: "single", passed: true }),
@@ -226,7 +266,7 @@ describe("agent application runtime", () => {
     }
     const target = agent({
       name: "skill-agent",
-      model,
+      tags: [agentModel(model)],
       skills: [
         skill({
           name: "policy",
@@ -277,7 +317,7 @@ describe("agent application runtime", () => {
     }
     const target = agent({
       name: "remote-agent",
-      model,
+      tags: [agentModel(model)],
       tools: [remoteTool],
     })
     const routed: unknown[] = []
@@ -344,7 +384,7 @@ describe("agent application runtime", () => {
     }
     const target = agent({
       name: "string-safe-agent",
-      model,
+      tags: [agentModel(model)],
       tools: [returnsVoid, returnsCyclic],
     })
     const scope = createScope()
@@ -414,7 +454,7 @@ describe("agent application runtime", () => {
     }
     const target = agent({
       name: "channel-target",
-      model,
+      tags: [agentModel(model)],
     })
     const slack = channel({
       name: "slack-message",
@@ -455,7 +495,7 @@ describe("agent application runtime", () => {
     }
     const target = agent({
       name: "http-agent",
-      model,
+      tags: [agentModel(model)],
     })
     const scope = createScope()
     const ctx = scope.createContext()
@@ -532,7 +572,7 @@ describe("agent application runtime", () => {
     }
     const target = agent({
       name: "sandbox-agent",
-      model,
+      tags: [agentModel(model)],
       tools: [readWorkspace],
     })
     const scope = createScope({
@@ -569,7 +609,7 @@ describe("agent application runtime", () => {
     }
     const target = agent({
       name: "session-agent",
-      model,
+      tags: [agentModel(model)],
     })
     const thread = session("session")
     const scope = createScope()
@@ -605,7 +645,7 @@ describe("agent application runtime", () => {
     }
     const target = agent({
       name: "summary-agent",
-      model,
+      tags: [agentModel(model)],
     })
     const evaluation = suite({
       name: "summary-suite",

--- a/packages/agent-sdk-test/tests/cli.test.ts
+++ b/packages/agent-sdk-test/tests/cli.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from "vitest"
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { createScope } from "@pumped-fn/lite"
 import {
   CliWorkerError,
+  claudeHarness,
   claudeCliWorker,
   cliWorker,
+  codexHarness,
   codexCliWorker,
+  guard,
+  runCli,
   step,
+  type ModelRequest,
 } from "@pumped-fn/agent-sdk"
 
 describe("CLI workers", () => {
@@ -54,6 +62,140 @@ describe("CLI workers", () => {
     })).rejects.toThrow("CLI helper extraArgs cannot include --")
 
     await ctx.close({ ok: false, error: new Error("expected") })
+  })
+
+  it("rejects bare Claude harness args", () => {
+    expect(() => claudeCliWorker({ extraArgs: ["--bare"] })).toThrow("Claude harness must not use --bare")
+    expect(() => claudeCliWorker({ extraArgs: ["--bare=true"] })).toThrow("Claude harness must not use --bare")
+    expect(() => claudeHarness({ extraArgs: ["--bare"] })).toThrow("Claude harness must not use --bare")
+  })
+
+  it("wraps isolated CLI runs with bubblewrap args", async () => {
+    const isolated = await runCli({
+      command: "printf",
+      args: ["ok"],
+      isolate: {
+        bwrap: "echo",
+        workdir: "/work",
+        home: "/home/agent",
+        network: true,
+        bind: [{ source: "/source", target: "/target", mode: "rw" }],
+      },
+    })
+    expect(isolated.stdout).toContain("--share-net")
+    expect(isolated.stdout).not.toContain("--ro-bind /etc /etc")
+    expect(isolated.stdout).not.toContain("--ro-bind /opt /opt")
+    await expect(runCli({
+      command: "printf",
+      args: ["ok"],
+      isolate: {
+        bwrap: "echo",
+        workdir: "/work",
+        home: "/home/agent",
+        bind: [{ source: "/source", target: "/target", mode: "rw" }],
+      },
+    })).resolves.toMatchObject({
+      stdout: expect.stringContaining("--bind /source /target"),
+    })
+  })
+
+  it("collects the first harness guard into material state", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "pumped-fn-model-"))
+    const command = join(dir, "model")
+    await writeFile(command, "#!/bin/sh\nprintf '%s' '{\"content\":\"ready\",\"guard\":\"Keep changes scoped\"}'\n")
+    await chmod(command, 0o755)
+    const store = guard("review-guard")
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const request = {
+      agentName: "review",
+      instructions: "Review the change.",
+      messages: [{ role: "user", content: "hello" }],
+      tools: [],
+      skills: [],
+      loadedSkills: [],
+      subagents: [],
+      round: 0,
+    } satisfies ModelRequest
+
+    await expect(codexHarness({ command, isolate: false, guard: store }).complete(ctx, request))
+      .resolves.toMatchObject({
+        content: "ready",
+        guard: "Keep changes scoped",
+        stop: true,
+      })
+    await expect(ctx.resolve(store)).resolves.toMatchObject({
+      state: { text: "Keep changes scoped" },
+    })
+
+    await ctx.close()
+    await scope.dispose()
+    await rm(dir, { recursive: true, force: true })
+  })
+
+  it("passes collected guards to later harness prompts", async () => {
+    const store = guard("planner-guard")
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const seen: string[] = []
+    const request = {
+      agentName: "planner",
+      instructions: "Plan the work.",
+      messages: [{ role: "user", content: "hello" }],
+      tools: [],
+      skills: [],
+      loadedSkills: [],
+      subagents: [],
+      round: 0,
+    } satisfies ModelRequest
+    const model = claudeHarness({
+      command: "echo",
+      isolate: false,
+      guard: store,
+      prompt: (_request, guard) => {
+        seen.push(guard.text)
+        return `guard=${guard.text}`
+      },
+      parse: () => seen.length === 1
+        ? { content: "ready", guard: "Avoid single-model truth", stop: true }
+        : { content: "ready", stop: true },
+    })
+
+    await model.complete(ctx, request)
+    await model.complete(ctx, request)
+    expect(seen).toEqual(["", "Avoid single-model truth"])
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("adapts Codex and Claude CLI harnesses into models", async () => {
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const request = {
+      agentName: "review",
+      instructions: "Review the change.",
+      messages: [{ role: "user", content: "hello" }],
+      tools: [],
+      skills: [],
+      loadedSkills: [],
+      subagents: [],
+      round: 0,
+    } satisfies ModelRequest
+
+    await expect(claudeHarness({ command: "echo", isolate: false }).complete(ctx, request))
+      .resolves.toMatchObject({
+        content: expect.stringContaining("-p --no-session-persistence -- Return JSON only."),
+        stop: true,
+      })
+    await expect(codexHarness({ command: "echo", isolate: false }).complete(ctx, request))
+      .resolves.toMatchObject({
+        content: expect.stringContaining("exec -s read-only --ephemeral --ignore-user-config -- Return JSON only."),
+        stop: true,
+      })
+
+    await ctx.close()
+    await scope.dispose()
   })
 
   it("reports CLI failures with captured stderr", async () => {

--- a/packages/agent-sdk-test/tests/steps.test.ts
+++ b/packages/agent-sdk-test/tests/steps.test.ts
@@ -9,12 +9,12 @@ import {
 } from "@pumped-fn/agent-sdk"
 import {
   MemoryWorkflowLog,
-  agent,
+  kit,
 } from "../src/index"
 
 describe("workflow steps", () => {
   it("memoizes completed workflow execution", async () => {
-    const { extensions } = agent()
+    const { extensions } = kit()
     const scope = createScope({ extensions })
     await scope.ready
     let calls = 0
@@ -51,7 +51,7 @@ describe("workflow steps", () => {
 
   it("replays completed flow before resolving deps", async () => {
     const gate = tag<string>({ label: "agent.replay.gate" })
-    const { extensions } = agent()
+    const { extensions } = kit()
     const scope = createScope({ extensions })
     await scope.ready
     let calls = 0
@@ -79,7 +79,7 @@ describe("workflow steps", () => {
 
   it("suspends durable work and replays memoized steps on resolution", async () => {
     const log = new MemoryWorkflowLog()
-    const { extensions } = agent({ log })
+    const { extensions } = kit({ log })
     const scope = createScope({ extensions })
     await scope.ready
     let expensiveCalls = 0
@@ -123,7 +123,7 @@ describe("workflow steps", () => {
 
   it("suspends durable work before resolving deps", async () => {
     const gate = tag<string>({ label: "agent.durable.gate" })
-    const { extensions } = agent()
+    const { extensions } = kit()
     const scope = createScope({ extensions })
     await scope.ready
     const approve = flow({
@@ -138,7 +138,7 @@ describe("workflow steps", () => {
   })
 
   it("aborts timed workflow steps cooperatively", async () => {
-    const { extensions } = agent()
+    const { extensions } = kit()
     const scope = createScope({ extensions })
     await scope.ready
     let aborted = false

--- a/packages/agent-sdk-test/tests/workers.test.ts
+++ b/packages/agent-sdk-test/tests/workers.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { createScope, flow, tag, tags, typed } from "@pumped-fn/lite"
 import {
-  agent as agentRuntime,
+  runtime,
   extension as agentExtension,
   workflowRun,
   step,
@@ -11,12 +11,12 @@ import {
 } from "@pumped-fn/agent-sdk"
 import {
   MemoryWorkflowLog,
-  agent,
+  kit,
 } from "../src/index"
 
 describe("worker delegation", () => {
   it("delegates by worker registry and routes remote workers", async () => {
-    const { extensions } = agent()
+    const { extensions } = kit()
     const scope = createScope({ extensions })
     await scope.ready
     const worker = flow({
@@ -30,8 +30,8 @@ describe("worker delegation", () => {
       name: "delegate-root",
       parse: typed<{ text: string }>(),
       tags: [step({ workflow: true }), workers(registry)],
-      deps: { agent: tags.required(agentRuntime) },
-      factory: (ctx, { agent }) => agent.delegate<string, { text: string }>("upper", ctx.input),
+      deps: { runtime: tags.required(runtime) },
+      factory: (ctx, { runtime }) => runtime.delegate<string, { text: string }>("upper", ctx.input),
     })
     const ctx = scope.createContext({ tags: [workflowRun({ taskId: "task-c", runId: "run-c" })] })
     expect(await ctx.exec({ flow: root, input: { text: "works" } })).toBe("WORKS")
@@ -39,7 +39,7 @@ describe("worker delegation", () => {
   })
 
   it("delegates by worker registry tag", async () => {
-    const { extensions } = agent()
+    const { extensions } = kit()
     const scope = createScope({ extensions })
     await scope.ready
     const worker = flow({
@@ -52,8 +52,8 @@ describe("worker delegation", () => {
       name: "delegate-root-tag",
       parse: typed<{ text: string }>(),
       tags: [step({ workflow: true })],
-      deps: { agent: tags.required(agentRuntime) },
-      factory: (ctx, { agent }) => agent.delegate<string, { text: string }>("reverse", ctx.input),
+      deps: { runtime: tags.required(runtime) },
+      factory: (ctx, { runtime }) => runtime.delegate<string, { text: string }>("reverse", ctx.input),
     })
     const ctx = scope.createContext({
       tags: [workflowRun({ taskId: "task-c-tag", runId: "run-c-tag" }), workers(registry)],
@@ -72,8 +72,8 @@ describe("worker delegation", () => {
       name: "unguarded-root",
       parse: typed<{ text: string }>(),
       tags: [step({ workflow: true }), workers(workerRegistry([worker]))],
-      deps: { agent: tags.required(agentRuntime) },
-      factory: (ctx, { agent }) => agent.delegate<string, { text: string }>("unguarded-worker", ctx.input),
+      deps: { runtime: tags.required(runtime) },
+      factory: (ctx, { runtime }) => runtime.delegate<string, { text: string }>("unguarded-worker", ctx.input),
     })
     const scope = createScope({ extensions: [workflowExtension({ log: new MemoryWorkflowLog() })] })
     await scope.ready
@@ -92,8 +92,8 @@ describe("worker delegation", () => {
     const root = flow({
       name: "agent-without-workflow",
       tags: [step({ workflow: true })],
-      deps: { agent: tags.required(agentRuntime) },
-      factory: (_ctx, { agent }) => agent.taskId,
+      deps: { runtime: tags.required(runtime) },
+      factory: (_ctx, { runtime }) => runtime.taskId,
     })
 
     const ctx = scope.createContext({ tags: [workflowRun({ taskId: "task-agent-only", runId: "run-agent-only" })] })
@@ -119,7 +119,7 @@ describe("worker delegation", () => {
 
   it("routes remote work before resolving deps when runner handles it", async () => {
     const gate = tag<string>({ label: "agent.remote.gate" })
-    const { extensions } = agent({
+    const { extensions } = kit({
       remoteRunner: {
         run: async (event) => {
           expect(event.targetName).toBe("remote-before-deps")

--- a/packages/agent-sdk/LICENSE
+++ b/packages/agent-sdk/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2025 Duke
+
+Permission is hereby granted, free of
+charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/agent-sdk/PATTERNS.md
+++ b/packages/agent-sdk/PATTERNS.md
@@ -243,11 +243,14 @@ const run = await inspect(log, { taskId: "triage-42", runId: "run-1" })
 Use `http()` to adapt a Fetch request to an agent turn without adding a server framework dependency.
 
 ```ts
-const handle = http({ scope, agent: triage })
-const response = await handle(new Request("https://agent.local/run", {
-  method: "POST",
-  body: JSON.stringify({ prompt: "triage ticket 42" }),
-}))
+const handle = http({ agent: triage })
+const response = await ctx.exec({
+  flow: handle,
+  input: new Request("https://agent.local/run", {
+    method: "POST",
+    body: JSON.stringify({ prompt: "triage ticket 42" }),
+  }),
+})
 ```
 
 ## 7. Channels and Schedules

--- a/packages/agent-sdk/PATTERNS.md
+++ b/packages/agent-sdk/PATTERNS.md
@@ -314,22 +314,38 @@ const scope = createScope({
 
 ## 10. CLI Worker Adapter
 
-Use CLI helpers when the runtime must call real local tools like Claude or Codex.
+Use CLI helpers when the runtime must call real local tools like Claude or Codex. Use harnesses when those tools should act as the agent model provider.
 
 ```ts
 const review = codexCliWorker({
   name: "codex-review",
   sandbox: "workspace-write",
+  isolate: { network: true },
   timeoutMs: 120_000,
 })
 
 const plan = claudeCliWorker({
   name: "claude-plan",
+  isolate: { network: true },
   timeoutMs: 120_000,
+})
+
+const shared = guard("review-guard")
+
+const reviewer = agent({
+  name: "reviewer",
+  model: codexHarness({ sandbox: "read-only", guard: shared }),
+})
+
+const planner = agent({
+  name: "planner",
+  model: claudeHarness({ guard: shared }),
 })
 ```
 
-Keep CLI workers at the edge. Stable domain tests should use provider state and presets.
+`codexHarness()` runs `codex exec --ephemeral --ignore-user-config`. `claudeHarness()` runs `claude -p --no-session-persistence` and rejects `--bare`. Harness prompts request JSON with `content`, optional `guard`, and optional skill/tool/subagent calls. `guard` is the anti-goal; the first value collected from a run is kept in material state and injected into later prompts.
+
+Harnesses default to bwrap isolation with network enabled. The default sandbox mounts only the workspace, temporary home, minimal runtime/cert/DNS paths, and explicit credential directories such as `codexHome`. Keep CLI workers at the edge. Stable domain tests should use provider state and presets.
 
 ## 11. Durable Step
 

--- a/packages/agent-sdk/PATTERNS.md
+++ b/packages/agent-sdk/PATTERNS.md
@@ -195,7 +195,10 @@ const triage = agent({
   tools: [loadTicket],
 })
 
-const result = await turn(ctx, triage, { prompt: "triage ticket 42" })
+const result = await ctx.exec({
+  flow: triage.turn,
+  input: { prompt: "triage ticket 42" },
+})
 ```
 
 Why: tools and subagent turns still run through `ctx.exec()`, so the same workflow extension can replay, suspend, route, or time out the work. `events` is a boundary resource, so run inspection is testable without a global observer.

--- a/packages/agent-sdk/PATTERNS.md
+++ b/packages/agent-sdk/PATTERNS.md
@@ -320,34 +320,25 @@ const scope = createScope({
 
 ## 10. CLI Worker Adapter
 
-Use CLI helpers when the runtime must call real local tools like Claude or Codex. Use harnesses when those tools should act as the agent model provider.
+Use provider packages when the runtime must call real local tools like Claude or Codex as the agent model provider. Keep the agent graph provider-free and choose the provider with scope or context tags.
 
 ```ts
-const review = codexCliWorker({
-  name: "codex-review",
-  sandbox: "workspace-write",
-  isolate: { network: true },
-  timeoutMs: 120_000,
-})
-
-const plan = claudeCliWorker({
-  name: "claude-plan",
-  isolate: { network: true },
-  timeoutMs: 120_000,
-})
+import { createScope } from "@pumped-fn/lite"
+import { agent, guard, model } from "@pumped-fn/agent-sdk"
+import { claude } from "@pumped-fn/agent-sdk-claude"
+import { codex } from "@pumped-fn/agent-sdk-codex"
 
 const shared = guard("review-guard")
 
 const reviewer = agent({
   name: "reviewer",
-  tags: [model(codexHarness({ sandbox: "read-only", guard: shared }))],
 })
 
-const planner = agent({
-  name: "planner",
-  tags: [model(claudeHarness({ guard: shared }))],
-})
+const codexScope = createScope({ tags: [codex({ sandbox: "read-only", guard: shared })] })
+const claudeScope = createScope({ tags: [claude({ guard: shared })] })
 ```
+
+`codex()` and `claude()` are lazy `model` tags. Tagging a scope is configuration only; the CLI harness is built on first model use. Replace either provider with `model(fake)` at the same seam for tests.
 
 `codexHarness()` runs `codex exec --ephemeral --ignore-user-config`. `claudeHarness()` runs `claude -p --no-session-persistence` and rejects `--bare`. Harness prompts request JSON with `content`, optional `guard`, and optional skill/tool/subagent calls. `guard` is the anti-goal; the first value collected from a run is kept in material state and injected into later prompts.
 

--- a/packages/agent-sdk/PATTERNS.md
+++ b/packages/agent-sdk/PATTERNS.md
@@ -153,7 +153,7 @@ const scope = createScope({
 
 ## 4. Agent Application
 
-Use `agent()` when the model should choose tools or delegate to another role. Keep the executable work as flows, and keep the model as a provider that can be preset or faked.
+Use `agent()` when the model should choose tools or delegate to another role. Keep the executable work as flows, and keep the model as a provider that can be tagged or faked.
 
 ```ts
 const loadTicket = tool({
@@ -165,7 +165,7 @@ const loadTicket = tool({
   }),
 })
 
-const model: Model = {
+const provider: Model = {
   complete: (_ctx, request) => request.loadedSkills.length === 0
     ? {
         content: "need routing policy",
@@ -184,7 +184,7 @@ const model: Model = {
 
 const triage = agent({
   name: "triage",
-  model,
+  tags: [model(provider)],
   skills: [
     skill({
       name: "routing-policy",
@@ -337,12 +337,12 @@ const shared = guard("review-guard")
 
 const reviewer = agent({
   name: "reviewer",
-  model: codexHarness({ sandbox: "read-only", guard: shared }),
+  tags: [model(codexHarness({ sandbox: "read-only", guard: shared }))],
 })
 
 const planner = agent({
   name: "planner",
-  model: claudeHarness({ guard: shared }),
+  tags: [model(claudeHarness({ guard: shared }))],
 })
 ```
 

--- a/packages/agent-sdk/PATTERNS.md
+++ b/packages/agent-sdk/PATTERNS.md
@@ -40,14 +40,14 @@ Use a workflow flow when code chooses order, branching, retries, and fan-out.
 ```ts
 import { createScope, flow, tags, typed } from "@pumped-fn/lite"
 import {
-  agent as agentRuntime,
+  runtime,
   step,
   workflow as workflowRuntime,
   workflowRun,
   workerRegistry,
   workers,
 } from "@pumped-fn/agent-sdk"
-import { agent as testAgent } from "@pumped-fn/agent-sdk-test"
+import { kit } from "@pumped-fn/agent-sdk-test"
 
 export const processPr = flow({
   name: "process_pr",
@@ -58,15 +58,15 @@ export const processPr = flow({
   ],
   deps: {
     workflow: tags.required(workflowRuntime),
-    agent: tags.required(agentRuntime),
+    runtime: tags.required(runtime),
   },
-  factory: async (ctx, { workflow, agent }) => {
-    const lintResult = await agent.delegate<{ failed: boolean }>("lint", { sha: ctx.input.sha })
+  factory: async (ctx, { workflow, runtime }) => {
+    const lintResult = await runtime.delegate<{ failed: boolean }>("lint", { sha: ctx.input.sha })
     if (lintResult.failed) return { taskId: workflow.taskId, status: "lint-failed" }
 
     const [tests, security] = await Promise.all([
-      agent.delegate("test", { sha: ctx.input.sha }),
-      agent.delegate("security", { sha: ctx.input.sha }),
+      runtime.delegate("test", { sha: ctx.input.sha }),
+      runtime.delegate("security", { sha: ctx.input.sha }),
     ])
 
     return { taskId: workflow.taskId, status: "ok", tests, security }
@@ -74,7 +74,7 @@ export const processPr = flow({
 })
 
 export async function runProcessPr(input: PrEvent) {
-  const { extensions } = testAgent()
+  const { extensions } = kit()
   const scope = createScope({ extensions })
   const ctx = scope.createContext({
     tags: [workflowRun({ taskId: input.sha, runId: "run-1" })],
@@ -89,9 +89,9 @@ export async function runProcessPr(input: PrEvent) {
 }
 ```
 
-Why: normal TypeScript control flow stays visible. Replay still works because expensive work is behind `ctx.exec()` through `agent.delegate()`.
+Why: normal TypeScript control flow stays visible. Replay still works because expensive work is behind `ctx.exec()` through `runtime.delegate()`.
 
-`step({ workflow: true })` marks the flow as workflow policy surface. `workflowRun()` is a context tag for run metadata, passed through `createContext({ tags: [...] })`. `workflow` and `agent` runtime tags are required deps, so missing extensions fail before the factory runs. Event-log policy and remote routing stay normal extension composition.
+`step({ workflow: true })` marks the flow as workflow policy surface. `workflowRun()` is a context tag for run metadata, passed through `createContext({ tags: [...] })`. `workflow` and `runtime` tags are required deps, so missing extensions fail before the factory runs. Event-log policy and remote routing stay normal extension composition.
 
 ## 2. Worker Flow
 
@@ -151,7 +151,168 @@ const scope = createScope({
 })
 ```
 
-## 4. CLI Worker Adapter
+## 4. Agent Application
+
+Use `agent()` when the model should choose tools or delegate to another role. Keep the executable work as flows, and keep the model as a provider that can be preset or faked.
+
+```ts
+const loadTicket = tool({
+  description: "Load ticket details.",
+  flow: flow({
+    name: "load-ticket",
+    parse: typed<{ id: string }>(),
+    factory: (ctx) => ({ id: ctx.input.id, title: `ticket:${ctx.input.id}` }),
+  }),
+})
+
+const model: Model = {
+  complete: (_ctx, request) => request.loadedSkills.length === 0
+    ? {
+        content: "need routing policy",
+        skillCalls: [{ name: "routing-policy" }],
+      }
+    : request.round === 1
+    ? {
+        content: "loading",
+        toolCalls: [{ name: "load-ticket", input: { id: "42" } }],
+      }
+    : {
+        content: "ready",
+        stop: true,
+      },
+}
+
+const triage = agent({
+  name: "triage",
+  model,
+  skills: [
+    skill({
+      name: "routing-policy",
+      description: "Support routing rules.",
+      content: "Route billing tickets to support.",
+    }),
+  ],
+  tools: [loadTicket],
+})
+
+const result = await turn(ctx, triage, { prompt: "triage ticket 42" })
+```
+
+Why: tools and subagent turns still run through `ctx.exec()`, so the same workflow extension can replay, suspend, route, or time out the work. `events` is a boundary resource, so run inspection is testable without a global observer.
+
+## 5. Agent Evals
+
+Use deterministic checks for exact requirements and judges for qualitative requirements. A subjective eval with exactly one judge is rejected.
+
+```ts
+const accepts = judge({
+  name: "accepts",
+  evaluate: () => ({ name: "accepts", passed: true }),
+})
+
+const grounded = judge({
+  name: "grounded",
+  evaluate: () => ({ name: "grounded", passed: true }),
+})
+
+const evaluation = suite({
+  name: "triage-quality",
+  agent: triage,
+  cases: [
+    {
+      name: "uses the loader",
+      input: { prompt: "triage ticket 42" },
+      checks: [used("load-ticket"), includes("ready")],
+    },
+  ],
+  judges: [accepts, grounded],
+})
+
+const report = await runEval(ctx, evaluation)
+const artifact = summary(report)
+```
+
+## 6. Run Inspection And HTTP
+
+Use `inspect()` against a `RunLog` to read workflow steps by `(taskId, runId)`.
+
+```ts
+const run = await inspect(log, { taskId: "triage-42", runId: "run-1" })
+```
+
+Use `http()` to adapt a Fetch request to an agent turn without adding a server framework dependency.
+
+```ts
+const handle = http({ scope, agent: triage })
+const response = await handle(new Request("https://agent.local/run", {
+  method: "POST",
+  body: JSON.stringify({ prompt: "triage ticket 42" }),
+}))
+```
+
+## 7. Channels and Schedules
+
+Use channel and schedule flows at the boundary. They should translate external shape into `TurnInput`, then let the agent turn own model/tool/subagent execution.
+
+```ts
+const slack = channel({
+  name: "slack-message",
+  parse: typed<{ text: string }>(),
+  agent: triage,
+  input: (ctx) => ({ prompt: ctx.input.text }),
+})
+
+const daily = schedule({
+  name: "daily-digest",
+  agent: triage,
+  input: () => ({ prompt: "daily digest" }),
+})
+```
+
+Why: Slack, HTTP, cron, queues, and CLIs stay adapters. The agent runtime still sees a flow input and a scoped execution context.
+
+## 8. Sessions
+
+Use `session()` for continuing message history. It is a material, so it uses the same patch and revision behavior as other task state.
+
+```ts
+const thread = session("support-session")
+
+await send(ctx, thread, triage, { prompt: "triage ticket 42" })
+await send(ctx, thread, triage, { prompt: "summarize the route" })
+```
+
+## 9. Sandbox Capability
+
+Use `sandbox` as an injected capability, not as a global file or process API.
+
+```ts
+const readWorkspace = tool({
+  description: "Read a file from the workspace.",
+  flow: flow({
+    name: "read-workspace",
+    parse: typed<{ path: string }>(),
+    deps: { sandbox: tags.required(sandbox) },
+    factory: (ctx, deps) => deps.sandbox.readFile(ctx.input.path),
+  }),
+})
+
+const scope = createScope({
+  tags: [
+    sandbox({
+      readFile: (path) => `file:${path}`,
+      writeFile: () => undefined,
+      exec: (command, args = []) => ({
+        stdout: [command, ...args].join(" "),
+        stderr: "",
+        exitCode: 0,
+      }),
+    }),
+  ],
+})
+```
+
+## 10. CLI Worker Adapter
 
 Use CLI helpers when the runtime must call real local tools like Claude or Codex.
 
@@ -170,7 +331,7 @@ const plan = claudeCliWorker({
 
 Keep CLI workers at the edge. Stable domain tests should use provider state and presets.
 
-## 5. Durable Step
+## 11. Durable Step
 
 Use `step({ durable: true })` for a step that should suspend until another process resolves it.
 
@@ -187,9 +348,9 @@ const approve = flow({
 
 First run writes a pending log entry and throws `SuspendSignal`. Replay returns the resolved value and continues.
 
-## 6. Remote Runner
+## 12. Remote Runner
 
-Remote routing belongs in `AgentRemoteRunner`, not inside workflow code.
+Remote routing belongs in `RemoteRunner`, not inside workflow code.
 
 ```ts
 const scope = createScope({
@@ -209,7 +370,7 @@ const scope = createScope({
 
 The runner may short-circuit before worker dependencies resolve. If it calls `next()`, the worker runs locally.
 
-## 7. Materials
+## 13. Materials
 
 Use materials for task state the workflow or workers must patch.
 
@@ -232,7 +393,7 @@ const count = derivedMaterial("inventory-count", inventory, (state) => state.ite
 })
 ```
 
-## 8. Event Log Boundary
+## 14. Event Log Boundary
 
 The event log key is `(taskId, runId, step)`. The step increments in standalone suspense `wrapExec`; `workflowExtension()` composes that lower layer.
 

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -47,7 +47,7 @@ flowchart TD
 - `WorkerRegistry` for named worker calls through `runtime.delegate()`.
 - `agent()`, `tool()`, `skill()`, and `sub()` for an agent application surface over lite.
 - `skillCalls` and `loadedSkills` for on-demand skill content.
-- `turn()` for model rounds that execute tools and subagents through `ctx.exec()`.
+- `agent.turn` flow for model rounds that execute tools and subagents through `ctx.exec()`.
 - `session()` and `send()` for continuing message history backed by materials.
 - `events` for per-boundary run inspection.
 - `model` and `sandbox` for swappable provider and execution capabilities.
@@ -78,7 +78,6 @@ import {
   skill,
   sub,
   tool,
-  turn,
   type Model,
 } from "@pumped-fn/agent-sdk"
 
@@ -144,7 +143,10 @@ const triage = agent({
 
 const scope = createScope()
 const ctx = scope.createContext()
-const result = await turn(ctx, triage, { prompt: "triage FEAT-42" })
+const result = await ctx.exec({
+  flow: triage.turn,
+  input: { prompt: "triage FEAT-42" },
+})
 const trace = await ctx.resolve(events)
 await ctx.close()
 await scope.dispose()
@@ -218,7 +220,10 @@ const ctx = scope.createContext({
   tags: [workflowRun({ taskId: "triage-42", runId: "run-1" })],
 })
 
-await turn(ctx, triage, { prompt: "triage FEAT-42" })
+await ctx.exec({
+  flow: triage.turn,
+  input: { prompt: "triage FEAT-42" },
+})
 const run = await inspect(log, { taskId: "triage-42", runId: "run-1" })
 ```
 

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -8,9 +8,9 @@ This package does not add a hosted runtime or filesystem framework. It gives nam
 |---|---|
 | `flow()` + `step({ workflow: true })` | Workflow boundary |
 | `flow()` | Worker, tool, subagent turn, durable step, CLI-backed LLM call |
-| state/service/atom | Provider, config, registry, model client, material state |
+| state/service/atom | Provider, config, registry, material state |
 | `resource()` | Per-run agent event capture |
-| typed tag | Routing config and ambient run data |
+| typed tag | Routing config, ambient run data, model and sandbox capabilities |
 | `ctx.exec()` | Step boundary for replay, remote routing, timeout, and suspend |
 | `workflowExtension()` | Replay, suspend, timeout, and event-log policy |
 | `extension()` | Agent remote-routing policy |
@@ -25,9 +25,11 @@ flowchart TD
   Config --> Durable["durable? write pending + suspend"]
   Config --> Remote["remote? hand to worker runner"]
   Config --> Local["otherwise run next()"]
-  Local --> Tool["tool/subagent/model provider flow"]
-  Tool --> CLI["optional Codex/Claude CLI harness"]
+  Local --> Tool["tool or subagent flow"]
+  Local --> Model["model tag provider"]
+  Model --> CLI["optional Codex/Claude CLI worker"]
   Tool --> Events["events resource"]
+  Model --> Events
   CLI --> Events
   Events --> Log["write completed"]
   Remote --> Log
@@ -48,7 +50,7 @@ flowchart TD
 - `turn()` for model rounds that execute tools and subagents through `ctx.exec()`.
 - `session()` and `send()` for continuing message history backed by materials.
 - `events` for per-boundary run inspection.
-- `sandbox` for swappable command/file execution capabilities.
+- `model` and `sandbox` for swappable provider and execution capabilities.
 - `guard()` for harness anti-goal state collected from the first model run.
 - `channel()` and `schedule()` for inbound and clock-driven adapter flows.
 - `suite()`, `runEval()`, deterministic checks, and judge quorum helpers.
@@ -72,6 +74,7 @@ import { createScope, flow, typed } from "@pumped-fn/lite"
 import {
   events,
   agent,
+  model,
   skill,
   sub,
   tool,
@@ -97,7 +100,7 @@ const summarizeModel: Model = {
 
 const summarize = agent({
   name: "summarize-ticket",
-  model: summarizeModel,
+  tags: [model(summarizeModel)],
   instructions: "Summarize the ticket context.",
 })
 
@@ -121,7 +124,7 @@ const triageModel: Model = {
 
 const triage = agent({
   name: "triage-ticket",
-  model: triageModel,
+  tags: [model(triageModel)],
   instructions: "Triage tickets with tools and delegated summaries.",
   skills: [
     skill({
@@ -147,7 +150,7 @@ await ctx.close()
 await scope.dispose()
 ```
 
-`result.toolResults`, `result.subagentResults`, and `trace.events` are deterministic inspection surfaces. Tests can preset or fake the model provider without module mocks.
+`result.toolResults`, `result.subagentResults`, and `trace.events` are deterministic inspection surfaces. Tests can set a default model with scope tags, define one on the agent flow, or override one turn with exec tags without module mocks.
 
 ## Sessions
 
@@ -425,7 +428,7 @@ const testScope = createScope({
 The CLI helpers are convenience adapters. Harnesses turn the popular local CLIs into `Model` providers for `agent()`.
 
 ```ts
-import { claudeHarness, claudeCliWorker, codexHarness, codexCliWorker, guard } from "@pumped-fn/agent-sdk"
+import { claudeHarness, claudeCliWorker, codexHarness, codexCliWorker, guard, model } from "@pumped-fn/agent-sdk"
 
 const codex = codexCliWorker({ name: "codex-review", sandbox: "workspace-write" })
 const claude = claudeCliWorker({ name: "claude-plan" })
@@ -433,19 +436,23 @@ const shared = guard("review-guard")
 
 const reviewer = agent({
   name: "reviewer",
-  model: codexHarness({
-    sandbox: "read-only",
-    guard: shared,
-    timeoutMs: 120_000,
-  }),
+  tags: [
+    model(codexHarness({
+      sandbox: "read-only",
+      guard: shared,
+      timeoutMs: 120_000,
+    })),
+  ],
 })
 
 const planner = agent({
   name: "planner",
-  model: claudeHarness({
-    guard: shared,
-    timeoutMs: 120_000,
-  }),
+  tags: [
+    model(claudeHarness({
+      guard: shared,
+      timeoutMs: 120_000,
+    })),
+  ],
 })
 ```
 

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -430,36 +430,34 @@ const testScope = createScope({
 })
 ```
 
-The CLI helpers are convenience adapters. Harnesses turn the popular local CLIs into `Model` providers for `agent()`.
+The CLI helpers are convenience adapters. Harnesses turn popular local CLIs into `Model` providers for `agent()`. Application composition should usually use the provider packages so the core SDK stays transport-neutral and the model is swappable at the scope seam.
 
 ```ts
-import { claudeHarness, claudeCliWorker, codexHarness, codexCliWorker, guard, model } from "@pumped-fn/agent-sdk"
+import { createScope } from "@pumped-fn/lite"
+import { agent, guard } from "@pumped-fn/agent-sdk"
+import { claude } from "@pumped-fn/agent-sdk-claude"
+import { codex } from "@pumped-fn/agent-sdk-codex"
 
-const codex = codexCliWorker({ name: "codex-review", sandbox: "workspace-write" })
-const claude = claudeCliWorker({ name: "claude-plan" })
 const shared = guard("review-guard")
 
 const reviewer = agent({
   name: "reviewer",
+})
+
+const scope = createScope({
   tags: [
-    model(codexHarness({
+    codex({
       sandbox: "read-only",
       guard: shared,
       timeoutMs: 120_000,
-    })),
+    }),
   ],
 })
 
-const planner = agent({
-  name: "planner",
-  tags: [
-    model(claudeHarness({
-      guard: shared,
-      timeoutMs: 120_000,
-    })),
-  ],
-})
+const otherScope = createScope({ tags: [claude({ guard: shared })] })
 ```
+
+`@pumped-fn/agent-sdk-codex` and `@pumped-fn/agent-sdk-claude` return lazy `model` tags. Tagging a scope does not create the CLI harness; first model use does. Replace them with each other or `model(fake)` at `createScope` or `createContext` without changing the agent graph.
 
 `codexHarness()` uses `codex exec --ephemeral --ignore-user-config`. `claudeHarness()` uses `claude -p --no-session-persistence` and rejects `--bare`; pass explicit `extraArgs` for other CLI flags. The default prompt asks for JSON with `content`, optional `guard`, and optional skill/tool/subagent calls. `guard` is the anti-goal; the first non-empty value is stored in material state and injected into later prompts. Pass a shared `guard("name")` atom when multiple harnesses should see the same anti-goal.
 

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -1,14 +1,15 @@
 # @pumped-fn/agent-sdk
 
-Agent workflow substrate helpers for `@pumped-fn/lite`.
+Agent workflow and application helpers for `@pumped-fn/lite`.
 
-This package does not add an agent runtime. It gives names and conventions to the primitives lite already has:
+This package does not add a hosted runtime or filesystem framework. It gives names and conventions to the primitives lite already has:
 
 | Lite primitive | Agent SDK use |
 |---|---|
 | `flow()` + `step({ workflow: true })` | Workflow boundary |
-| `flow()` | Worker, durable step, CLI-backed LLM call |
-| state/service | Provider, config, registry, model client, material state |
+| `flow()` | Worker, tool, subagent turn, durable step, CLI-backed LLM call |
+| state/service/atom | Provider, config, registry, model client, material state |
+| `resource()` | Per-run agent event capture |
 | typed tag | Routing config and ambient run data |
 | `ctx.exec()` | Step boundary for replay, remote routing, timeout, and suspend |
 | `workflowExtension()` | Replay, suspend, timeout, and event-log policy |
@@ -18,13 +19,15 @@ The core idea: author orchestration as normal TypeScript `flow()` code. Put ever
 
 ```mermaid
 flowchart TD
-  Root["workflow flow"] --> Exec["ctx.exec"]
+  Root["workflow flow or agent turn"] --> Exec["ctx.exec"]
   Exec --> Config["read step config"]
   Config --> Replay["completed? return cached"]
   Config --> Durable["durable? write pending + suspend"]
   Config --> Remote["remote? hand to worker runner"]
   Config --> Local["otherwise run next()"]
-  Local --> Log["write completed"]
+  Local --> Tool["tool/subagent/model provider flow"]
+  Tool --> Events["events resource"]
+  Events --> Log["write completed"]
   Remote --> Log
 ```
 
@@ -36,14 +39,244 @@ flowchart TD
 - `step()` config: `workflow`, `remote`, `durable`, `kind`, `timeoutMs`.
 - `workflowRun()` context tag for workflow-scoped run data.
 - `abortSignal` tag for cooperative timeout cancellation.
-- `agent` runtime tag for named worker delegation.
-- `WorkerRegistry` for named worker calls through `agent.delegate()`.
+- `runtime` tag for named worker delegation.
+- `WorkerRegistry` for named worker calls through `runtime.delegate()`.
+- `agent()`, `tool()`, `skill()`, and `sub()` for an agent application surface over lite.
+- `skillCalls` and `loadedSkills` for on-demand skill content.
+- `turn()` for model rounds that execute tools and subagents through `ctx.exec()`.
+- `session()` and `send()` for continuing message history backed by materials.
+- `events` for per-boundary run inspection.
+- `sandbox` for swappable command/file execution capabilities.
+- `channel()` and `schedule()` for inbound and clock-driven adapter flows.
+- `suite()`, `runEval()`, deterministic checks, and judge quorum helpers.
+- `inspect()` for workflow-log run inspection.
+- `summary()` for JSON-safe eval reports.
+- `http()` for Fetch request adapters.
 - `material()`, `patchMaterial()`, and `derivedMaterial()` for small task-scoped JSON materials.
 - `cliWorker()`, `claudeCliWorker()`, and `codexCliWorker()` for real CLI-backed work.
 
 `step()` is one defaulted config tag. Flow tags set defaults. Exec tags override per call.
 
-Transport is outside this core package. Tests use `@pumped-fn/agent-sdk-test` with an in-memory event log. A NATS package can implement the same `WorkflowEventLog` and `AgentRemoteRunner` contracts.
+Transport is outside this core package. Tests use `@pumped-fn/agent-sdk-test` with an in-memory event log. A NATS, HTTP, or queue package can implement the same `WorkflowEventLog` and `RemoteRunner` contracts.
+
+## Agent Application
+
+Use `agent()` when a model should choose tools or delegate to subagents, but keep every executable capability as a lite flow. A model is just a swappable provider. Tools and subagent turns run through `ctx.exec()`, so workflow replay, remote routing, timeouts, and event capture still apply at the same seam as the rest of the graph.
+
+```ts
+import { createScope, flow, typed } from "@pumped-fn/lite"
+import {
+  events,
+  agent,
+  skill,
+  sub,
+  tool,
+  turn,
+  type Model,
+} from "@pumped-fn/agent-sdk"
+
+const lookupTicket = tool({
+  description: "Load a ticket by id.",
+  flow: flow({
+    name: "lookup-ticket",
+    parse: typed<{ id: string }>(),
+    factory: (ctx) => ({ id: ctx.input.id, title: `ticket:${ctx.input.id}` }),
+  }),
+})
+
+const summarizeModel: Model = {
+  complete: (_ctx, request) => ({
+    content: `summary:${request.messages.at(-1)?.content ?? ""}`,
+    stop: true,
+  }),
+}
+
+const summarize = agent({
+  name: "summarize-ticket",
+  model: summarizeModel,
+  instructions: "Summarize the ticket context.",
+})
+
+const triageModel: Model = {
+  complete: (_ctx, request) => request.loadedSkills.length === 0
+    ? {
+        content: "need policy",
+        skillCalls: [{ name: "triage-policy" }],
+      }
+    : request.round === 1
+    ? {
+        content: "checking",
+        toolCalls: [{ name: "lookup-ticket", input: { id: "42" } }],
+        subagentCalls: [{ name: "summarize-ticket", input: { prompt: "ticket 42" } }],
+      }
+    : {
+        content: `ready:${request.messages.map((message) => message.content).join("|")}`,
+        stop: true,
+      },
+}
+
+const triage = agent({
+  name: "triage-ticket",
+  model: triageModel,
+  instructions: "Triage tickets with tools and delegated summaries.",
+  skills: [
+    skill({
+      name: "triage-policy",
+      description: "Ticket triage policy.",
+      content: "Escalate unclear incidents.",
+    }),
+  ],
+  tools: [lookupTicket],
+  subagents: [
+    sub({
+      description: "Summarizes ticket context.",
+      agent: summarize,
+    }),
+  ],
+})
+
+const scope = createScope()
+const ctx = scope.createContext()
+const result = await turn(ctx, triage, { prompt: "triage FEAT-42" })
+const trace = await ctx.resolve(events)
+await ctx.close()
+await scope.dispose()
+```
+
+`result.toolResults`, `result.subagentResults`, and `trace.events` are deterministic inspection surfaces. Tests can preset or fake the model provider without module mocks.
+
+## Sessions
+
+Use `session()` when a continuing agent needs message history. The session is a material, so history is ordinary scope state with revisioned patches.
+
+```ts
+import { session, send } from "@pumped-fn/agent-sdk"
+
+const thread = session("triage-session")
+
+await send(ctx, thread, triage, { prompt: "triage FEAT-42" })
+await send(ctx, thread, triage, { prompt: "summarize the decision" })
+```
+
+For persistent durability, pair the session material with a workflow event-log adapter. The core session API stays storage-agnostic.
+
+## Evals
+
+`suite()` accepts deterministic checks and zero or at least two judges. One judge is rejected because a subjective gate should not rest on a single model answer.
+
+```ts
+import {
+  suite,
+  judge,
+  includes,
+  runEval,
+  summary,
+} from "@pumped-fn/agent-sdk"
+
+const accepts = judge({
+  name: "accepts",
+  evaluate: () => ({ name: "accepts", passed: true, score: 1 }),
+})
+
+const grounded = judge({
+  name: "grounded",
+  evaluate: () => ({ name: "grounded", passed: true, score: 1 }),
+})
+
+const evaluation = suite({
+  name: "triage-quality",
+  agent: triage,
+  cases: [
+    {
+      name: "answers with readiness",
+      input: { prompt: "triage FEAT-42" },
+      checks: [includes("ready")],
+    },
+  ],
+  judges: [accepts, grounded],
+})
+
+const report = await runEval(ctx, evaluation)
+const artifact = summary(report)
+```
+
+## Runs And HTTP
+
+Use `inspect()` with any log that implements `RunLog`. `@pumped-fn/agent-sdk-test` provides an in-memory log; production packages can back the same contract with SQL, NATS, object storage, or a trace backend.
+
+```ts
+import { inspect, workflowRun } from "@pumped-fn/agent-sdk"
+
+const ctx = scope.createContext({
+  tags: [workflowRun({ taskId: "triage-42", runId: "run-1" })],
+})
+
+await turn(ctx, triage, { prompt: "triage FEAT-42" })
+const run = await inspect(log, { taskId: "triage-42", runId: "run-1" })
+```
+
+Use `http()` when an existing Fetch-compatible server should expose an agent turn. Auth, routing, and provider request verification stay outside the core package.
+
+```ts
+import { http } from "@pumped-fn/agent-sdk"
+
+const handle = http({ scope, agent: triage })
+const response = await handle(new Request("https://agent.local/run", {
+  method: "POST",
+  body: JSON.stringify({ prompt: "triage FEAT-42" }),
+}))
+```
+
+## Channels, Schedules, and Sandboxes
+
+Channels and schedules are flow adapters. They translate an external event or clock tick into an agent turn input, then execute that turn through `ctx.exec()`.
+
+```ts
+import { createScope, flow, tags, typed } from "@pumped-fn/lite"
+import {
+  channel,
+  schedule,
+  tool,
+  sandbox,
+} from "@pumped-fn/agent-sdk"
+
+const readWorkspace = tool({
+  description: "Read a file from the agent workspace.",
+  flow: flow({
+    name: "read-workspace",
+    parse: typed<{ path: string }>(),
+    deps: { sandbox: tags.required(sandbox) },
+    factory: (ctx, deps) => deps.sandbox.readFile(ctx.input.path),
+  }),
+})
+
+const slack = channel({
+  name: "slack-message",
+  parse: typed<{ text: string }>(),
+  agent: triage,
+  input: (ctx) => ({ prompt: ctx.input.text }),
+})
+
+const daily = schedule({
+  name: "daily-digest",
+  agent: triage,
+  input: () => ({ prompt: "daily digest" }),
+})
+
+const scope = createScope({
+  tags: [
+    sandbox({
+      readFile: (path) => `file:${path}`,
+      writeFile: () => undefined,
+      exec: (command, args = []) => ({
+        stdout: [command, ...args].join(" "),
+        stderr: "",
+        exitCode: 0,
+      }),
+    }),
+  ],
+})
+```
 
 ## Standalone Suspense
 
@@ -88,7 +321,7 @@ First run writes a pending entry and throws `SuspendSignal`. A resolver writes t
 ```ts
 import { createScope, flow, tags, typed } from "@pumped-fn/lite"
 import {
-  agent as agentRuntime,
+  runtime,
   extension,
   workflowRun,
   workflow as workflowRuntime,
@@ -114,10 +347,10 @@ const processIssue = flow({
   ],
   deps: {
     workflow: tags.required(workflowRuntime),
-    agent: tags.required(agentRuntime),
+    runtime: tags.required(runtime),
   },
-  factory: async (ctx, { workflow, agent }) => {
-    const summary = await agent.delegate<string, { text: string }>("summarize", {
+  factory: async (ctx, { workflow, runtime }) => {
+    const summary = await runtime.delegate<string, { text: string }>("summarize", {
       text: ctx.input.body,
     })
     return { taskId: workflow.taskId, summary }
@@ -142,7 +375,7 @@ const ctx = scope.createContext({
 const result = await ctx.exec({ flow: processIssue, input: { body: "..." } })
 ```
 
-`workflowRun()` is a tag and belongs in `createContext({ tags: [...] })`. `agent.delegate()` is just `ctx.exec({ flow, input })` plus a registry lookup. Supply that registry through a `workers(registry)` flow or context tag. `workflow` and `agent` are required deps; if the matching extension is missing, dependency resolution fails before the factory runs.
+`workflowRun()` is a tag and belongs in `createContext({ tags: [...] })`. `runtime.delegate()` is just `ctx.exec({ flow, input })` plus a registry lookup. Supply that registry through a `workers(registry)` flow or context tag. `workflow` and `runtime` are required deps; if the matching extension is missing, dependency resolution fails before the factory runs.
 
 ## AI Is Just A Provider
 
@@ -231,9 +464,9 @@ const html = derivedMaterial("status-html", status, renderStatus, { kind: "text"
 Use `@pumped-fn/agent-sdk-test` for in-memory replay and fake remote routing:
 
 ```ts
-import { agent } from "@pumped-fn/agent-sdk-test"
+import { kit } from "@pumped-fn/agent-sdk-test"
 
-const { extensions, log } = agent({
+const { extensions, log } = kit({
   remoteRunner: {
     run: async (event) => ({ routed: event.targetName }),
   },

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -224,11 +224,14 @@ Use `http()` when an existing Fetch-compatible server should expose an agent tur
 ```ts
 import { http } from "@pumped-fn/agent-sdk"
 
-const handle = http({ scope, agent: triage })
-const response = await handle(new Request("https://agent.local/run", {
-  method: "POST",
-  body: JSON.stringify({ prompt: "triage FEAT-42" }),
-}))
+const handle = http({ agent: triage })
+const response = await ctx.exec({
+  flow: handle,
+  input: new Request("https://agent.local/run", {
+    method: "POST",
+    body: JSON.stringify({ prompt: "triage FEAT-42" }),
+  }),
+})
 ```
 
 ## Channels, Schedules, and Sandboxes

--- a/packages/agent-sdk/README.md
+++ b/packages/agent-sdk/README.md
@@ -26,7 +26,9 @@ flowchart TD
   Config --> Remote["remote? hand to worker runner"]
   Config --> Local["otherwise run next()"]
   Local --> Tool["tool/subagent/model provider flow"]
+  Tool --> CLI["optional Codex/Claude CLI harness"]
   Tool --> Events["events resource"]
+  CLI --> Events
   Events --> Log["write completed"]
   Remote --> Log
 ```
@@ -47,6 +49,7 @@ flowchart TD
 - `session()` and `send()` for continuing message history backed by materials.
 - `events` for per-boundary run inspection.
 - `sandbox` for swappable command/file execution capabilities.
+- `guard()` for harness anti-goal state collected from the first model run.
 - `channel()` and `schedule()` for inbound and clock-driven adapter flows.
 - `suite()`, `runEval()`, deterministic checks, and judge quorum helpers.
 - `inspect()` for workflow-log run inspection.
@@ -54,6 +57,7 @@ flowchart TD
 - `http()` for Fetch request adapters.
 - `material()`, `patchMaterial()`, and `derivedMaterial()` for small task-scoped JSON materials.
 - `cliWorker()`, `claudeCliWorker()`, and `codexCliWorker()` for real CLI-backed work.
+- `claudeHarness()` and `codexHarness()` for non-interactive CLI model adapters with optional bwrap isolation.
 
 `step()` is one defaulted config tag. Flow tags set defaults. Exec tags override per call.
 
@@ -415,16 +419,38 @@ const testScope = createScope({
 })
 ```
 
-The CLI helpers are convenience adapters:
+The CLI helpers are convenience adapters. Harnesses turn the popular local CLIs into `Model` providers for `agent()`.
 
 ```ts
-import { claudeCliWorker, codexCliWorker } from "@pumped-fn/agent-sdk"
+import { claudeHarness, claudeCliWorker, codexHarness, codexCliWorker, guard } from "@pumped-fn/agent-sdk"
 
 const codex = codexCliWorker({ name: "codex-review", sandbox: "workspace-write" })
 const claude = claudeCliWorker({ name: "claude-plan" })
+const shared = guard("review-guard")
+
+const reviewer = agent({
+  name: "reviewer",
+  model: codexHarness({
+    sandbox: "read-only",
+    guard: shared,
+    timeoutMs: 120_000,
+  }),
+})
+
+const planner = agent({
+  name: "planner",
+  model: claudeHarness({
+    guard: shared,
+    timeoutMs: 120_000,
+  }),
+})
 ```
 
-Use them when the backend should invoke the real CLI. For stable tests, prefer provider state plus presets.
+`codexHarness()` uses `codex exec --ephemeral --ignore-user-config`. `claudeHarness()` uses `claude -p --no-session-persistence` and rejects `--bare`; pass explicit `extraArgs` for other CLI flags. The default prompt asks for JSON with `content`, optional `guard`, and optional skill/tool/subagent calls. `guard` is the anti-goal; the first non-empty value is stored in material state and injected into later prompts. Pass a shared `guard("name")` atom when multiple harnesses should see the same anti-goal.
+
+Harnesses default to bwrap isolation with network enabled because the CLIs need provider access. The sandbox mounts the workspace read-only by default, a temporary home, minimal runtime/cert/DNS paths, and only explicit credential directories such as `isolate: { network: true, codexHome: process.env.CODEX_HOME }`. Use `isolate: false` only when another trusted boundary already isolates the process.
+
+For stable tests, prefer provider state plus presets.
 
 ## Replay Contract
 

--- a/packages/agent-sdk/package.json
+++ b/packages/agent-sdk/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@pumped-fn/agent-sdk",
   "version": "1.0.0",
-  "private": true,
-  "description": "Agent workflow substrate helpers for @pumped-fn/lite",
+  "private": false,
+  "description": "Agent workflow and app helpers for @pumped-fn/lite",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -22,7 +22,8 @@
   "files": [
     "dist",
     "README.md",
-    "PATTERNS.md"
+    "PATTERNS.md",
+    "LICENSE"
   ],
   "publishConfig": {
     "access": "public"
@@ -34,10 +35,10 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@pumped-fn/lite": "^3.0.0"
+    "@pumped-fn/lite": "^3.1.0"
   },
   "dependencies": {
-    "@pumped-fn/lite-extension-suspense": "workspace:*"
+    "@pumped-fn/lite-extension-suspense": "workspace:^"
   },
   "devDependencies": {
     "@pumped-fn/lite": "workspace:*",

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import { atom, flow, tag, typed, type Lite } from "@pumped-fn/lite"
+import { atom, flow, isAtom, resource, tag, typed, type Lite } from "@pumped-fn/lite"
 import {
   extension as suspenseExtension,
   formatSuspenseStepKey,
@@ -9,7 +9,6 @@ import {
   type SuspenseStepEntry,
   type SuspenseStepKey,
 } from "@pumped-fn/lite-extension-suspense"
-import { execFile } from "node:child_process"
 
 export type WorkerKind = "code" | "llm" | "cli" | string
 export type MaterialKind = "json" | "text" | "binary" | "reference"
@@ -19,7 +18,7 @@ export type WorkflowStepKey = SuspenseStepKey
 export type WorkflowStepEntry = SuspenseStepEntry
 export type WorkflowEventLog = SuspenseEventLog
 export type WorkflowExecEvent = SuspenseExecEvent
-export interface AgentExecEvent {
+export interface ExecEvent {
   readonly key?: WorkflowStepKey
   readonly target: Lite.ExecTarget
   readonly ctx: Lite.ExecutionContext
@@ -36,8 +35,8 @@ export interface Step {
 
 export { SuspendSignal, SuspenseSignal } from "@pumped-fn/lite-extension-suspense"
 
-export interface AgentRemoteRunner {
-  run(event: AgentExecEvent, next: () => Promise<unknown>): Promise<unknown>
+export interface RemoteRunner {
+  run(event: ExecEvent, next: () => Promise<unknown>): Promise<unknown>
 }
 
 export interface WorkflowExtensionOptions {
@@ -46,8 +45,8 @@ export interface WorkflowExtensionOptions {
   defaultRunId?: string
 }
 
-export interface AgentExtensionOptions {
-  remoteRunner?: AgentRemoteRunner
+export interface ExtensionOptions {
+  remoteRunner?: RemoteRunner
 }
 
 export const step = tag<Step>({ label: "agent.step", default: {} })
@@ -96,7 +95,7 @@ export interface WorkflowContext {
   readonly runId: string
 }
 
-export interface AgentContext {
+export interface Runtime {
   readonly taskId: string
   readonly runId: string
   delegate<Output = unknown, Input = unknown>(name: string, input: Input): Promise<Output>
@@ -104,7 +103,7 @@ export interface AgentContext {
 
 export const workflowRun = tag<WorkflowRunOptions>({ label: "workflow.run" })
 export const workflow = tag<WorkflowContext>({ label: "workflow.runtime" })
-export const agent = tag<AgentContext>({ label: "agent.runtime" })
+export const runtime = tag<Runtime>({ label: "agent.runtime" })
 export const abortSignal = tag<AbortSignal>({ label: "workflow.abortSignal" })
 
 const activeWorkflowEvent = tag<WorkflowExecEvent>({ label: "workflow.event" })
@@ -138,14 +137,14 @@ export function workflowExtension(options: WorkflowExtensionOptions): Lite.Exten
   }
 }
 
-export function extension(options: AgentExtensionOptions = {}): Lite.Extension {
+export function extension(options: ExtensionOptions = {}): Lite.Extension {
   return {
     name: "agent-sdk",
     async wrapExec(next, target, ctx) {
-      return withRuntimeTag(ctx, agent, agentRuntimeOf(ctx), async () => {
+      return withRuntimeTag(ctx, runtime, runtimeOf(ctx), async () => {
         if (stepOf(target, ctx).remote !== true) return next()
         if (!options.remoteRunner) throw new Error("Remote step requires remoteRunner")
-        return options.remoteRunner.run(agentExecEvent(target, ctx), next)
+        return options.remoteRunner.run(execEvent(target, ctx), next)
       })
     },
   }
@@ -190,7 +189,7 @@ function registryOf(ctx: Lite.ExecutionContext): WorkerRegistry | undefined {
   return ctx.data.seekTag(workers)
 }
 
-function agentExecEvent(target: Lite.ExecTarget, ctx: Lite.ExecutionContext): AgentExecEvent {
+function execEvent(target: Lite.ExecTarget, ctx: Lite.ExecutionContext): ExecEvent {
   const workflowEvent = ctx.data.seekTag(activeWorkflowEvent)
   return workflowEvent ?? {
     target,
@@ -226,7 +225,7 @@ function workflowRuntimeOf(
   }
 }
 
-function agentRuntimeOf(ctx: Lite.ExecutionContext): AgentContext {
+function runtimeOf(ctx: Lite.ExecutionContext): Runtime {
   const config = ctx.data.seekTag(workflow)
   if (!config) throw new Error("agent extension requires workflow extension")
   return {
@@ -560,7 +559,8 @@ export interface RunCliOptions {
   signal?: AbortSignal
 }
 
-export function runCli(options: RunCliOptions): Promise<CliResult> {
+export async function runCli(options: RunCliOptions): Promise<CliResult> {
+  const { execFile } = await import("node:child_process")
   return new Promise((resolve, reject) => {
     const child = execFile(options.command, [...(options.args ?? [])], {
       cwd: options.cwd,
@@ -667,4 +667,926 @@ export function codexCliWorker(options: CodexCliWorkerOptions = {}): Lite.Flow<s
 function cliPromptArgs(args: readonly string[], prompt: string): string[] {
   if (args.includes("--")) throw new Error("CLI helper extraArgs cannot include --")
   return [...args, "--", prompt]
+}
+
+type MaybePromise<T> = T | Promise<T>
+
+export type Role = "system" | "user" | "assistant" | "tool" | "subagent" | "skill"
+
+export interface Message {
+  role: Role
+  content: string
+  name?: string
+}
+
+export interface ToolCall {
+  name: string
+  input: unknown
+  id?: string
+}
+
+export interface SubCall {
+  name: string
+  input: TurnInput
+  id?: string
+}
+
+export interface SkillCall {
+  name: string
+  id?: string
+}
+
+export interface ModelResponse {
+  content: string
+  skillCalls?: readonly SkillCall[]
+  toolCalls?: readonly ToolCall[]
+  subagentCalls?: readonly SubCall[]
+  stop?: boolean
+}
+
+export interface ModelRequest {
+  agentName: string
+  instructions: string
+  messages: readonly Message[]
+  tools: readonly Capability[]
+  skills: readonly Capability[]
+  loadedSkills: readonly LoadedSkill[]
+  subagents: readonly Capability[]
+  round: number
+}
+
+export interface Model {
+  complete(ctx: Lite.ExecutionContext, request: ModelRequest): MaybePromise<ModelResponse>
+}
+
+export interface SandboxExecResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+export interface Sandbox {
+  readFile(path: string): MaybePromise<string>
+  writeFile(path: string, content: string): MaybePromise<void>
+  exec(command: string, args?: readonly string[]): MaybePromise<SandboxExecResult>
+}
+
+export interface TurnInput {
+  messages?: readonly Message[]
+  prompt?: string
+  maxRounds?: number
+  metadata?: Lite.JsonValue
+}
+
+export interface Capability {
+  name: string
+  description: string
+}
+
+export interface Tool<Output = unknown, Input = unknown> extends Capability {
+  flow: Lite.Flow<Output, Input>
+}
+
+type AnyTool = Tool<any, any>
+
+export interface Skill {
+  name: string
+  description?: string
+  load(ctx: Lite.ExecutionContext): MaybePromise<string>
+}
+
+export interface LoadedSkill {
+  name: string
+  description?: string
+  content: string
+}
+
+export interface Sub extends Capability {
+  agent: Agent
+}
+
+export interface Agent {
+  name: string
+  description?: string
+  instructions: string
+  model: Lite.Atom<Model>
+  tools: readonly AnyTool[]
+  skills: readonly Skill[]
+  subagents: readonly Sub[]
+  turn: Lite.Flow<TurnResult, TurnInput>
+  maxRounds: number
+}
+
+export interface AgentOptions {
+  name: string
+  description?: string
+  instructions?: string
+  model: Lite.Atom<Model> | Model
+  tools?: readonly AnyTool[]
+  skills?: readonly Skill[]
+  subagents?: readonly Sub[]
+  maxRounds?: number
+  tags?: Lite.Tagged<any>[]
+}
+
+export interface ChannelOptions<Input> {
+  name: string
+  parse: ((raw: unknown) => MaybePromise<Input>) | Lite.Typed<Input>
+  agent: Agent
+  input(ctx: Lite.ExecutionContext & { readonly input: Input }): MaybePromise<TurnInput>
+  tags?: Lite.Tagged<any>[]
+}
+
+export interface ScheduleOptions {
+  name: string
+  agent: Agent
+  input(ctx: Lite.ExecutionContext): MaybePromise<TurnInput>
+  tags?: Lite.Tagged<any>[]
+}
+
+export interface ToolResult {
+  name: string
+  id?: string
+  input: unknown
+  output: unknown
+}
+
+export interface SkillResult {
+  name: string
+  id?: string
+  content: string
+}
+
+export interface SubResult {
+  name: string
+  id?: string
+  input: TurnInput
+  output: TurnResult
+}
+
+export interface TurnResult {
+  agentName: string
+  content: string
+  messages: readonly Message[]
+  skillResults: readonly SkillResult[]
+  toolResults: readonly ToolResult[]
+  subagentResults: readonly SubResult[]
+  rounds: number
+  events: readonly Event[]
+}
+
+export interface SessionState {
+  messages: readonly Message[]
+}
+
+export interface SessionOptions {
+  messages?: readonly Message[]
+  tags?: Lite.Tagged<any>[]
+  keepAlive?: boolean
+}
+
+export type EventType =
+  | "agent_start"
+  | "agent_model_start"
+  | "agent_model_end"
+  | "agent_skill_start"
+  | "agent_skill_end"
+  | "agent_tool_start"
+  | "agent_tool_end"
+  | "agent_subagent_start"
+  | "agent_subagent_end"
+  | "agent_end"
+
+export interface Event {
+  index: number
+  type: EventType
+  agentName: string
+  targetName?: string
+  round?: number
+  input?: unknown
+  output?: unknown
+}
+
+export interface EventBuffer {
+  readonly events: readonly Event[]
+  record(event: Omit<Event, "index">): Event
+}
+
+export const events = resource<EventBuffer>({
+  name: "agent.events",
+  ownership: "boundary",
+  factory: () => {
+    let next = 0
+    const events: Event[] = []
+    return {
+      get events() {
+        return events
+      },
+      record(event) {
+        const stored = { ...event, index: next++ }
+        events.push(stored)
+        return stored
+      },
+    }
+  },
+})
+
+export const sandbox = tag<Sandbox>({ label: "agent.sandbox" })
+
+export function session(name: string, options: SessionOptions = {}): Lite.Atom<MaterialState<SessionState>> {
+  return material(name, {
+    kind: "json",
+    initialState: { messages: options.messages ?? [] },
+    tags: options.tags,
+    keepAlive: options.keepAlive,
+  })
+}
+
+export interface ToolOptions<Output, Input> {
+  name?: string
+  description: string
+  flow: Lite.Flow<Output, Input>
+}
+
+export function tool<Output, Input>(options: ToolOptions<Output, Input>): Tool<Output, Input> {
+  const name = options.name ?? options.flow.name
+  if (!name) throw new Error("Agent tool requires a name")
+  return {
+    name,
+    description: options.description,
+    flow: options.flow,
+  }
+}
+
+export interface SkillOptions {
+  name: string
+  description?: string
+  content?: string
+  load?: (ctx: Lite.ExecutionContext) => MaybePromise<string>
+}
+
+export function skill(options: SkillOptions): Skill {
+  if (options.load) {
+    return {
+      name: options.name,
+      description: options.description,
+      load: options.load,
+    }
+  }
+  const content = options.content ?? ""
+  return {
+    name: options.name,
+    description: options.description,
+    load: () => content,
+  }
+}
+
+export interface SubOptions {
+  name?: string
+  description: string
+  agent: Agent
+}
+
+export function sub(options: SubOptions): Sub {
+  return {
+    name: options.name ?? options.agent.name,
+    description: options.description,
+    agent: options.agent,
+  }
+}
+
+export function agent(options: AgentOptions): Agent {
+  const model = modelAtomOf(options.model)
+  const tools = options.tools ?? []
+  const skills = options.skills ?? []
+  const subagents = options.subagents ?? []
+  const maxRounds = options.maxRounds ?? 4
+  let agent: Agent
+  const turn = flow({
+    name: options.name,
+    parse: typed<TurnInput>(),
+    deps: { model },
+    tags: agentStepTags({ workflow: true, kind: "agent" }, options.tags),
+    factory: (ctx, deps) => executeAgentTurn(ctx, agent, deps.model),
+  })
+  agent = {
+    name: options.name,
+    description: options.description,
+    instructions: options.instructions ?? "",
+    model,
+    tools,
+    skills,
+    subagents,
+    turn,
+    maxRounds,
+  }
+  return agent
+}
+
+export function turn(
+  ctx: Lite.ExecutionContext,
+  agent: Agent,
+  input: TurnInput
+): Promise<TurnResult> {
+  return ctx.exec({
+    flow: agent.turn,
+    input,
+    name: agent.name,
+  })
+}
+
+export async function send(
+  ctx: Lite.ExecutionContext,
+  session: Lite.Atom<MaterialState<SessionState>>,
+  agent: Agent,
+  input: TurnInput
+): Promise<TurnResult> {
+  const current = await ctx.resolve(session)
+  const result = await turn(ctx, agent, {
+    ...input,
+    messages: [
+      ...current.state.messages,
+      ...(input.messages ?? []),
+    ],
+  })
+  await patchMaterial(ctx, session, [
+    { op: "replace", path: "/messages", value: serializeMessages(result.messages) },
+  ], { expectedRevision: current.revision })
+  return result
+}
+
+export function channel<Input>(options: ChannelOptions<Input>): Lite.Flow<TurnResult, Input> {
+  const flowOptions = {
+    name: options.name,
+    tags: agentStepTags({ workflow: true, kind: "channel" }, options.tags),
+    factory: async (ctx: Lite.ExecutionContext & { readonly input: Input }) =>
+      turn(ctx, options.agent, await options.input(ctx)),
+  }
+  return typeof options.parse === "function"
+    ? flow<TurnResult, Input>({ ...flowOptions, parse: options.parse })
+    : flow<TurnResult, Input>({ ...flowOptions, parse: options.parse })
+}
+
+export function schedule(options: ScheduleOptions): Lite.Flow<TurnResult, void> {
+  return flow({
+    name: options.name,
+    tags: agentStepTags({ workflow: true, kind: "schedule" }, options.tags),
+    factory: async (ctx) => turn(ctx, options.agent, await options.input(ctx)),
+  })
+}
+
+export interface EvalCheckResult {
+  name: string
+  passed: boolean
+  details?: string
+}
+
+export type EvalCheck = (result: TurnResult) => MaybePromise<EvalCheckResult>
+
+export interface JudgeResult {
+  name: string
+  passed: boolean
+  score?: number
+  reason?: string
+}
+
+export interface Judge {
+  name: string
+  evaluate(ctx: Lite.ExecutionContext, result: TurnResult): MaybePromise<JudgeResult>
+}
+
+export interface EvalCase {
+  name: string
+  input: TurnInput
+  checks?: readonly EvalCheck[]
+}
+
+export interface Suite {
+  name: string
+  agent: Agent
+  cases: readonly EvalCase[]
+  judges: readonly Judge[]
+}
+
+export interface SuiteOptions {
+  name: string
+  agent: Agent
+  cases: readonly EvalCase[]
+  judges?: readonly Judge[]
+}
+
+export interface EvalCaseReport {
+  name: string
+  result: TurnResult
+  checks: readonly EvalCheckResult[]
+  judges: readonly JudgeResult[]
+  passed: boolean
+}
+
+export interface EvalReport {
+  name: string
+  cases: readonly EvalCaseReport[]
+  passed: boolean
+}
+
+export interface RunQuery {
+  taskId: string
+  runId: string
+}
+
+export interface RunStep {
+  key: WorkflowStepKey
+  status: WorkflowStepEntry["status"]
+  targetName: string
+  input?: unknown
+  output?: unknown
+  kind?: string
+}
+
+export interface RunRecord {
+  taskId: string
+  runId: string
+  status: "pending" | "completed"
+  steps: readonly RunStep[]
+}
+
+export interface RunLog extends WorkflowEventLog {
+  entries(query?: Partial<RunQuery>): MaybePromise<readonly WorkflowStepEntry[]>
+}
+
+export interface HttpOptions {
+  scope: Lite.Scope
+  agent: Agent
+  input?: (request: Request) => MaybePromise<TurnInput>
+  tags?: (request: Request) => MaybePromise<Lite.Tagged<any>[]>
+}
+
+export function judge(options: Judge): Judge {
+  return options
+}
+
+export function suite(options: SuiteOptions): Suite {
+  const judges = options.judges ?? []
+  assertJudgeQuorum(judges)
+  return {
+    name: options.name,
+    agent: options.agent,
+    cases: options.cases,
+    judges,
+  }
+}
+
+export function includes(text: string): EvalCheck {
+  return (result) => ({
+    name: `output includes "${text}"`,
+    passed: result.content.includes(text),
+  })
+}
+
+export function used(name: string): EvalCheck {
+  return (result) => ({
+    name: `tool used "${name}"`,
+    passed: result.toolResults.some((call) => call.name === name),
+  })
+}
+
+export function loaded(name: string): EvalCheck {
+  return (result) => ({
+    name: `skill loaded "${name}"`,
+    passed: result.skillResults.some((call) => call.name === name),
+  })
+}
+
+export function delegated(name: string): EvalCheck {
+  return (result) => ({
+    name: `subagent used "${name}"`,
+    passed: result.subagentResults.some((call) => call.name === name),
+  })
+}
+
+export async function runEval(ctx: Lite.ExecutionContext, target: Suite): Promise<EvalReport> {
+  assertJudgeQuorum(target.judges)
+  const cases: EvalCaseReport[] = []
+  for (const item of target.cases) {
+    const result = await turn(ctx, target.agent, item.input)
+    const checks = await runEvalChecks(result, item.checks ?? [])
+    const judges = await runEvalJudges(ctx, result, target.judges)
+    cases.push({
+      name: item.name,
+      result,
+      checks,
+      judges,
+      passed: checks.every((check) => check.passed) && judges.every((judge) => judge.passed),
+    })
+  }
+  return {
+    name: target.name,
+    cases,
+    passed: cases.every((item) => item.passed),
+  }
+}
+
+export async function inspect(log: RunLog, query: RunQuery): Promise<RunRecord> {
+  const entries = (await log.entries(query)).filter((entry) =>
+    entry.key.taskId === query.taskId && entry.key.runId === query.runId
+  )
+  const first = entries[0]
+  if (!first) throw new Error("Run not found")
+  const steps = entries.map(runStep)
+  return {
+    taskId: query.taskId,
+    runId: query.runId,
+    status: steps.some((item) => item.status === "pending") ? "pending" : "completed",
+    steps,
+  }
+}
+
+export function summary(report: EvalReport): Lite.JsonValue {
+  return jsonValue({
+    name: report.name,
+    passed: report.passed,
+    cases: report.cases.map((item) => ({
+      name: item.name,
+      passed: item.passed,
+      output: item.result.content,
+      checks: item.checks,
+      judges: item.judges,
+      tools: item.result.toolResults.map((call) => ({ name: call.name, output: call.output })),
+      skills: item.result.skillResults.map((call) => ({ name: call.name })),
+      subagents: item.result.subagentResults.map((call) => ({ name: call.name, output: call.output.content })),
+      events: item.result.events.map((event) => ({
+        type: event.type,
+        agentName: event.agentName,
+        targetName: event.targetName,
+        round: event.round,
+      })),
+    })),
+  })
+}
+
+export function http(options: HttpOptions): (request: Request) => Promise<Response> {
+  return async (request) => {
+    const input = options.input ? await options.input(request) : await request.json() as TurnInput
+    const tags = options.tags ? await options.tags(request) : []
+    const ctx = options.scope.createContext({ tags })
+    return turn(ctx, options.agent, input).then(
+      async (result) => {
+        await ctx.close()
+        return Response.json(jsonValue(result))
+      },
+      async (error) => {
+        await ctx.close({ ok: false, error })
+        throw error
+      }
+    )
+  }
+}
+
+async function executeAgentTurn(
+  ctx: Lite.ExecutionContext & { readonly input: TurnInput },
+  agent: Agent,
+  model: Model
+): Promise<TurnResult> {
+  const messages = initialMessages(ctx.input)
+  const loadedSkills: LoadedSkill[] = []
+  const skillResults: SkillResult[] = []
+  const toolResults: ToolResult[] = []
+  const subagentResults: SubResult[] = []
+  const maxRounds = ctx.input.maxRounds ?? agent.maxRounds
+  let content = ""
+  let rounds = 0
+  const startIndex = (await ctx.resolve(events)).events.length
+
+  await recordAgentEvent(ctx, {
+    type: "agent_start",
+    agentName: agent.name,
+    input: ctx.input,
+  })
+
+  for (let round = 0; round < maxRounds; round++) {
+    rounds = round + 1
+    await recordAgentEvent(ctx, {
+      type: "agent_model_start",
+      agentName: agent.name,
+      round,
+      input: messages,
+    })
+    const response = await model.complete(ctx, {
+      agentName: agent.name,
+      instructions: agent.instructions,
+      messages,
+      tools: agent.tools.map(agentToolCapability),
+      skills: agent.skills.map(agentSkillCapability),
+      loadedSkills,
+      subagents: agent.subagents.map(agentSubagentCapability),
+      round,
+    })
+    content = response.content
+    await recordAgentEvent(ctx, {
+      type: "agent_model_end",
+      agentName: agent.name,
+      round,
+      output: response,
+    })
+
+    const skillCalls = response.skillCalls ?? []
+    const toolCalls = response.toolCalls ?? []
+    const subagentCalls = response.subagentCalls ?? []
+    if (response.content) messages.push({ role: "assistant", content: response.content })
+    if (response.stop === true || (skillCalls.length === 0 && toolCalls.length === 0 && subagentCalls.length === 0)) break
+
+    for (const call of skillCalls) {
+      const result = await executeAgentSkill(ctx, agent, call)
+      loadedSkills.push({
+        name: result.name,
+        content: result.content,
+        description: findByName(agent.skills, result.name, "skill").description,
+      })
+      skillResults.push(result)
+      messages.push({
+        role: "skill",
+        name: result.name,
+        content: result.content,
+      })
+    }
+
+    for (const call of toolCalls) {
+      const result = await executeAgentTool(ctx, agent, call)
+      toolResults.push(result)
+      messages.push({
+        role: "tool",
+        name: result.name,
+        content: stringifyAgentValue(result.output),
+      })
+    }
+
+    for (const call of subagentCalls) {
+      const result = await executeAgentSubagent(ctx, agent, call)
+      subagentResults.push(result)
+      messages.push({
+        role: "subagent",
+        name: result.name,
+        content: result.output.content,
+      })
+    }
+  }
+
+  await recordAgentEvent(ctx, {
+    type: "agent_end",
+    agentName: agent.name,
+    output: content,
+  })
+
+  const buffer = await ctx.resolve(events)
+  return {
+    agentName: agent.name,
+    content,
+    messages,
+    skillResults,
+    toolResults,
+    subagentResults,
+    rounds,
+    events: buffer.events.slice(startIndex),
+  }
+}
+
+async function executeAgentSkill(
+  ctx: Lite.ExecutionContext,
+  agent: Agent,
+  call: SkillCall
+): Promise<SkillResult> {
+  const target = findByName(agent.skills, call.name, "skill")
+  await recordAgentEvent(ctx, {
+    type: "agent_skill_start",
+    agentName: agent.name,
+    targetName: target.name,
+  })
+  const content = await ctx.exec({
+    fn: (skillCtx) => target.load(skillCtx),
+    params: [],
+    name: target.name,
+    tags: [agentStepTag({ workflow: true, kind: "skill" })],
+  })
+  await recordAgentEvent(ctx, {
+    type: "agent_skill_end",
+    agentName: agent.name,
+    targetName: target.name,
+    output: content,
+  })
+  return {
+    name: target.name,
+    id: call.id,
+    content,
+  }
+}
+
+async function executeAgentTool(
+  ctx: Lite.ExecutionContext,
+  agent: Agent,
+  call: ToolCall
+): Promise<ToolResult> {
+  const target = findByName(agent.tools, call.name, "tool")
+  await recordAgentEvent(ctx, {
+    type: "agent_tool_start",
+    agentName: agent.name,
+    targetName: target.name,
+    input: call.input,
+  })
+  const output = await ctx.exec({
+    flow: target.flow as Lite.Flow<unknown, unknown>,
+    rawInput: call.input,
+    name: target.name,
+    tags: [agentStepTag({ workflow: true, kind: "tool" }, target.flow.tags)],
+  })
+  await recordAgentEvent(ctx, {
+    type: "agent_tool_end",
+    agentName: agent.name,
+    targetName: target.name,
+    output,
+  })
+  return {
+    name: target.name,
+    id: call.id,
+    input: call.input,
+    output,
+  }
+}
+
+async function executeAgentSubagent(
+  ctx: Lite.ExecutionContext,
+  agent: Agent,
+  call: SubCall
+): Promise<SubResult> {
+  const target = findByName(agent.subagents, call.name, "subagent")
+  await recordAgentEvent(ctx, {
+    type: "agent_subagent_start",
+    agentName: agent.name,
+    targetName: target.name,
+    input: call.input,
+  })
+  const output = await ctx.exec({
+    flow: target.agent.turn,
+    input: call.input,
+    name: target.name,
+    tags: [agentStepTag({ workflow: true, kind: "subagent" }, target.agent.turn.tags)],
+  })
+  await recordAgentEvent(ctx, {
+    type: "agent_subagent_end",
+    agentName: agent.name,
+    targetName: target.name,
+    output,
+  })
+  return {
+    name: target.name,
+    id: call.id,
+    input: call.input,
+    output,
+  }
+}
+
+async function recordAgentEvent(
+  ctx: Lite.ExecutionContext,
+  event: Omit<Event, "index">
+): Promise<Event> {
+  return (await ctx.resolve(events)).record(event)
+}
+
+function initialMessages(input: TurnInput): Message[] {
+  return [
+    ...(input.messages ?? []),
+    ...(input.prompt ? [{ role: "user" as const, content: input.prompt }] : []),
+  ]
+}
+
+function modelAtomOf(model: Lite.Atom<Model> | Model): Lite.Atom<Model> {
+  return isAtom(model)
+    ? model as Lite.Atom<Model>
+    : atom({ factory: () => model })
+}
+
+function agentStepTags(defaults: Step, source: Lite.Tagged<any>[] = []): Lite.Tagged<any>[] {
+  return [
+    agentStepTag(defaults, source),
+    ...source.filter((tagged) => tagged.key !== step.key),
+  ]
+}
+
+function agentStepTag(defaults: Step, source: Lite.Tagged<any>[] = []): Lite.Tagged<Step> {
+  return step(Object.assign({}, defaults, ...step.collect(source)))
+}
+
+function agentToolCapability(tool: AnyTool): Capability {
+  return {
+    name: tool.name,
+    description: tool.description,
+  }
+}
+
+function agentSkillCapability(skill: Skill): Capability {
+  return {
+    name: skill.name,
+    description: skill.description ?? "",
+  }
+}
+
+function agentSubagentCapability(subagent: Sub): Capability {
+  return {
+    name: subagent.name,
+    description: subagent.description,
+  }
+}
+
+function findByName<T extends { name: string }>(items: readonly T[], name: string, kind: string): T {
+  const found = items.find((item) => item.name === name)
+  if (!found) throw new Error(`Agent ${kind} "${name}" not found`)
+  return found
+}
+
+function runStep(entry: WorkflowStepEntry): RunStep {
+  if (entry.status === "pending") {
+    return {
+      key: entry.key,
+      status: entry.status,
+      targetName: entry.targetName,
+      input: entry.input,
+      kind: entry.kind,
+    }
+  }
+  if (entry.status === "resolved") {
+    return {
+      key: entry.key,
+      status: entry.status,
+      targetName: entry.targetName,
+      output: entry.value,
+    }
+  }
+  return {
+    key: entry.key,
+    status: entry.status,
+    targetName: entry.targetName,
+    output: entry.result,
+  }
+}
+
+function stringifyAgentValue(value: unknown): string {
+  if (typeof value === "string") return value
+  if (value === undefined) return String(value)
+  if (typeof value === "bigint" || typeof value === "symbol" || typeof value === "function") return String(value)
+  const seen = new WeakSet<object>()
+  const serialized = JSON.stringify(value, (_key, item: unknown) => {
+    if (typeof item === "bigint" || typeof item === "symbol" || typeof item === "function") return String(item)
+    if (typeof item === "object" && item !== null) {
+      if (seen.has(item)) return "[Circular]"
+      seen.add(item)
+    }
+    return item
+  })
+  return serialized ?? String(value)
+}
+
+function jsonValue(value: unknown, seen = new WeakSet<object>()): Lite.JsonValue {
+  if (value === null) return null
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value
+  if (value === undefined || typeof value === "bigint" || typeof value === "symbol" || typeof value === "function") return String(value)
+  if (Array.isArray(value)) return value.map((item) => jsonValue(item, seen))
+  if (typeof value === "object") {
+    if (seen.has(value)) return "[Circular]"
+    seen.add(value)
+    return Object.fromEntries(Object.entries(value as Record<string, unknown>).map(([key, item]) => [key, jsonValue(item, seen)]))
+  }
+  return String(value)
+}
+
+function serializeMessages(messages: readonly Message[]): Lite.JsonValue {
+  return messages.map((message) => {
+    const serialized: Record<string, Lite.JsonValue> = {
+      role: message.role,
+      content: message.content,
+    }
+    if (message.name !== undefined) serialized["name"] = message.name
+    return serialized
+  })
+}
+
+async function runEvalChecks(
+  result: TurnResult,
+  checks: readonly EvalCheck[]
+): Promise<EvalCheckResult[]> {
+  const results: EvalCheckResult[] = []
+  for (const check of checks) results.push(await check(result))
+  return results
+}
+
+function assertJudgeQuorum(judges: readonly Judge[]): void {
+  if (judges.length === 1) throw new Error("Agent evals require zero judges or at least two judges")
+}
+
+async function runEvalJudges(
+  ctx: Lite.ExecutionContext,
+  result: TurnResult,
+  judges: readonly Judge[]
+): Promise<JudgeResult[]> {
+  const results: JudgeResult[] = []
+  for (const judge of judges) results.push(await judge.evaluate(ctx, result))
+  return results
 }

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -1381,14 +1381,6 @@ export function agent(options: AgentOptions): Agent {
   return agent
 }
 
-export function turn(
-  ctx: Lite.ExecutionContext,
-  agent: Agent,
-  input: TurnInput
-): Promise<TurnResult> {
-  return execTurn(ctx, agent, input)
-}
-
 function execTurn(
   ctx: Lite.ExecutionContext,
   agent: Agent,
@@ -1410,7 +1402,7 @@ export async function send(
   input: TurnInput
 ): Promise<TurnResult> {
   const current = await ctx.resolve(session)
-  const result = await turn(ctx, agent, {
+  const result = await execTurn(ctx, agent, {
     ...input,
     messages: [
       ...current.state.messages,
@@ -1428,7 +1420,7 @@ export function channel<Input>(options: ChannelOptions<Input>): Lite.Flow<TurnRe
     name: options.name,
     tags: agentStepTags({ workflow: true, kind: "channel" }, options.tags),
     factory: async (ctx: Lite.ExecutionContext & { readonly input: Input }) =>
-      turn(ctx, options.agent, await options.input(ctx)),
+      execTurn(ctx, options.agent, await options.input(ctx)),
   }
   return typeof options.parse === "function"
     ? flow<TurnResult, Input>({ ...flowOptions, parse: options.parse })
@@ -1439,7 +1431,7 @@ export function schedule(options: ScheduleOptions): Lite.Flow<TurnResult, void> 
   return flow({
     name: options.name,
     tags: agentStepTags({ workflow: true, kind: "schedule" }, options.tags),
-    factory: async (ctx) => turn(ctx, options.agent, await options.input(ctx)),
+    factory: async (ctx) => execTurn(ctx, options.agent, await options.input(ctx)),
   })
 }
 
@@ -1576,7 +1568,7 @@ export async function runEval(ctx: Lite.ExecutionContext, target: Suite): Promis
   assertJudgeQuorum(target.judges)
   const cases: EvalCaseReport[] = []
   for (const item of target.cases) {
-    const result = await turn(ctx, target.agent, item.input)
+    const result = await execTurn(ctx, target.agent, item.input)
     const checks = await runEvalChecks(result, item.checks ?? [])
     const judges = await runEvalJudges(ctx, result, target.judges)
     cases.push({

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -1,4 +1,4 @@
-import { atom, flow, isAtom, resource, tag, typed, type Lite } from "@pumped-fn/lite"
+import { atom, flow, resource, tag, tags, typed, type Lite } from "@pumped-fn/lite"
 import {
   extension as suspenseExtension,
   formatSuspenseStepKey,
@@ -1170,7 +1170,6 @@ export interface Agent {
   name: string
   description?: string
   instructions: string
-  model: Lite.Atom<Model>
   tools: readonly AnyTool[]
   skills: readonly Skill[]
   subagents: readonly Sub[]
@@ -1182,7 +1181,6 @@ export interface AgentOptions {
   name: string
   description?: string
   instructions?: string
-  model: Lite.Atom<Model> | Model
   tools?: readonly AnyTool[]
   skills?: readonly Skill[]
   subagents?: readonly Sub[]
@@ -1292,6 +1290,7 @@ export const events = resource<EventBuffer>({
   },
 })
 
+export const model = tag<Model>({ label: "agent.model" })
 export const sandbox = tag<Sandbox>({ label: "agent.sandbox" })
 
 export function session(name: string, options: SessionOptions = {}): Lite.Atom<MaterialState<SessionState>> {
@@ -1357,7 +1356,6 @@ export function sub(options: SubOptions): Sub {
 }
 
 export function agent(options: AgentOptions): Agent {
-  const model = modelAtomOf(options.model)
   const tools = options.tools ?? []
   const skills = options.skills ?? []
   const subagents = options.subagents ?? []
@@ -1366,7 +1364,7 @@ export function agent(options: AgentOptions): Agent {
   const turn = flow({
     name: options.name,
     parse: typed<TurnInput>(),
-    deps: { model },
+    deps: { model: tags.required(model) },
     tags: agentStepTags({ workflow: true, kind: "agent" }, options.tags),
     factory: (ctx, deps) => executeAgentTurn(ctx, agent, deps.model),
   })
@@ -1374,7 +1372,6 @@ export function agent(options: AgentOptions): Agent {
     name: options.name,
     description: options.description,
     instructions: options.instructions ?? "",
-    model,
     tools,
     skills,
     subagents,
@@ -1863,12 +1860,6 @@ function initialMessages(input: TurnInput): Message[] {
     ...(input.messages ?? []),
     ...(input.prompt ? [{ role: "user" as const, content: input.prompt }] : []),
   ]
-}
-
-function modelAtomOf(model: Lite.Atom<Model> | Model): Lite.Atom<Model> {
-  return isAtom(model)
-    ? model as Lite.Atom<Model>
-    : atom({ factory: () => model })
 }
 
 function agentStepTags(defaults: Step, source: Lite.Tagged<any>[] = []): Lite.Tagged<any>[] {

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -124,7 +124,7 @@ export function workflowExtension(options: WorkflowExtensionOptions): Lite.Exten
     name: "workflow",
     options,
     shouldHandle: shouldHandleWorkflowTarget,
-    run: (event, next) => runTimed(event.target, event.ctx, next),
+    run: (event, next) => runTimer(event.target, event.ctx, next),
   })
 
   return {
@@ -272,7 +272,7 @@ function targetNameOf(target: Lite.ExecTarget, ctx: Lite.ExecutionContext): stri
   return name
 }
 
-function runTimed(target: Lite.ExecTarget, ctx: Lite.ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
+function runTimer(target: Lite.ExecTarget, ctx: Lite.ExecutionContext, next: () => Promise<unknown>): Promise<unknown> {
   const timeoutMs = stepOf(target, ctx).timeoutMs
   if (timeoutMs === undefined) return next()
   const controller = new AbortController()
@@ -346,7 +346,7 @@ export async function patchMaterial<T>(
   ops: JsonPatchOperation[],
   options: { expectedRevision?: number } = {}
 ): Promise<MaterialState<T>> {
-  return queueMaterialPatch(ctx.scope, target, async () => {
+  return queueMaterialPatch(ctx, target, async () => {
     const ctrl = ctx.scope.controller(target)
     if (ctrl.state === "idle") await ctrl.resolve()
     const current = ctrl.get()
@@ -383,14 +383,14 @@ export function derivedMaterial<TSource, TOutput>(
 }
 
 function queueMaterialPatch<T>(
-  scope: Lite.Scope,
+  ctx: Lite.ExecutionContext,
   target: Lite.Atom<MaterialState<T>>,
   run: () => Promise<MaterialState<T>>
 ): Promise<MaterialState<T>> {
-  let scopePatches = materialPatches.get(scope)
+  let scopePatches = materialPatches.get(ctx.scope)
   if (!scopePatches) {
     scopePatches = new WeakMap()
-    materialPatches.set(scope, scopePatches)
+    materialPatches.set(ctx.scope, scopePatches)
   }
   const previous = scopePatches.get(target) ?? Promise.resolve()
   const current = previous.catch(() => undefined).then(run)
@@ -1389,10 +1389,20 @@ export function turn(
   agent: Agent,
   input: TurnInput
 ): Promise<TurnResult> {
+  return execTurn(ctx, agent, input)
+}
+
+function execTurn(
+  ctx: Lite.ExecutionContext,
+  agent: Agent,
+  input: TurnInput,
+  tags: readonly Lite.Tagged<any>[] = []
+): Promise<TurnResult> {
   return ctx.exec({
     flow: agent.turn,
     input,
     name: agent.name,
+    tags: [...tags],
   })
 }
 
@@ -1516,7 +1526,7 @@ export interface RunLog extends WorkflowEventLog {
 }
 
 export interface HttpOptions {
-  scope: Lite.Scope
+  name?: string
   agent: Agent
   input?: (request: Request) => MaybePromise<TurnInput>
   tags?: (request: Request) => MaybePromise<Lite.Tagged<any>[]>
@@ -1625,22 +1635,18 @@ export function summary(report: EvalReport): Lite.JsonValue {
   })
 }
 
-export function http(options: HttpOptions): (request: Request) => Promise<Response> {
-  return async (request) => {
-    const input = options.input ? await options.input(request) : await request.json() as TurnInput
-    const tags = options.tags ? await options.tags(request) : []
-    const ctx = options.scope.createContext({ tags })
-    return turn(ctx, options.agent, input).then(
-      async (result) => {
-        await ctx.close()
-        return Response.json(jsonValue(result))
-      },
-      async (error) => {
-        await ctx.close({ ok: false, error })
-        throw error
-      }
-    )
-  }
+export function http(options: HttpOptions): Lite.Flow<Response, Request> {
+  return flow({
+    name: options.name ?? `${options.agent.name}-http`,
+    parse: typed<Request>(),
+    tags: agentStepTags({ workflow: true, kind: "channel" }),
+    factory: async (ctx: Lite.ExecutionContext & { readonly input: Request }) => {
+      const request = ctx.input
+      const input = options.input ? await options.input(request) : await request.json() as TurnInput
+      const tags = options.tags ? await options.tags(request) : []
+      return Response.json(jsonValue(await execTurn(ctx, options.agent, input, tags)))
+    },
+  })
 }
 
 async function executeAgentTurn(

--- a/packages/agent-sdk/src/index.ts
+++ b/packages/agent-sdk/src/index.ts
@@ -486,6 +486,23 @@ function clone<T>(value: T): T {
 
 type Resolvable<Input, T> = T | ((input: Input, ctx: Lite.ExecutionContext) => T)
 
+export interface CliBind {
+  source: string
+  target?: string
+  mode?: "ro" | "rw"
+}
+
+export interface CliIsolateOptions {
+  bwrap?: string
+  workdir?: string
+  home?: string
+  codexHome?: string
+  writable?: boolean
+  network?: boolean
+  bind?: readonly CliBind[]
+  env?: Record<string, string | undefined>
+}
+
 export interface CliResult {
   stdout: string
   stderr: string
@@ -501,6 +518,7 @@ export interface CliWorkerOptions<Input, Output> {
   stdin?: Resolvable<Input, string | undefined>
   cwd?: Resolvable<Input, string | undefined>
   env?: Resolvable<Input, Record<string, string | undefined> | undefined>
+  isolate?: Resolvable<Input, boolean | CliIsolateOptions | undefined>
   timeoutMs?: number
   kind?: WorkerKind
   parseOutput?: (result: CliResult, input: Input) => Output
@@ -532,6 +550,7 @@ export function cliWorker<Input = { prompt: string }, Output = string>(
       stdin: resolveValue(options.stdin, input, ctx),
       cwd: resolveValue(options.cwd, input, ctx),
       env: resolveValue(options.env, input, ctx),
+      isolate: resolveValue(options.isolate, input, ctx),
       timeoutMs: options.timeoutMs,
       signal: ctx.data.seekTag(abortSignal),
     })
@@ -555,19 +574,22 @@ export interface RunCliOptions {
   stdin?: string
   cwd?: string
   env?: Record<string, string | undefined>
+  isolate?: boolean | CliIsolateOptions
   timeoutMs?: number
   signal?: AbortSignal
 }
 
 export async function runCli(options: RunCliOptions): Promise<CliResult> {
   const { execFile } = await import("node:child_process")
+  const prepared = await prepareCli(options)
   return new Promise((resolve, reject) => {
-    const child = execFile(options.command, [...(options.args ?? [])], {
-      cwd: options.cwd,
-      env: { ...process.env, ...options.env },
+    const child = execFile(prepared.command, [...prepared.args], {
+      cwd: prepared.cwd,
+      env: prepared.env,
       timeout: options.timeoutMs,
       signal: options.signal,
-    }, (error, stdout, stderr) => {
+    }, async (error, stdout, stderr) => {
+      await prepared.cleanup()
       const execError = error as ExecFileError | null
       const exitCode = typeof execError?.code === "number" ? execError.code : error ? null : 0
       const signal = execError?.signal ?? null
@@ -590,6 +612,165 @@ export async function runCli(options: RunCliOptions): Promise<CliResult> {
 
     child.stdin?.end(options.stdin)
   })
+}
+
+interface PreparedCli {
+  command: string
+  args: readonly string[]
+  cwd?: string
+  env: Record<string, string | undefined>
+  cleanup(): Promise<void>
+}
+
+interface PreparedBind {
+  source: string
+  target: string
+  mode: "ro" | "rw"
+}
+
+async function prepareCli(options: RunCliOptions): Promise<PreparedCli> {
+  if (!options.isolate) {
+    return {
+      command: options.command,
+      args: options.args ?? [],
+      cwd: options.cwd,
+      env: { ...process.env, ...options.env },
+      cleanup: async () => undefined,
+    }
+  }
+  return prepareIsolatedCli(options, typeof options.isolate === "boolean" ? {} : options.isolate)
+}
+
+async function prepareIsolatedCli(options: RunCliOptions, isolate: CliIsolateOptions): Promise<PreparedCli> {
+  const { mkdtemp, rm, realpath } = await import("node:fs/promises")
+  const { existsSync } = await import("node:fs")
+  const { dirname, join, resolve } = await import("node:path")
+  const { tmpdir } = await import("node:os")
+  const hostCwd = resolve(options.cwd ?? process.cwd())
+  const workdir = isolate.workdir ?? "/workspace"
+  const tempDirs: string[] = []
+  const home = isolate.home ?? await mkdtemp(join(tmpdir(), "pumped-fn-home-"))
+  if (!isolate.home) tempDirs.push(home)
+  const binds = new Map<string, PreparedBind>()
+  addBind(binds, hostCwd, workdir, isolate.writable === true ? "rw" : "ro")
+  addBind(binds, home, "/home/agent", "rw")
+  if (isolate.codexHome) addBind(binds, isolate.codexHome, "/codex-home", "rw")
+  const commandPath = await commandPathOf(options.command, process.env["PATH"] ?? "", existsSync, realpath)
+  const nodePath = await realpath(process.execPath)
+  for (const dir of defaultCliDirs(existsSync)) addBind(binds, dir, dir, "ro")
+  for (const dir of defaultCliCertDirs(existsSync)) addBind(binds, dir, dir, "ro")
+  for (const file of defaultCliFiles(existsSync)) addBind(binds, file, file, "ro")
+  if (commandPath) {
+    addBind(binds, dirname(commandPath), dirname(commandPath), "ro")
+    addBind(binds, dirname(dirname(commandPath)), dirname(dirname(commandPath)), "ro")
+  }
+  addBind(binds, dirname(nodePath), dirname(nodePath), "ro")
+  addBind(binds, dirname(dirname(nodePath)), dirname(dirname(nodePath)), "ro")
+  for (const bind of isolate.bind ?? []) addBind(binds, bind.source, bind.target ?? bind.source, bind.mode ?? "ro")
+  const env = {
+    PATH: isolatedPathEnv(commandPath, nodePath, dirname),
+    HOME: "/home/agent",
+    TMPDIR: "/tmp",
+    ...(isolate.codexHome ? { CODEX_HOME: "/codex-home" } : {}),
+    ...options.env,
+    ...isolate.env,
+  }
+  return {
+    command: isolate.bwrap ?? "bwrap",
+    args: [
+      "--die-with-parent",
+      "--unshare-all",
+      ...(isolate.network === true ? ["--share-net"] : []),
+      "--proc",
+      "/proc",
+      "--dev",
+      "/dev",
+      "--tmpfs",
+      "/tmp",
+      "--dir",
+      "/etc",
+      "--dir",
+      "/home",
+      ...Object.entries(env).flatMap(([key, value]) => value === undefined ? [] : ["--setenv", key, value]),
+      ...[...binds.values()].flatMap((bind) => [bind.mode === "rw" ? "--bind" : "--ro-bind", bind.source, bind.target]),
+      "--chdir",
+      workdir,
+      "--",
+      commandPath ?? options.command,
+      ...(options.args ?? []),
+    ],
+    env: { PATH: process.env["PATH"] },
+    cleanup: async () => {
+      await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })))
+    },
+  }
+}
+
+function addBind(
+  binds: Map<string, PreparedBind>,
+  source: string,
+  target: string,
+  mode: "ro" | "rw"
+): void {
+  binds.set(`${source}\u0000${target}`, { source, target, mode })
+}
+
+function defaultCliDirs(exists: (path: string) => boolean): string[] {
+  return [
+    "/usr/bin",
+    "/bin",
+    "/usr/lib",
+    "/usr/lib64",
+    "/lib",
+    "/lib64",
+  ].filter((path, index, items) => items.indexOf(path) === index && exists(path))
+}
+
+function defaultCliCertDirs(exists: (path: string) => boolean): string[] {
+  return [
+    "/etc/ssl",
+    "/etc/pki",
+    "/etc/ca-certificates",
+    "/usr/share/ca-certificates",
+    "/usr/local/share/ca-certificates",
+  ].filter((path, index, items) => items.indexOf(path) === index && exists(path))
+}
+
+function defaultCliFiles(exists: (path: string) => boolean): string[] {
+  return [
+    "/etc/hosts",
+    "/etc/resolv.conf",
+  ].filter((path, index, items) => items.indexOf(path) === index && exists(path))
+}
+
+function isolatedPathEnv(
+  commandPath: string | undefined,
+  nodePath: string,
+  dirname: (path: string) => string
+): string {
+  return [
+    commandPath ? dirname(commandPath) : undefined,
+    dirname(nodePath),
+    "/usr/bin",
+    "/bin",
+  ].filter((path, index, items): path is string =>
+    path !== undefined && items.indexOf(path) === index
+  ).join(":")
+}
+
+async function commandPathOf(
+  command: string,
+  pathEnv: string,
+  exists: (path: string) => boolean,
+  realpath: (path: string) => Promise<string>
+): Promise<string | undefined> {
+  if (command.includes("/")) return realpath(command)
+  const found = pathEnv
+    .split(":")
+    .filter(Boolean)
+    .map((dir) => `${dir}/${command}`)
+    .find((path) => exists(path))
+  return found ? realpath(found) : undefined
 }
 
 type ExecFileError = Error & {
@@ -620,19 +801,33 @@ export interface PromptInput {
   prompt: string
 }
 
+export interface GuardState {
+  text: string
+}
+
+export function guard(name: string, text = ""): Lite.Atom<MaterialState<GuardState>> {
+  return material(name, {
+    kind: "json",
+    initialState: { text },
+  })
+}
+
 export interface ClaudeCliWorkerOptions {
   name?: string
   command?: string
   extraArgs?: readonly string[]
+  isolate?: boolean | CliIsolateOptions
   timeoutMs?: number
   tags?: Lite.Tagged<any>[]
 }
 
 export function claudeCliWorker(options: ClaudeCliWorkerOptions = {}): Lite.Flow<string, PromptInput> {
+  assertNoClaudeBare(options.extraArgs ?? [])
   return cliWorker({
     name: options.name ?? "claude",
     command: options.command ?? "claude",
     args: (input) => cliPromptArgs(["-p", ...(options.extraArgs ?? [])], input.prompt),
+    isolate: options.isolate,
     timeoutMs: options.timeoutMs,
     kind: "llm",
     tags: options.tags,
@@ -644,6 +839,7 @@ export interface CodexCliWorkerOptions {
   command?: string
   sandbox?: "read-only" | "workspace-write" | "danger-full-access"
   extraArgs?: readonly string[]
+  isolate?: boolean | CliIsolateOptions
   timeoutMs?: number
   tags?: Lite.Tagged<any>[]
 }
@@ -658,10 +854,214 @@ export function codexCliWorker(options: CodexCliWorkerOptions = {}): Lite.Flow<s
       options.sandbox ?? "read-only",
       ...(options.extraArgs ?? []),
     ], input.prompt),
+    isolate: options.isolate,
     timeoutMs: options.timeoutMs,
     kind: "llm",
     tags: options.tags,
   })
+}
+
+export interface CliHarnessOptions {
+  name?: string
+  command?: string
+  extraArgs?: readonly string[]
+  isolate?: boolean | CliIsolateOptions
+  timeoutMs?: number
+  guard?: Lite.Atom<MaterialState<GuardState>> | false
+  prompt?: (request: ModelRequest, guard: GuardState) => string
+  parse?: (output: string) => ModelResponse
+  tags?: Lite.Tagged<any>[]
+}
+
+export interface CodexHarnessOptions extends CliHarnessOptions {
+  sandbox?: "read-only" | "workspace-write" | "danger-full-access"
+}
+
+export function claudeHarness(options: CliHarnessOptions = {}): Model {
+  const worker = claudeCliWorker({
+    name: options.name ?? "claude-harness",
+    command: options.command,
+    extraArgs: ["--no-session-persistence", ...(options.extraArgs ?? [])],
+    isolate: options.isolate ?? { network: true },
+    timeoutMs: options.timeoutMs,
+    tags: options.tags,
+  })
+  return cliHarnessModel(worker, {
+    guard: options.guard === undefined ? guard(`${options.name ?? "claude-harness"}-guard`) : options.guard,
+    prompt: options.prompt,
+    parse: options.parse,
+  })
+}
+
+export function codexHarness(options: CodexHarnessOptions = {}): Model {
+  const worker = codexCliWorker({
+    name: options.name ?? "codex-harness",
+    command: options.command,
+    sandbox: options.sandbox,
+    extraArgs: ["--ephemeral", "--ignore-user-config", ...(options.extraArgs ?? [])],
+    isolate: options.isolate ?? { network: true },
+    timeoutMs: options.timeoutMs,
+    tags: options.tags,
+  })
+  return cliHarnessModel(worker, {
+    guard: options.guard === undefined ? guard(`${options.name ?? "codex-harness"}-guard`) : options.guard,
+    prompt: options.prompt,
+    parse: options.parse,
+  })
+}
+
+interface CliHarnessConfig {
+  guard: Lite.Atom<MaterialState<GuardState>> | false
+  prompt?: (request: ModelRequest, guard: GuardState) => string
+  parse?: (output: string) => ModelResponse
+}
+
+function cliHarnessModel(
+  worker: Lite.Flow<string, PromptInput>,
+  config: CliHarnessConfig
+): Model {
+  return {
+    complete: async (ctx, request) => {
+      const current = config.guard ? await ctx.resolve(config.guard) : undefined
+      const state = current?.state ?? { text: "" }
+      const output = await ctx.exec({
+        flow: worker,
+        input: { prompt: config.prompt ? config.prompt(request, state) : modelPrompt(request, state) },
+      })
+      const response = config.parse ? config.parse(output) : parseModelOutput(output)
+      if (config.guard && current) await collectGuard(ctx, config.guard, current, response)
+      return response
+    },
+  }
+}
+
+async function collectGuard(
+  ctx: Lite.ExecutionContext,
+  store: Lite.Atom<MaterialState<GuardState>>,
+  current: MaterialState<GuardState>,
+  response: ModelResponse
+): Promise<void> {
+  const text = guardTextOf(response.guard)
+  if (!text || current.state.text) return
+  await patchMaterial(ctx, store, [
+    { op: "replace", path: "/text", value: text },
+  ], { expectedRevision: current.revision })
+}
+
+function modelPrompt(request: ModelRequest, guard: GuardState): string {
+  return [
+    "Return JSON only.",
+    "Schema: {\"content\":string,\"stop\"?:boolean,\"guard\"?:string,\"skillCalls\"?:array,\"toolCalls\"?:array,\"subagentCalls\"?:array}.",
+    guard.text
+      ? `Guard:\n${guard.text}`
+      : "First run only: set guard to the anti-goal that should prevent this agent from drifting.",
+    `Agent: ${request.agentName}`,
+    request.instructions ? `Instructions:\n${request.instructions}` : undefined,
+    request.skills.length ? `Available skills:\n${request.skills.map(formatCapability).join("\n")}` : undefined,
+    request.loadedSkills.length ? `Loaded skills:\n${request.loadedSkills.map(formatLoadedSkill).join("\n\n")}` : undefined,
+    request.tools.length ? `Available tools:\n${request.tools.map(formatCapability).join("\n")}` : undefined,
+    request.subagents.length ? `Available subagents:\n${request.subagents.map(formatCapability).join("\n")}` : undefined,
+    `Round: ${request.round}`,
+    `Messages:\n${request.messages.map(formatMessage).join("\n")}`,
+  ].filter((item) => item !== undefined).join("\n\n")
+}
+
+function parseModelOutput(output: string): ModelResponse {
+  const value = readJson(output)
+  if (!isRecord(value)) return { content: output, stop: true }
+  const response: ModelResponse = {
+    content: typeof value["content"] === "string" ? value["content"] : output,
+    stop: typeof value["stop"] === "boolean" ? value["stop"] : true,
+  }
+  const guard = guardTextOf(value["guard"] ?? value["antiGoal"])
+  const skillCalls = skillCallsOf(value["skillCalls"])
+  const toolCalls = toolCallsOf(value["toolCalls"])
+  const subagentCalls = subagentCallsOf(value["subagentCalls"])
+  if (guard) response.guard = guard
+  if (skillCalls) response.skillCalls = skillCalls
+  if (toolCalls) response.toolCalls = toolCalls
+  if (subagentCalls) response.subagentCalls = subagentCalls
+  return response
+}
+
+function readJson(output: string): unknown {
+  const trimmed = output.trim()
+  if (!trimmed) return undefined
+  try {
+    return JSON.parse(trimmed) as unknown
+  } catch {
+    const start = trimmed.indexOf("{")
+    const end = trimmed.lastIndexOf("}")
+    if (start === -1 || end <= start) return undefined
+    try {
+      return JSON.parse(trimmed.slice(start, end + 1)) as unknown
+    } catch {
+      return undefined
+    }
+  }
+}
+
+function skillCallsOf(value: unknown): SkillCall[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const calls = value.flatMap((item) => {
+    if (!isRecord(item) || typeof item["name"] !== "string") return []
+    return [{
+      name: item["name"],
+      ...(typeof item["id"] === "string" ? { id: item["id"] } : {}),
+    }]
+  })
+  return calls.length ? calls : undefined
+}
+
+function toolCallsOf(value: unknown): ToolCall[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const calls = value.flatMap((item) => {
+    if (!isRecord(item) || typeof item["name"] !== "string") return []
+    return [{
+      name: item["name"],
+      input: item["input"],
+      ...(typeof item["id"] === "string" ? { id: item["id"] } : {}),
+    }]
+  })
+  return calls.length ? calls : undefined
+}
+
+function subagentCallsOf(value: unknown): SubCall[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const calls = value.flatMap((item) => {
+    if (!isRecord(item) || typeof item["name"] !== "string") return []
+    return [{
+      name: item["name"],
+      input: turnInputOf(item["input"]),
+      ...(typeof item["id"] === "string" ? { id: item["id"] } : {}),
+    }]
+  })
+  return calls.length ? calls : undefined
+}
+
+function turnInputOf(value: unknown): TurnInput {
+  if (isRecord(value)) return value as TurnInput
+  return { prompt: stringifyAgentValue(value) }
+}
+
+function guardTextOf(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined
+}
+
+function formatCapability(capability: Capability): string {
+  return `- ${capability.name}: ${capability.description}`
+}
+
+function formatLoadedSkill(skill: LoadedSkill): string {
+  return `## ${skill.name}\n${skill.content}`
+}
+
+function formatMessage(message: Message): string {
+  return message.name ? `${message.role}(${message.name}): ${message.content}` : `${message.role}: ${message.content}`
+}
+
+function assertNoClaudeBare(args: readonly string[]): void {
+  if (args.some((arg) => arg === "--bare" || arg.startsWith("--bare="))) throw new Error("Claude harness must not use --bare")
 }
 
 function cliPromptArgs(args: readonly string[], prompt: string): string[] {
@@ -698,6 +1098,7 @@ export interface SkillCall {
 
 export interface ModelResponse {
   content: string
+  guard?: string
   skillCalls?: readonly SkillCall[]
   toolCalls?: readonly ToolCall[]
   subagentCalls?: readonly SubCall[]

--- a/packages/lite-extension-suspense/LICENSE
+++ b/packages/lite-extension-suspense/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2025 Duke
+
+Permission is hereby granted, free of
+charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/lite-extension-suspense/package.json
+++ b/packages/lite-extension-suspense/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pumped-fn/lite-extension-suspense",
   "version": "1.0.0",
-  "private": true,
+  "private": false,
   "description": "Replay and suspend extension for @pumped-fn/lite",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -21,7 +21,8 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "publishConfig": {
     "access": "public"
@@ -33,7 +34,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@pumped-fn/lite": "^3.0.0"
+    "@pumped-fn/lite": "^3.1.0"
   },
   "devDependencies": {
     "@pumped-fn/lite": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ catalogs:
     jscodeshift:
       specifier: 17.3.0
       version: 17.3.0
+    just-bash:
+      specifier: 3.0.2
+      version: 3.0.2
     magic-string:
       specifier: 0.30.21
       version: 0.30.21
@@ -135,7 +138,7 @@ importers:
         version: 19.2.15
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))(vitest@4.1.7)
+        version: 4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
       playwright:
         specifier: 'catalog:'
         version: 1.61.0
@@ -150,13 +153,22 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   examples/agent-practical:
     dependencies:
       '@pumped-fn/agent-sdk':
         specifier: workspace:*
         version: link:../../packages/agent-sdk
+      '@pumped-fn/agent-sdk-claude':
+        specifier: workspace:*
+        version: link:../../packages/agent-sdk-claude
+      '@pumped-fn/agent-sdk-codex':
+        specifier: workspace:*
+        version: link:../../packages/agent-sdk-codex
+      '@pumped-fn/agent-sdk-just-bash':
+        specifier: workspace:*
+        version: link:../../packages/agent-sdk-just-bash
       '@pumped-fn/agent-sdk-test':
         specifier: workspace:*
         version: link:../../packages/agent-sdk-test
@@ -175,10 +187,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   examples/lite-bff-practical:
     dependencies:
@@ -200,10 +212,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   examples/lite-practical:
     dependencies:
@@ -225,7 +237,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   examples/lite-react-practical:
     dependencies:
@@ -253,7 +265,7 @@ importers:
         version: 7.0.0-dev.20260526.1
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))(vitest@4.1.7)
+        version: 4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
@@ -271,10 +283,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/agent-sdk:
     dependencies:
@@ -299,10 +311,95 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/agent-sdk-claude:
+    devDependencies:
+      '@pumped-fn/agent-sdk':
+        specifier: workspace:*
+        version: link:../agent-sdk
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../lite
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/agent-sdk-codex:
+    devDependencies:
+      '@pumped-fn/agent-sdk':
+        specifier: workspace:*
+        version: link:../agent-sdk
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../lite
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
+
+  packages/agent-sdk-just-bash:
+    dependencies:
+      just-bash:
+        specifier: 'catalog:'
+        version: 3.0.2
+    devDependencies:
+      '@pumped-fn/agent-sdk':
+        specifier: workspace:*
+        version: link:../agent-sdk
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../lite
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/agent-sdk-test:
     dependencies:
@@ -330,10 +427,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/codemod:
     dependencies:
@@ -355,10 +452,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/lite:
     devDependencies:
@@ -379,10 +476,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/lite-devtools:
     devDependencies:
@@ -397,10 +494,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/lite-extension-otel:
     dependencies:
@@ -431,10 +528,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/lite-extension-suspense:
     devDependencies:
@@ -455,10 +552,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/lite-hmr:
     dependencies:
@@ -486,10 +583,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/lite-lint:
     dependencies:
@@ -508,7 +605,7 @@ importers:
         version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/lite-react:
     devDependencies:
@@ -529,7 +626,7 @@ importers:
         version: 19.2.15
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))(vitest@4.1.7)
+        version: 4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
@@ -550,10 +647,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
 
 packages:
 
@@ -792,6 +889,9 @@ packages:
 
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -1077,6 +1177,21 @@ packages:
       '@types/node':
         optional: true
 
+  '@jitl/quickjs-ffi-types@0.32.0':
+    resolution: {integrity: sha512-v9T+GQpmk43VDJ7d72sf0Nexhk+ArvtUihW27dy7lqAl0zBObFKtSBBIm5RBjwIhE8VwsPPm9PNuvPvNqLWUEg==}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    resolution: {integrity: sha512-EX8zbXwGqCgAE764M+qvkHtyXDi/FUoMBea0JnES7vCM3P7a2+EOZOjGv85wtZ2sJhI1oJ+nekmqpOODFDY+hw==}
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    resolution: {integrity: sha512-LeYWrPGC1uNCTBWvibo3ZLJj0CSVNYUXvJpXMCmuQ5Sap2cCACc3uvGvYV4homHHBAzfw5akoTqMMS4YFRtw+Q==}
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    resolution: {integrity: sha512-3oSwPfja12ICz4aIblB58cuY8JlEq5Txt8Cut4VLo+LH47QN+mzCnSgnbB03hWzg1LBcc+VyyI9UOag7a1NF+Q==}
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    resolution: {integrity: sha512-BKNDI/TPBfGlLNGYpLrhcDGXmIk4xHm4MRAisOBnOzpXVn9HZWsfmMAc9WMBrAHjvvds6HOikKeaOBKdPdpVrg==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -1099,11 +1214,21 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mixmark-io/domino@2.2.0':
+    resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@mongodb-js/zstd@7.0.0':
+    resolution: {integrity: sha512-mQ2s0pYYiav+tzCDR05Zptem8Ey2v8s11lri5RKGhTtL4COVCvVCk5vtyRYNT+9L8qSfyOqqefF9UtnW8mC5jA==}
+    engines: {node: '>= 20.19.0'}
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nodable/entities@2.2.0':
+    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1310,6 +1435,13 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -1468,6 +1600,9 @@ packages:
     resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
     engines: {node: '>=14'}
 
+  anynum@1.0.1:
+    resolution: {integrity: sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -1497,6 +1632,13 @@ packages:
   ast-v8-to-istanbul@1.0.2:
     resolution: {integrity: sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.32:
     resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
     engines: {node: '>=6.0.0'}
@@ -1512,6 +1654,13 @@ packages:
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -1523,6 +1672,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -1538,9 +1690,16 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  chownr@1.1.4:
+    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
+
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
+
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
 
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -1581,6 +1740,14 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decompress-response@6.0.0:
+    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
+    engines: {node: '>=10'}
+
+  deep-extend@0.6.0:
+    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
+    engines: {node: '>=4.0.0'}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -1595,6 +1762,10 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -1625,6 +1796,9 @@ packages:
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
     engines: {node: '>=14'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -1658,6 +1832,10 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  expand-template@2.0.3:
+    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
+    engines: {node: '>=6'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1668,6 +1846,13 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
+  fast-xml-parser@5.9.3:
+    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -1680,6 +1865,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1700,6 +1889,9 @@ packages:
   flow-parser@0.314.0:
     resolution: {integrity: sha512-ayvpVFL/wibphkhjaz6PwL/F+Vz9lZB7qwFIHvsFiPQMfKmrqRXp1UyJgxMqyanW6QQDvsB12MLWFCc2cYBOtw==}
     engines: {node: '>=0.4.0'}
+
+  fs-constants@1.0.0:
+    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1726,6 +1918,9 @@ packages:
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
     engines: {node: '>=20.20.0'}
+
+  github-from-package@0.0.0:
+    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1764,6 +1959,9 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1779,6 +1977,16 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1802,6 +2010,9 @@ packages:
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
+
+  is-unsafe@1.0.1:
+    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
 
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -1867,6 +2078,10 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  just-bash@3.0.2:
+    resolution: {integrity: sha512-uY8LMD2NpADp1HlYUcZSw9ffuq0tRhW76sg8xkeo+ZRDMu7mbekWbKbYDWquazVVi7pqpGZlic/liMFktQKy6w==}
+    hasBin: true
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -1993,9 +2208,27 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mimic-response@3.1.0:
+    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
+    engines: {node: '>=10'}
+
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  mkdirp-classic@0.5.3:
+    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  modern-tar@0.7.6:
+    resolution: {integrity: sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==}
+    engines: {node: '>=18.0.0'}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -2013,8 +2246,19 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  napi-build-utils@2.0.0:
+    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
+
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
+  node-abi@3.92.0:
+    resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
+    engines: {node: '>=10'}
+
+  node-addon-api@8.8.0:
+    resolution: {integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==}
+    engines: {node: ^18 || ^20 || >= 21}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -2025,12 +2269,24 @@ packages:
       encoding:
         optional: true
 
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  node-liblzma@2.2.0:
+    resolution: {integrity: sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+
   node-releases@2.0.46:
     resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
     engines: {node: '>=18'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -2062,6 +2318,9 @@ packages:
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
 
+  papaparse@5.5.4:
+    resolution: {integrity: sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==}
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -2072,6 +2331,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-expression-matcher@1.6.0:
+    resolution: {integrity: sha512-e5y7RCLHKjemsgQ4eqGJtPyr10ILz25HO7flzxhTV8bgvd5yHx98DGtCAtbVW9f2TqnYI/gEVZd+vz7snrdPTw==}
+    engines: {node: '>=14.0.0'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2125,6 +2388,12 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prebuild-install@7.1.3:
+    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
+    engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
+    hasBin: true
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -2133,6 +2402,9 @@ packages:
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2146,6 +2418,20 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quickjs-emscripten-core@0.32.0:
+    resolution: {integrity: sha512-QFnPfjFey8EqknSrSxe1hZrf1/8z7/6s1QzGOmKo6++02r7QRRX7ZoyNaZh7JuVjWsVW87KnQrbZqnHkOAzUyg==}
+
+  quickjs-emscripten@0.32.0:
+    resolution: {integrity: sha512-So0Sqw869y/S2oE3Nuc0uT3Dhqgvsj8FSrwBdsuTosVsG8ME5/OcudU1GxsrIFdFABgy17GHnTVO9TYV/bLQcA==}
+    engines: {node: '>=16.0.0'}
+
+  rc@1.2.8:
+    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
+    hasBin: true
+
+  re2js@1.3.3:
+    resolution: {integrity: sha512-s/I5zEAo79SUK0Qw4dpZKpiMwbQ6Gz0KU2NRr7eaO4x/p2g7Vvmn3hdeXDg8VsaUjfj/ora+e9oi27LX/C9+mw==}
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
@@ -2162,6 +2448,10 @@ packages:
   read-yaml-file@2.1.0:
     resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
     engines: {node: '>=10.13'}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
@@ -2213,6 +2503,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -2222,6 +2515,10 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  seek-bzip@2.0.0:
+    resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
+    hasBin: true
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -2255,6 +2552,12 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  simple-concat@1.0.1:
+    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
+
+  simple-get@4.0.1:
+    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -2262,6 +2565,10 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2277,11 +2584,20 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  sql.js@1.14.1:
+    resolution: {integrity: sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2295,12 +2611,30 @@ packages:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
 
+  strip-json-comments@2.0.1:
+    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
+    engines: {node: '>=0.10.0'}
+
+  strnum@2.4.1:
+    resolution: {integrity: sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==}
+
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tar-fs@2.1.4:
+    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
+
+  tar-stream@2.2.0:
+    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
+    engines: {node: '>=6'}
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -2338,6 +2672,10 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -2400,10 +2738,21 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tunnel-agent@0.6.0:
+    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  turndown@7.2.4:
+    resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
+    engines: {node: '>=18', npm: '>=9'}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
@@ -2424,6 +2773,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   vite@8.0.14:
     resolution: {integrity: sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==}
@@ -2545,6 +2897,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -2577,11 +2932,20 @@ packages:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
 snapshots:
 
@@ -2887,6 +3251,8 @@ snapshots:
 
   '@blazediff/core@1.9.1': {}
 
+  '@borewit/text-codec@0.2.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -3184,6 +3550,24 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.1
 
+  '@jitl/quickjs-ffi-types@0.32.0': {}
+
+  '@jitl/quickjs-wasmfile-debug-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-debug-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-asyncify@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  '@jitl/quickjs-wasmfile-release-sync@0.32.0':
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3219,12 +3603,22 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 2.1.0
 
+  '@mixmark-io/domino@2.2.0': {}
+
+  '@mongodb-js/zstd@7.0.0':
+    dependencies:
+      node-addon-api: 8.8.0
+      prebuild-install: 7.1.3
+    optional: true
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nodable/entities@2.2.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3394,6 +3788,15 @@ snapshots:
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
 
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -3471,29 +3874,29 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260526.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260526.1
 
-  '@vitest/browser-playwright@4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))(vitest@4.1.7)':
+  '@vitest/browser-playwright@4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
-      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))(vitest@4.1.7)
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
       playwright: 1.61.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))(vitest@4.1.7)':
+  '@vitest/browser@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -3513,9 +3916,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+      vitest: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))(vitest@4.1.7)
+      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -3526,13 +3929,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))':
+  '@vitest/mocker@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.7':
     dependencies:
@@ -3568,6 +3971,8 @@ snapshots:
 
   ansis@4.3.0: {}
 
+  anynum@1.0.1: {}
+
   argparse@2.0.1: {}
 
   aria-query@5.3.0:
@@ -3596,6 +4001,11 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  balanced-match@4.0.4: {}
+
+  base64-js@1.5.1:
+    optional: true
+
   baseline-browser-mapping@2.10.32: {}
 
   better-path-resolve@1.0.0:
@@ -3608,6 +4018,17 @@ snapshots:
     optional: true
 
   birpc@4.0.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+    optional: true
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -3623,6 +4044,12 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+    optional: true
+
   cac@7.0.0: {}
 
   caniuse-lite@1.0.30001793: {}
@@ -3631,11 +4058,16 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  chownr@1.1.4:
+    optional: true
+
   clone-deep@4.0.1:
     dependencies:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+
+  commander@6.2.1: {}
 
   commondir@1.0.1: {}
 
@@ -3674,6 +4106,14 @@ snapshots:
   decimal.js@10.6.0:
     optional: true
 
+  decompress-response@6.0.0:
+    dependencies:
+      mimic-response: 3.1.0
+    optional: true
+
+  deep-extend@0.6.0:
+    optional: true
+
   defu@6.1.7: {}
 
   dequal@2.0.3: {}
@@ -3681,6 +4121,8 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
+
+  diff@8.0.4: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -3697,6 +4139,11 @@ snapshots:
   electron-to-chromium@1.5.362: {}
 
   empathic@2.0.1: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+    optional: true
 
   enquirer@2.4.1:
     dependencies:
@@ -3749,6 +4196,9 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  expand-template@2.0.3:
+    optional: true
+
   expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
@@ -3761,6 +4211,20 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.6.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.9.3:
+    dependencies:
+      '@nodable/entities': 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.6.0
+      strnum: 2.4.1
+      xml-naming: 0.1.0
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -3768,6 +4232,15 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   fill-range@7.1.1:
     dependencies:
@@ -3789,6 +4262,9 @@ snapshots:
       path-exists: 4.0.0
 
   flow-parser@0.314.0: {}
+
+  fs-constants@1.0.0:
+    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -3813,6 +4289,9 @@ snapshots:
   get-tsconfig@5.0.0-beta.5:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -3861,6 +4340,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
 
   import-without-cache@0.4.0: {}
@@ -3868,6 +4349,14 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
+
+  inherits@2.0.4:
+    optional: true
+
+  ini@1.3.8:
+    optional: true
+
+  ini@6.0.0: {}
 
   is-extglob@2.1.1: {}
 
@@ -3887,6 +4376,8 @@ snapshots:
   is-subdir@1.2.0:
     dependencies:
       better-path-resolve: 1.0.0
+
+  is-unsafe@1.0.1: {}
 
   is-windows@1.0.2: {}
 
@@ -3972,6 +4463,29 @@ snapshots:
   jsonfile@4.0.0:
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  just-bash@3.0.2:
+    dependencies:
+      diff: 8.0.4
+      fast-xml-parser: 5.9.3
+      file-type: 21.3.4
+      ini: 6.0.0
+      minimatch: 10.2.5
+      modern-tar: 0.7.6
+      papaparse: 5.5.4
+      quickjs-emscripten: 0.32.0
+      re2js: 1.3.3
+      seek-bzip: 2.0.0
+      smol-toml: 1.6.1
+      sprintf-js: 1.1.3
+      sql.js: 1.14.1
+      turndown: 7.2.4
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mongodb-js/zstd': 7.0.0
+      node-liblzma: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
 
   kind-of@6.0.3: {}
 
@@ -4073,7 +4587,22 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mimic-response@3.1.0:
+    optional: true
+
   min-indent@1.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minimist@1.2.8:
+    optional: true
+
+  mkdirp-classic@0.5.3:
+    optional: true
+
+  modern-tar@0.7.6: {}
 
   mri@1.2.0: {}
 
@@ -4083,15 +4612,40 @@ snapshots:
 
   nanoid@3.3.12: {}
 
+  napi-build-utils@2.0.0:
+    optional: true
+
   neo-async@2.6.2: {}
+
+  node-abi@3.92.0:
+    dependencies:
+      semver: 7.8.1
+    optional: true
+
+  node-addon-api@8.8.0:
+    optional: true
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
 
+  node-gyp-build@4.8.4:
+    optional: true
+
+  node-liblzma@2.2.0:
+    dependencies:
+      node-addon-api: 8.8.0
+      node-gyp-build: 4.8.4
+    optional: true
+
   node-releases@2.0.46: {}
 
   obug@2.1.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+    optional: true
 
   outdent@0.5.0: {}
 
@@ -4119,6 +4673,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  papaparse@5.5.4: {}
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -4127,6 +4683,8 @@ snapshots:
   path-exists@3.0.0: {}
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.6.0: {}
 
   path-key@3.1.1: {}
 
@@ -4164,6 +4722,22 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prebuild-install@7.1.3:
+    dependencies:
+      detect-libc: 2.1.2
+      expand-template: 2.0.3
+      github-from-package: 0.0.0
+      minimist: 1.2.8
+      mkdirp-classic: 0.5.3
+      napi-build-utils: 2.0.0
+      node-abi: 3.92.0
+      pump: 3.0.4
+      rc: 1.2.8
+      simple-get: 4.0.1
+      tar-fs: 2.1.4
+      tunnel-agent: 0.6.0
+    optional: true
+
   prettier@2.8.8: {}
 
   pretty-format@27.5.1:
@@ -4171,6 +4745,12 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+    optional: true
 
   punycode@2.3.1:
     optional: true
@@ -4180,6 +4760,28 @@ snapshots:
   quansync@1.0.0: {}
 
   queue-microtask@1.2.3: {}
+
+  quickjs-emscripten-core@0.32.0:
+    dependencies:
+      '@jitl/quickjs-ffi-types': 0.32.0
+
+  quickjs-emscripten@0.32.0:
+    dependencies:
+      '@jitl/quickjs-wasmfile-debug-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-debug-sync': 0.32.0
+      '@jitl/quickjs-wasmfile-release-asyncify': 0.32.0
+      '@jitl/quickjs-wasmfile-release-sync': 0.32.0
+      quickjs-emscripten-core: 0.32.0
+
+  rc@1.2.8:
+    dependencies:
+      deep-extend: 0.6.0
+      ini: 1.3.8
+      minimist: 1.2.8
+      strip-json-comments: 2.0.1
+    optional: true
+
+  re2js@1.3.3: {}
 
   react-dom@19.2.6(react@19.2.6):
     dependencies:
@@ -4194,6 +4796,13 @@ snapshots:
     dependencies:
       js-yaml: 4.1.1
       strip-bom: 4.0.0
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+    optional: true
 
   recast@0.23.11:
     dependencies:
@@ -4259,6 +4868,9 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1:
+    optional: true
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -4267,6 +4879,10 @@ snapshots:
     optional: true
 
   scheduler@0.27.0: {}
+
+  seek-bzip@2.0.0:
+    dependencies:
+      commander: 6.2.1
 
   semver@5.7.2: {}
 
@@ -4288,6 +4904,16 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  simple-concat@1.0.1:
+    optional: true
+
+  simple-get@4.0.1:
+    dependencies:
+      decompress-response: 6.0.0
+      once: 1.4.0
+      simple-concat: 1.0.1
+    optional: true
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -4295,6 +4921,8 @@ snapshots:
       totalist: 3.0.1
 
   slash@3.0.0: {}
+
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 
@@ -4310,9 +4938,18 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  sprintf-js@1.1.3: {}
+
+  sql.js@1.14.1: {}
+
   stackback@0.0.2: {}
 
   std-env@4.1.0: {}
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -4324,11 +4961,39 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
+  strip-json-comments@2.0.1:
+    optional: true
+
+  strnum@2.4.1:
+    dependencies:
+      anynum: 1.0.1
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
 
   symbol-tree@3.2.4:
+    optional: true
+
+  tar-fs@2.1.4:
+    dependencies:
+      chownr: 1.1.4
+      mkdirp-classic: 0.5.3
+      pump: 3.0.4
+      tar-stream: 2.2.0
+    optional: true
+
+  tar-stream@2.2.0:
+    dependencies:
+      bl: 4.1.0
+      end-of-stream: 1.4.5
+      fs-constants: 1.0.0
+      inherits: 2.0.4
+      readable-stream: 3.6.2
     optional: true
 
   term-size@2.2.1: {}
@@ -4359,6 +5024,12 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   totalist@3.0.1: {}
 
@@ -4411,7 +5082,18 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
+  tunnel-agent@0.6.0:
+    dependencies:
+      safe-buffer: 5.2.1
+    optional: true
+
+  turndown@7.2.4:
+    dependencies:
+      '@mixmark-io/domino': 2.2.0
+
   typescript@6.0.3: {}
+
+  uint8array-extras@1.5.0: {}
 
   unconfig-core@7.5.0:
     dependencies:
@@ -4431,7 +5113,10 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3):
+  util-deprecate@1.0.2:
+    optional: true
+
+  vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -4443,11 +5128,12 @@ snapshots:
       esbuild: 0.27.7
       fsevents: 2.3.3
       tsx: 4.22.3
+      yaml: 2.9.0
 
-  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)):
+  vitest@4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
-      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.7
       '@vitest/runner': 4.1.7
       '@vitest/snapshot': 4.1.7
@@ -4464,12 +5150,12 @@ snapshots:
       tinyexec: 1.2.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+      vite: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.1
-      '@vitest/browser-playwright': 4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(playwright@1.61.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/coverage-v8': 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       happy-dom: 20.9.0
       jsdom: 29.1.1
@@ -4515,6 +5201,9 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrappy@1.0.2:
+    optional: true
+
   write-file-atomic@5.0.1:
     dependencies:
       imurmurhash: 0.1.4
@@ -4528,9 +5217,13 @@ snapshots:
   xml-name-validator@5.0.0:
     optional: true
 
+  xml-naming@0.1.0: {}
+
   xmlchars@2.2.0:
     optional: true
 
   yallist@3.1.1: {}
+
+  yaml@2.9.0: {}
 
 time: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
 
+  examples/agent-practical:
+    dependencies:
+      '@pumped-fn/agent-sdk':
+        specifier: workspace:*
+        version: link:../../packages/agent-sdk
+      '@pumped-fn/agent-sdk-test':
+        specifier: workspace:*
+        version: link:../../packages/agent-sdk-test
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../packages/lite
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+
   examples/lite-bff-practical:
     dependencies:
       '@pumped-fn/lite':
@@ -251,7 +279,7 @@ importers:
   packages/agent-sdk:
     dependencies:
       '@pumped-fn/lite-extension-suspense':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../lite-extension-suspense
     devDependencies:
       '@pumped-fn/lite':
@@ -279,7 +307,7 @@ importers:
   packages/agent-sdk-test:
     dependencies:
       '@pumped-fn/lite-extension-suspense':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../lite-extension-suspense
     devDependencies:
       '@pumped-fn/agent-sdk':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,7 +36,9 @@ overrides:
   yaml@>=2 <3: 2.9.0
 
 allowBuilds:
+  "@mongodb-js/zstd": false
   esbuild: true
+  node-liblzma: false
   sharp: true
   protobufjs: false
   puppeteer: false
@@ -70,6 +72,7 @@ catalog:
   acorn: 8.16.0
   estree-walker: 3.0.3
   jscodeshift: 17.3.0
+  just-bash: 3.0.2
   magic-string: 0.30.21
   playwright: 1.61.0
   react: 19.2.6


### PR DESCRIPTION
## Summary

Adds a lite-native agent workflow surface for @pumped-fn/agent-sdk and extends the PR with lazy, composable default harness packages. Codex, Claude, and just-bash are now available as provider packages that plug into the existing `model(...)` and `sandbox(...)` tag seams, so application graphs stay provider-agnostic and every implementation remains replaceable at `createScope({ tags })` or execution-context composition time.

## Changes

- Add concise agent authoring helpers: agent, model, tool, skill, sub, send, channel, schedule, suite, judge, runEval, inspect, summary, and http.
- Resolve model providers through the `model(provider)` typed tag, matching `sandbox(...)`; agent turns read `tags.required(model)` and do not store a special model slot.
- Keep turn execution on the lite seam: consumers execute `ctx.exec({ flow: agent.turn, input })`.
- Keep the Fetch adapter scope-free: `http()` returns a lite flow, and composition roots execute it with their own context.
- Add lazy provider packages: `@pumped-fn/agent-sdk-codex`, `@pumped-fn/agent-sdk-claude`, and `@pumped-fn/agent-sdk-just-bash`.
- Keep Codex and Claude harness construction deferred until first model use, so importing or tagging a provider does not start CLI validation/work.
- Add a lazy just-bash sandbox adapter that instantiates `Bash` only when a sandbox capability is used.
- Update `agent-practical` so provider choice is fully swappable through tags, with tests covering fake providers plus Codex/Claude-style command harnesses and just-bash workspace access.
- Add package docs, package map entries, changeset entries, and source aliases needed for deterministic workspace/browser tests.

## Anti-Goal Guardrails

- No drift from pumped-fn lite design: provider composition stays at the scope/tag seam.
- No fixed agent-sdk provider: Codex, Claude, fake models, and sandbox replacements are all interchangeable without changing agent graph code.
- No eager harness setup: provider packages are lazy until the capability is used.
- No non-working demo surface: the practical example exercises tools, subagents, workspace reads, schedule/http flow, and provider swapping.
- No lint or type debt.

## Testing

- `pnpm install`
- `pnpm build`
- `pnpm test` from a cold Vite cache
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`

## Notes

This update also fixes two cold-cache Vitest browser config issues encountered during full workspace verification: `benchmarks/lite-perf` now aliases lite/lite-react to source and dedupes React, and `examples/lite-react-practical` pre-optimizes browser-test dependencies Vitest requested during the recursive root test run.
