### PR TITLE
feat(lite-react-json-render): bridge json-render state and actions

### DIFF
--- a/.changeset/brave-json-render.md
+++ b/.changeset/brave-json-render.md
@@ -1,0 +1,5 @@
+---
+"@pumped-fn/lite-react-json-render": minor
+---
+
+Add the dedicated json-render adapter package for scopedValue-backed controlled state.

--- a/.changeset/brave-json-render.md
+++ b/.changeset/brave-json-render.md
@@ -2,4 +2,4 @@
 "@pumped-fn/lite-react-json-render": minor
 ---
 
-Add the dedicated json-render adapter package for scopedValue-backed controlled state.
+Add the dedicated json-render adapter package for scopedValue-backed controlled state and Lite flow-backed action handlers.

--- a/README.md
+++ b/README.md
@@ -202,7 +202,9 @@ owning execution context unmounts or is released.
 
 When generated UI needs json-render controlled state, `@pumped-fn/lite-react-json-render` adapts a
 `scopedValue` access object to json-render's external `StateStore` shape. The graph still owns the state;
-json-render observes and writes through its normal `StateProvider`.
+json-render observes and writes through its normal `StateProvider`. Use it at genuine json-render boundaries
+such as generated specs, server-authored forms, or schema-driven editors; hand-authored React should keep using
+the normal Lite React hooks directly.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Extensions wrap execution. React is an observer layer.
 | `@pumped-fn/lite` | Core runtime: scopes, atoms, flows, resources, tags, presets, controllers, extensions |
 | `@pumped-fn/lite-react` | React integration: providers, Suspense/ErrorBoundary-aware observers, scoped frontend state |
 | `@pumped-fn/lite-lint` | Static scanner for the documented lite and lite-react anti-patterns |
-| `@pumped-fn/lite-react-json-render` | json-render StateStore adapter for Lite React scoped values |
+| `@pumped-fn/lite-react-json-render` | json-render state and action adapters for Lite React scoped values and flows |
 | `@pumped-fn/lite-devtools` | Devtools transports and observability helpers |
 | `@pumped-fn/lite-hmr` | HMR helpers for preserving atom state during development |
 | `@pumped-fn/lite-extension-otel` | OpenTelemetry integration |
@@ -73,7 +73,7 @@ The same seam works for backend and frontend:
 - Backend handlers create or receive an execution context and run flows.
 - Workers create scopes for process lifetime and contexts per job.
 - React roots render `ScopeProvider` and `ExecutionContextProvider`.
-- Edge renderers such as json-render can bind to Lite-owned scoped values through external stores.
+- Edge renderers such as json-render can bind to Lite-owned scoped values and emit actions into Lite flows.
 - Tests use `createScope({ presets, tags, extensions })` and public APIs.
 
 ## Core Primitives
@@ -201,10 +201,11 @@ That state is backed by a current-owned resource, so it is testable without Reac
 owning execution context unmounts or is released.
 
 When generated UI needs json-render controlled state, `@pumped-fn/lite-react-json-render` adapts a
-`scopedValue` access object to json-render's external `StateStore` shape. The graph still owns the state;
-json-render observes and writes through its normal `StateProvider`. Use it at genuine json-render boundaries
-such as generated specs, server-authored forms, or schema-driven editors; hand-authored React should keep using
-the normal Lite React hooks directly.
+`scopedValue` access object to json-render's external `StateStore` shape and adapts json-render action
+handlers to Lite flows. The graph still owns state and behavior; json-render observes, writes, and emits
+through its normal `JSONUIProvider` contracts. Use it at genuine json-render boundaries such as generated
+specs, server-authored forms, or schema-driven editors; hand-authored React should keep using the normal
+Lite React hooks directly.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Extensions wrap execution. React is an observer layer.
 | `@pumped-fn/lite` | Core runtime: scopes, atoms, flows, resources, tags, presets, controllers, extensions |
 | `@pumped-fn/lite-react` | React integration: providers, Suspense/ErrorBoundary-aware observers, scoped frontend state |
 | `@pumped-fn/lite-lint` | Static scanner for the documented lite and lite-react anti-patterns |
+| `@pumped-fn/lite-react-json-render` | json-render StateStore adapter for Lite React scoped values |
 | `@pumped-fn/lite-devtools` | Devtools transports and observability helpers |
 | `@pumped-fn/lite-hmr` | HMR helpers for preserving atom state during development |
 | `@pumped-fn/lite-extension-otel` | OpenTelemetry integration |
@@ -72,6 +73,7 @@ The same seam works for backend and frontend:
 - Backend handlers create or receive an execution context and run flows.
 - Workers create scopes for process lifetime and contexts per job.
 - React roots render `ScopeProvider` and `ExecutionContextProvider`.
+- Edge renderers such as json-render can bind to Lite-owned scoped values through external stores.
 - Tests use `createScope({ presets, tags, extensions })` and public APIs.
 
 ## Core Primitives
@@ -198,6 +200,10 @@ For forms, modals, editors, and nested UI boundaries, `@pumped-fn/lite-react` pr
 That state is backed by a current-owned resource, so it is testable without React and resets when the
 owning execution context unmounts or is released.
 
+When generated UI needs json-render controlled state, `@pumped-fn/lite-react-json-render` adapts a
+`scopedValue` access object to json-render's external `StateStore` shape. The graph still owns the state;
+json-render observes and writes through its normal `StateProvider`.
+
 ## Tests
 
 The scope is the single seam:
@@ -240,7 +246,7 @@ The examples are part of the public contract for how code should be shaped:
 | Path | What it shows |
 | --- | --- |
 | `examples/lite-practical` | Backend and service-style patterns, plus a service health capstone |
-| `examples/lite-react-practical` | React observer patterns, provider-owned execution, scoped drafts, complex Kanban |
+| `examples/lite-react-practical` | React observer patterns, provider-owned execution, scoped drafts, json-render, complex Kanban |
 | `examples/lite-bff-practical` | BFF transport/capability/feature layering and HTTP-shaped flow boundaries |
 | `benchmarks/lite-perf` | Runtime and React observer performance checks |
 
@@ -269,6 +275,7 @@ pnpm -F @pumped-fn/lite-lint test
 - Core patterns: [`packages/lite/PATTERNS.md`](packages/lite/PATTERNS.md)
 - React runtime: [`packages/lite-react/README.md`](packages/lite-react/README.md)
 - React patterns: [`packages/lite-react/PATTERNS.md`](packages/lite-react/PATTERNS.md)
+- json-render adapter: [`packages/lite-react-json-render/README.md`](packages/lite-react-json-render/README.md)
 - Anti-pattern scanner: [`packages/lite-lint/README.md`](packages/lite-lint/README.md)
 
 ## License

--- a/examples/lite-react-practical/README.md
+++ b/examples/lite-react-practical/README.md
@@ -42,6 +42,7 @@ pnpm typecheck
 |---|---|---|---|
 | F01 | State / derived soup in a component | atoms + derived atom; component observes | IO, OI |
 | F13 | Untested `main.tsx` owning state/root setup | main as composition-root adapter; graph owns state | IO, OI |
+| F14 | json-render external store beside the graph | scopedValue-backed StateStore; json-render observes | IO, OI |
 | K | Complex Kanban workspace board | map-backed graph state + resources + scoped drafts; component observes | IO, OI |
 
 (More patterns and capstone slices land incrementally.)

--- a/examples/lite-react-practical/README.md
+++ b/examples/lite-react-practical/README.md
@@ -42,7 +42,7 @@ pnpm typecheck
 |---|---|---|---|
 | F01 | State / derived soup in a component | atoms + derived atom; component observes | IO, OI |
 | F13 | Untested `main.tsx` owning state/root setup | main as composition-root adapter; graph owns state | IO, OI |
-| F14 | json-render external store beside the graph | scopedValue-backed StateStore; json-render observes | IO, OI |
+| F14 | json-render store beside the graph | scopedValue store + flow handlers; json-render observes | IO, OI |
 | K | Complex Kanban workspace board | map-backed graph state + resources + scoped drafts; component observes | IO, OI |
 
 (More patterns and capstone slices land incrementally.)

--- a/examples/lite-react-practical/package.json
+++ b/examples/lite-react-practical/package.json
@@ -8,12 +8,16 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
+    "@json-render/core": "catalog:",
+    "@json-render/react": "catalog:",
     "@pumped-fn/lite": "workspace:*",
-    "@pumped-fn/lite-react": "workspace:*"
+    "@pumped-fn/lite-react": "workspace:*",
+    "@pumped-fn/lite-react-json-render": "workspace:*",
+    "zod": "catalog:"
   },
   "peerDependencies": {
-    "react": "^18.0.0 || ^19.0.0",
-    "react-dom": "^18.0.0 || ^19.0.0"
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "catalog:",

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/README.md
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/README.md
@@ -19,11 +19,17 @@ scoped value with `@pumped-fn/lite-react-json-render` `scopedValueStateStore` an
 store to `@json-render/react` `JSONUIProvider`. json-render still uses its normal `$bindState` and
 `$state` expressions; the source of truth is the Lite graph.
 
+The example also adapts json-render action handlers with `useFlowActionHandlers`. The generated spec emits
+a `submitOrder` action through its normal `on.press` binding, json-render resolves params from `$state`,
+and the adapter executes the Lite `submitOrder` flow. Because scoped values are current-owned resources, the
+integration boundary passes the resolved draft access through a tag so the flow mutates the actual draft
+instead of resolving a second action-local draft.
+
 ## Timing
 
 Reach for this only when the rendering boundary is genuinely json-render: generated UI, remote specs,
-schema-driven editors, or a surface that must speak json-render state bindings. The adapter belongs at that
-edge after the state has a Lite owner.
+schema-driven editors, or a surface that must speak json-render state bindings and action events. The adapter
+belongs at that edge after the state and action flows have Lite owners.
 
 For ordinary React forms and drafts, stay with `useScopedValue`. Use `useResource` when an integration
 boundary needs the resolved access object. The adapter is not a new default state path; it is the bridge that
@@ -32,13 +38,13 @@ prevents a real json-render boundary from creating a second owner.
 ## Lens coverage
 
 - **inside-out** (`after.test.ts`, node): resolve the scoped value through `createScope`, adapt it, and
-  prove JSON Pointer writes update the scoped draft without React.
+  prove JSON Pointer writes plus json-render action params update the scoped draft without React.
 - **outside-in** (`view.browser.test.tsx`, browser mode): render the real `@json-render/react`
   `JSONUIProvider` and `Renderer` under `ScopeProvider` and `ExecutionContextProvider`, then prove a
-  `$bindState` input updates the DOM and the scoped value.
+  `$bindState` input updates the DOM and a json-render event executes the Lite flow.
 
 ## Why 100%
 
-The state model is declared once in `after.ts`. The adapter behavior is verified through the same
-`StateStore` shape that json-render's official external-store packages consume. The rendered observer
-test covers the real provider stack instead of replacing json-render with a fake.
+The state model and submit flow are declared once in `after.ts`. The adapter behavior is verified through
+the same `StateStore` and `ActionHandler` shapes that json-render consumes. The rendered observer test
+covers the real provider stack instead of replacing json-render with a fake.

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/README.md
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/README.md
@@ -1,4 +1,4 @@
-# F14 - json-render external store points at component state
+# F14 - json-render bridge points at Lite graph
 
 ## The smell
 
@@ -19,7 +19,7 @@ scoped value with `@pumped-fn/lite-react-json-render` `scopedValueStateStore` an
 store to `@json-render/react` `JSONUIProvider`. json-render still uses its normal `$bindState` and
 `$state` expressions; the source of truth is the Lite graph.
 
-The example also adapts json-render action handlers with `useFlowActionHandlers`. The generated spec emits
+The example also adapts json-render action handlers with `useFlowHandlers`. The generated spec emits
 a `submitOrder` action through its normal `on.press` binding, json-render resolves params from `$state`,
 and the adapter executes the Lite `submitOrder` flow. Because scoped values are current-owned resources, the
 integration boundary passes the resolved draft access through a tag so the flow mutates the actual draft

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/README.md
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/README.md
@@ -19,12 +19,22 @@ scoped value with `@pumped-fn/lite-react-json-render` `scopedValueStateStore` an
 store to `@json-render/react` `JSONUIProvider`. json-render still uses its normal `$bindState` and
 `$state` expressions; the source of truth is the Lite graph.
 
+## Timing
+
+Reach for this only when the rendering boundary is genuinely json-render: generated UI, remote specs,
+schema-driven editors, or a surface that must speak json-render state bindings. The adapter belongs at that
+edge after the state has a Lite owner.
+
+For ordinary React forms and drafts, stay with `useScopedValue`. Use `useResource` when an integration
+boundary needs the resolved access object. The adapter is not a new default state path; it is the bridge that
+prevents a real json-render boundary from creating a second owner.
+
 ## Lens coverage
 
 - **inside-out** (`after.test.ts`, node): resolve the scoped value through `createScope`, adapt it, and
   prove JSON Pointer writes update the scoped draft without React.
 - **outside-in** (`view.browser.test.tsx`, browser mode): render the real `@json-render/react`
-  `StateProvider` and `Renderer` under `ScopeProvider` and `ExecutionContextProvider`, then prove a
+  `JSONUIProvider` and `Renderer` under `ScopeProvider` and `ExecutionContextProvider`, then prove a
   `$bindState` input updates the DOM and the scoped value.
 
 ## Why 100%

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/README.md
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/README.md
@@ -1,0 +1,34 @@
+# F14 - json-render external store points at component state
+
+## The smell
+
+A json-render integration owns a separate external store beside the application graph. The generated UI
+can read and write state, but those writes bypass the scope seam, provider-owned execution context, and
+node-testable frontend state.
+
+## Harm
+
+The app now has two state owners. Lite flows and scoped values cannot see json-render form edits unless
+React glue copies them across, and tests must render json-render just to prove state behavior. That
+recreates the local-state mirror problem at an integration boundary.
+
+## Transformation
+
+`orderDraft` is a Lite `scopedValue`, owned by the current execution context. `view.tsx` adapts that
+scoped value with `@pumped-fn/lite-react-json-render` `scopedValueStateStore` and passes the returned
+store to `@json-render/react` `JSONUIProvider`. json-render still uses its normal `$bindState` and
+`$state` expressions; the source of truth is the Lite graph.
+
+## Lens coverage
+
+- **inside-out** (`after.test.ts`, node): resolve the scoped value through `createScope`, adapt it, and
+  prove JSON Pointer writes update the scoped draft without React.
+- **outside-in** (`view.browser.test.tsx`, browser mode): render the real `@json-render/react`
+  `StateProvider` and `Renderer` under `ScopeProvider` and `ExecutionContextProvider`, then prove a
+  `$bindState` input updates the DOM and the scoped value.
+
+## Why 100%
+
+The state model is declared once in `after.ts`. The adapter behavior is verified through the same
+`StateStore` shape that json-render's official external-store packages consume. The rendered observer
+test covers the real provider stack instead of replacing json-render with a fake.

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/after.test.ts
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/after.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest"
 import { createScope } from "@pumped-fn/lite"
-import { scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
-import { orderDraft } from "./after"
+import { flowAction, flowActionHandlers, scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
+import { currentOrderDraft, orderDraft, submitOrder } from "./after"
 
 describe("inside-out", () => {
   test("IO1: json-render store writes stay inside the execution-scoped draft", async () => {
@@ -20,6 +20,37 @@ describe("inside-out", () => {
       order: {
         item: "Tea",
         quantity: 3,
+      },
+      submission: null,
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  test("IO2: json-render action params execute a Lite flow against the scoped draft", async () => {
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const draft = await orderDraft.resolve(ctx)
+    const handlers = flowActionHandlers({
+      ctx,
+      actions: {
+        submitOrder: flowAction({
+          flow: submitOrder,
+          tags: [currentOrderDraft(draft)],
+        }),
+      },
+    })
+
+    await handlers.submitOrder({ item: "Tea", quantity: 3 })
+
+    expect(draft.getSnapshot()).toEqual({
+      order: {
+        item: "Coffee",
+        quantity: 1,
+      },
+      submission: {
+        message: "Submitted Tea x 3",
       },
     })
 

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/after.test.ts
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/after.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest"
+import { createScope } from "@pumped-fn/lite"
+import { scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
+import { orderDraft } from "./after"
+
+describe("inside-out", () => {
+  test("IO1: json-render store writes stay inside the execution-scoped draft", async () => {
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const draft = await orderDraft.resolve(ctx)
+    const store = scopedValueStateStore({ value: draft })
+
+    expect(store.get("/order/item")).toBe("Coffee")
+    expect(store.get("/order/quantity")).toBe(1)
+
+    store.set("/order/quantity", 2)
+    store.update({ "/order/item": "Tea", "/order/quantity": 3 })
+
+    expect(draft.getSnapshot()).toEqual({
+      order: {
+        item: "Tea",
+        quantity: 3,
+      },
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+})

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/after.test.ts
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/after.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest"
 import { createScope } from "@pumped-fn/lite"
-import { flowAction, flowActionHandlers, scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
+import { flowAction, flowHandlers, scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
 import { currentOrderDraft, orderDraft, submitOrder } from "./after"
 
 describe("inside-out", () => {
@@ -32,7 +32,7 @@ describe("inside-out", () => {
     const scope = createScope()
     const ctx = scope.createContext()
     const draft = await orderDraft.resolve(ctx)
-    const handlers = flowActionHandlers({
+    const handlers = flowHandlers({
       ctx,
       actions: {
         submitOrder: flowAction({

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/after.ts
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/after.ts
@@ -1,11 +1,26 @@
+import { flow, tag } from "@pumped-fn/lite"
 import { scopedValue } from "@pumped-fn/lite-react"
+import type { ScopedValueAccess } from "@pumped-fn/lite-react"
+import { z } from "zod"
+
+const submitOrderInput = z.object({
+  item: z.string(),
+  quantity: z.number(),
+})
 
 export interface OrderState {
   order: {
     item: string
     quantity: number
   }
+  submission: {
+    message: string
+  } | null
 }
+
+export const currentOrderDraft = tag<ScopedValueAccess<OrderState>>({
+  label: "json-render.current-order-draft",
+})
 
 export const orderDraft = scopedValue({
   name: "json-render-order-draft",
@@ -14,5 +29,22 @@ export const orderDraft = scopedValue({
       item: "Coffee",
       quantity: 1,
     },
+    submission: null,
   }),
+})
+
+export const submitOrder = flow({
+  name: "json-render-submit-order",
+  parse: submitOrderInput.parse,
+  factory: (ctx) => {
+    const draft = ctx.data.getTag(currentOrderDraft)!
+    const message = `Submitted ${ctx.input.item} x ${ctx.input.quantity}`
+    draft.update((state) => ({
+      ...state,
+      submission: {
+        message,
+      },
+    }))
+    return message
+  },
 })

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/after.ts
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/after.ts
@@ -1,0 +1,18 @@
+import { scopedValue } from "@pumped-fn/lite-react"
+
+export interface OrderState {
+  order: {
+    item: string
+    quantity: number
+  }
+}
+
+export const orderDraft = scopedValue({
+  name: "json-render-order-draft",
+  initial: (): OrderState => ({
+    order: {
+      item: "Coffee",
+      quantity: 1,
+    },
+  }),
+})

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/before.tsx
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/before.tsx
@@ -1,0 +1,17 @@
+import { StateProvider } from "@json-render/react"
+
+const localStore = {
+  get: () => undefined,
+  set: () => undefined,
+  update: () => undefined,
+  getSnapshot: () => ({ order: { item: "Coffee", quantity: 1 } }),
+  subscribe: () => () => undefined,
+}
+
+export function JsonRenderOrder() {
+  return (
+    <StateProvider store={localStore}>
+      <div>Order</div>
+    </StateProvider>
+  )
+}

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/view.browser.test.tsx
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/view.browser.test.tsx
@@ -5,7 +5,7 @@ import { JSONUIProvider, Renderer, defineRegistry } from "@json-render/react"
 import { schema } from "@json-render/react/schema"
 import { createScope, flow, tag, typed } from "@pumped-fn/lite"
 import { ExecutionContextProvider, ScopeProvider } from "@pumped-fn/lite-react"
-import { flowAction, useFlowActionHandlers } from "@pumped-fn/lite-react-json-render"
+import { flowAction, useFlowHandlers } from "@pumped-fn/lite-react-json-render"
 import { useMemo } from "react"
 import { z } from "zod"
 import { orderDraft } from "./after"
@@ -13,7 +13,7 @@ import { JsonRenderOrder } from "./view"
 
 const actionSink = tag<{ records: string[] }>({ label: "json-render.action-sink" })
 
-const recordAction = flow({
+const record = flow({
   name: "json-render-record-action",
   parse: typed<{ label: string }>(),
   factory: (ctx) => {
@@ -66,11 +66,11 @@ const actionSpec = {
 function ActionHarness({ sink }: { sink: { records: string[] } }) {
   const actions = useMemo(() => ({
     record: flowAction({
-      flow: recordAction,
+      flow: record,
       tags: [actionSink(sink)],
     }),
   }), [sink])
-  const handlers = useFlowActionHandlers(actions)
+  const handlers = useFlowHandlers(actions)
 
   return (
     <JSONUIProvider registry={actionRegistry} handlers={handlers} initialState={{}}>

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/view.browser.test.tsx
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/view.browser.test.tsx
@@ -1,9 +1,83 @@
 import { describe, expect, test } from "vitest"
 import { act, fireEvent, render, screen } from "@testing-library/react"
-import { createScope } from "@pumped-fn/lite"
+import { defineCatalog } from "@json-render/core"
+import { JSONUIProvider, Renderer, defineRegistry } from "@json-render/react"
+import { schema } from "@json-render/react/schema"
+import { createScope, flow, tag, typed } from "@pumped-fn/lite"
 import { ExecutionContextProvider, ScopeProvider } from "@pumped-fn/lite-react"
+import { flowAction, useFlowActionHandlers } from "@pumped-fn/lite-react-json-render"
+import { useMemo } from "react"
+import { z } from "zod"
 import { orderDraft } from "./after"
 import { JsonRenderOrder } from "./view"
+
+const actionSink = tag<{ records: string[] }>({ label: "json-render.action-sink" })
+
+const recordAction = flow({
+  name: "json-render-record-action",
+  parse: typed<{ label: string }>(),
+  factory: (ctx) => {
+    ctx.data.getTag(actionSink)!.records.push(ctx.input.label)
+  },
+})
+
+const actionCatalog = defineCatalog(schema, {
+  components: {
+    ActionButton: {
+      props: z.object({
+        label: z.string(),
+      }),
+    },
+  },
+  actions: {},
+})
+
+const { registry: actionRegistry } = defineRegistry(actionCatalog, {
+  components: {
+    ActionButton: ({ props, emit }) => (
+      <button type="button" onClick={() => emit("press")}>
+        {props.label}
+      </button>
+    ),
+  },
+})
+
+const actionSpec = {
+  root: "button",
+  elements: {
+    button: {
+      type: "ActionButton",
+      props: {
+        label: "Record",
+      },
+      on: {
+        press: {
+          action: "record",
+          params: {
+            label: "pressed",
+          },
+        },
+      },
+      children: [],
+    },
+  },
+}
+
+function ActionHarness({ sink }: { sink: { records: string[] } }) {
+  const actions = useMemo(() => ({
+    record: flowAction({
+      flow: recordAction,
+      tags: [actionSink(sink)],
+    }),
+  }), [sink])
+  const handlers = useFlowActionHandlers(actions)
+
+  return (
+    <JSONUIProvider registry={actionRegistry} handlers={handlers} initialState={{}}>
+      <Renderer spec={actionSpec} registry={actionRegistry} />
+    </JSONUIProvider>
+  )
+}
 
 describe("outside-in", () => {
   test("OI1: json-render waits for the Lite scoped value boundary", async () => {
@@ -45,6 +119,7 @@ describe("outside-in", () => {
     const quantity = await screen.findByRole("spinbutton", { name: "Quantity" })
     expect(quantity).toHaveValue(1)
     expect(await screen.findByLabelText("order summary")).toHaveTextContent("Coffee: 1")
+    expect(await screen.findByLabelText("submission status")).toHaveTextContent("Not submitted")
 
     await act(async () => {
       fireEvent.change(quantity, { target: { value: "4" } })
@@ -58,7 +133,71 @@ describe("outside-in", () => {
         item: "Coffee",
         quantity: 4,
       },
+      submission: null,
     })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Submit order" }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(await screen.findByLabelText("submission status")).toHaveTextContent("Submitted Coffee x 4")
+    expect(draft.getSnapshot()).toEqual({
+      order: {
+        item: "Coffee",
+        quantity: 4,
+      },
+      submission: {
+        message: "Submitted Coffee x 4",
+      },
+    })
+
+    view!.unmount()
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  test("OI3: json-render keeps the latest Lite action handler target without remounting provider", async () => {
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const firstSink = { records: [] }
+    const secondSink = { records: [] }
+    let view: ReturnType<typeof render>
+
+    await act(async () => {
+      view = render(
+        <ScopeProvider scope={scope}>
+          <ExecutionContextProvider ctx={ctx}>
+            <ActionHarness sink={firstSink} />
+          </ExecutionContextProvider>
+        </ScopeProvider>
+      )
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Record" }))
+      await Promise.resolve()
+    })
+    expect(firstSink.records).toEqual(["pressed"])
+    expect(secondSink.records).toEqual([])
+
+    await act(async () => {
+      view!.rerender(
+        <ScopeProvider scope={scope}>
+          <ExecutionContextProvider ctx={ctx}>
+            <ActionHarness sink={secondSink} />
+          </ExecutionContextProvider>
+        </ScopeProvider>
+      )
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Record" }))
+      await Promise.resolve()
+    })
+    expect(firstSink.records).toEqual(["pressed"])
+    expect(secondSink.records).toEqual(["pressed"])
 
     view!.unmount()
     await ctx.close()

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/view.browser.test.tsx
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/view.browser.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "vitest"
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { createScope } from "@pumped-fn/lite"
+import { ExecutionContextProvider, ScopeProvider } from "@pumped-fn/lite-react"
+import { orderDraft } from "./after"
+import { JsonRenderOrder } from "./view"
+
+describe("outside-in", () => {
+  test("OI1: json-render waits for the Lite scoped value boundary", async () => {
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const view = render(
+      <ScopeProvider scope={scope}>
+        <ExecutionContextProvider ctx={ctx}>
+          <JsonRenderOrder />
+        </ExecutionContextProvider>
+      </ScopeProvider>
+    )
+
+    expect(view.container).toBeEmptyDOMElement()
+
+    view.unmount()
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  test("OI2: json-render reads and writes a Lite scoped value through StateProvider", async () => {
+    const scope = createScope()
+    const ctx = scope.createContext()
+    await orderDraft.resolve(ctx)
+    let view: ReturnType<typeof render>
+
+    await act(async () => {
+      view = render(
+        <ScopeProvider scope={scope}>
+          <ExecutionContextProvider ctx={ctx}>
+            <JsonRenderOrder />
+          </ExecutionContextProvider>
+        </ScopeProvider>
+      )
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    const quantity = await screen.findByRole("spinbutton", { name: "Quantity" })
+    expect(quantity).toHaveValue(1)
+    expect(await screen.findByLabelText("order summary")).toHaveTextContent("Coffee: 1")
+
+    await act(async () => {
+      fireEvent.change(quantity, { target: { value: "4" } })
+      await Promise.resolve()
+    })
+    expect(await screen.findByLabelText("order summary")).toHaveTextContent("Coffee: 4")
+
+    const draft = await orderDraft.resolve(ctx)
+    expect(draft.getSnapshot()).toEqual({
+      order: {
+        item: "Coffee",
+        quantity: 4,
+      },
+    })
+
+    view!.unmount()
+    await ctx.close()
+    await scope.dispose()
+  })
+})

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/view.tsx
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/view.tsx
@@ -3,7 +3,7 @@ import { JSONUIProvider, Renderer, defineRegistry, useBoundProp } from "@json-re
 import { schema } from "@json-render/react/schema"
 import { useResource } from "@pumped-fn/lite-react"
 import type { ScopedValueAccess } from "@pumped-fn/lite-react"
-import { flowAction, scopedValueStateStore, useFlowActionHandlers } from "@pumped-fn/lite-react-json-render"
+import { flowAction, scopedValueStateStore, useFlowHandlers } from "@pumped-fn/lite-react-json-render"
 import { useMemo } from "react"
 import { z } from "zod"
 import { currentOrderDraft, type OrderState, orderDraft, submitOrder } from "./after"
@@ -122,10 +122,10 @@ export function JsonRenderOrder() {
 
   if (draft.status !== "ready") return null
 
-  return <JsonRenderOrderReady draft={draft.data} />
+  return <OrderBridge draft={draft.data} />
 }
 
-function JsonRenderOrderReady({ draft }: { draft: ScopedValueAccess<OrderState> }) {
+function OrderBridge({ draft }: { draft: ScopedValueAccess<OrderState> }) {
   const store = useMemo(() => scopedValueStateStore({ value: draft }), [draft])
   const actions = useMemo(() => ({
     submitOrder: flowAction({
@@ -133,7 +133,7 @@ function JsonRenderOrderReady({ draft }: { draft: ScopedValueAccess<OrderState> 
       tags: [currentOrderDraft(draft)],
     }),
   }), [draft])
-  const handlers = useFlowActionHandlers(actions)
+  const handlers = useFlowHandlers(actions)
 
   return (
     <JSONUIProvider registry={registry} store={store} handlers={handlers}>

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/view.tsx
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/view.tsx
@@ -1,0 +1,89 @@
+import { defineCatalog } from "@json-render/core"
+import { JSONUIProvider, Renderer, defineRegistry, useBoundProp } from "@json-render/react"
+import { schema } from "@json-render/react/schema"
+import { useResource } from "@pumped-fn/lite-react"
+import { scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
+import { useMemo } from "react"
+import { z } from "zod"
+import { orderDraft } from "./after"
+
+const catalog = defineCatalog(schema, {
+  components: {
+    QuantityField: {
+      props: z.object({
+        label: z.string(),
+        value: z.number(),
+      }),
+    },
+    QuantitySummary: {
+      props: z.object({
+        item: z.string(),
+        quantity: z.number(),
+      }),
+    },
+  },
+  actions: {},
+})
+
+const { registry } = defineRegistry(catalog, {
+  components: {
+    QuantityField: ({ props, bindings, children }) => {
+      const [value, setValue] = useBoundProp<number>(props.value, bindings?.["value"])
+      return (
+        <label>
+          {props.label}
+          <input
+            aria-label={props.label}
+            type="number"
+            min={1}
+            value={value}
+            onChange={(event) => setValue(event.currentTarget.valueAsNumber)}
+          />
+          {children}
+        </label>
+      )
+    },
+    QuantitySummary: ({ props }) => (
+      <output aria-label="order summary">
+        {props.item}: {props.quantity}
+      </output>
+    ),
+  },
+})
+
+const spec = {
+  root: "quantity",
+  elements: {
+    quantity: {
+      type: "QuantityField",
+      props: {
+        label: "Quantity",
+        value: { $bindState: "/order/quantity" },
+      },
+      children: ["summary"],
+    },
+    summary: {
+      type: "QuantitySummary",
+      props: {
+        item: { $state: "/order/item" },
+        quantity: { $state: "/order/quantity" },
+      },
+      children: [],
+    },
+  },
+}
+
+export function JsonRenderOrder() {
+  const draft = useResource(orderDraft, { suspense: false })
+  const store = useMemo(() => (
+    draft.status === "ready" ? scopedValueStateStore({ value: draft.data }) : undefined
+  ), [draft.status, draft.data])
+
+  if (!store) return null
+
+  return (
+    <JSONUIProvider registry={registry} store={store}>
+      <Renderer spec={spec} registry={registry} />
+    </JSONUIProvider>
+  )
+}

--- a/examples/lite-react-practical/patterns/F14-json-render-state-store/view.tsx
+++ b/examples/lite-react-practical/patterns/F14-json-render-state-store/view.tsx
@@ -2,10 +2,11 @@ import { defineCatalog } from "@json-render/core"
 import { JSONUIProvider, Renderer, defineRegistry, useBoundProp } from "@json-render/react"
 import { schema } from "@json-render/react/schema"
 import { useResource } from "@pumped-fn/lite-react"
-import { scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
+import type { ScopedValueAccess } from "@pumped-fn/lite-react"
+import { flowAction, scopedValueStateStore, useFlowActionHandlers } from "@pumped-fn/lite-react-json-render"
 import { useMemo } from "react"
 import { z } from "zod"
-import { orderDraft } from "./after"
+import { currentOrderDraft, type OrderState, orderDraft, submitOrder } from "./after"
 
 const catalog = defineCatalog(schema, {
   components: {
@@ -19,6 +20,16 @@ const catalog = defineCatalog(schema, {
       props: z.object({
         item: z.string(),
         quantity: z.number(),
+      }),
+    },
+    SubmitButton: {
+      props: z.object({
+        label: z.string(),
+      }),
+    },
+    SubmissionStatus: {
+      props: z.object({
+        message: z.string().optional(),
       }),
     },
   },
@@ -48,6 +59,16 @@ const { registry } = defineRegistry(catalog, {
         {props.item}: {props.quantity}
       </output>
     ),
+    SubmitButton: ({ props, emit }) => (
+      <button type="button" onClick={() => emit("press")}>
+        {props.label}
+      </button>
+    ),
+    SubmissionStatus: ({ props }) => (
+      <output aria-label="submission status">
+        {props.message ?? "Not submitted"}
+      </output>
+    ),
   },
 })
 
@@ -60,7 +81,7 @@ const spec = {
         label: "Quantity",
         value: { $bindState: "/order/quantity" },
       },
-      children: ["summary"],
+      children: ["summary", "submit", "submitted"],
     },
     summary: {
       type: "QuantitySummary",
@@ -70,19 +91,52 @@ const spec = {
       },
       children: [],
     },
+    submit: {
+      type: "SubmitButton",
+      props: {
+        label: "Submit order",
+      },
+      on: {
+        press: {
+          action: "submitOrder",
+          params: {
+            item: { $state: "/order/item" },
+            quantity: { $state: "/order/quantity" },
+          },
+        },
+      },
+      children: [],
+    },
+    submitted: {
+      type: "SubmissionStatus",
+      props: {
+        message: { $state: "/submission/message" },
+      },
+      children: [],
+    },
   },
 }
 
 export function JsonRenderOrder() {
   const draft = useResource(orderDraft, { suspense: false })
-  const store = useMemo(() => (
-    draft.status === "ready" ? scopedValueStateStore({ value: draft.data }) : undefined
-  ), [draft.status, draft.data])
 
-  if (!store) return null
+  if (draft.status !== "ready") return null
+
+  return <JsonRenderOrderReady draft={draft.data} />
+}
+
+function JsonRenderOrderReady({ draft }: { draft: ScopedValueAccess<OrderState> }) {
+  const store = useMemo(() => scopedValueStateStore({ value: draft }), [draft])
+  const actions = useMemo(() => ({
+    submitOrder: flowAction({
+      flow: submitOrder,
+      tags: [currentOrderDraft(draft)],
+    }),
+  }), [draft])
+  const handlers = useFlowActionHandlers(actions)
 
   return (
-    <JSONUIProvider registry={registry} store={store}>
+    <JSONUIProvider registry={registry} store={store} handlers={handlers}>
       <Renderer spec={spec} registry={registry} />
     </JSONUIProvider>
   )

--- a/packages/lite-react-json-render/CHANGELOG.md
+++ b/packages/lite-react-json-render/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @pumped-fn/lite-react-json-render

--- a/packages/lite-react-json-render/LICENSE
+++ b/packages/lite-react-json-render/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2025 Duke
+
+Permission is hereby granted, free of
+charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/lite-react-json-render/README.md
+++ b/packages/lite-react-json-render/README.md
@@ -1,21 +1,22 @@
 # @pumped-fn/lite-react-json-render
 
-json-render `StateStore` adapter for `@pumped-fn/lite-react` scoped values.
+json-render state and action adapters for `@pumped-fn/lite-react`.
 
-Use this package when a json-render spec should bind to Lite-owned frontend state. `@pumped-fn/lite-react`
-still owns the scope, execution context, and scoped value; json-render reads and writes through its normal
-controlled `StateProvider` store prop.
+Use this package when a json-render spec should bind to Lite-owned frontend state and emit actions into
+Lite-owned flows. `@pumped-fn/lite-react` still owns the scope, execution context, scoped value, resources,
+tags, presets, and tests; json-render reads, writes, and emits through its normal provider contracts.
 
 ## When to Use
 
-Use this adapter when json-render is already the right UI boundary: generated specs, server-authored forms,
-schema-driven editors, or embedded surfaces that need json-render's `$state` and `$bindState` expressions.
-The timing is the integration edge, after the draft/form/editor state has a clear Lite owner.
+Use these adapters when json-render is already the right UI boundary: generated specs, server-authored
+forms, schema-driven editors, or embedded surfaces that need json-render's `$state`, `$bindState`, `on`,
+or `watch` contracts. The timing is the integration edge, after the draft/form/editor state and action
+flows have clear Lite owners.
 
 Do not use it to make ordinary React components more indirect. If the UI is hand-authored React, render forms
 and drafts from `useScopedValue` and mutate through scoped actions. Use `useResource` when an integration
 boundary needs the resolved access object. If json-render should own isolated state that never needs Lite
-flows, resources, resets, or tests, use json-render's own store instead.
+flows, resources, resets, or tests, use json-render's own store and handlers instead.
 
 ## Install
 
@@ -27,30 +28,108 @@ npm install @json-render/core @json-render/react zod
 ## Usage
 
 ```tsx
-import { StateProvider } from "@json-render/react"
-import { scopedValue, useResource } from "@pumped-fn/lite-react"
-import { scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
+import { JSONUIProvider, type ComponentRegistry } from "@json-render/react"
+import { flow, tag } from "@pumped-fn/lite"
+import { scopedValue, type ScopedValueAccess, useResource } from "@pumped-fn/lite-react"
+import { flowAction, scopedValueStateStore, useFlowActionHandlers } from "@pumped-fn/lite-react-json-render"
 import { useMemo } from "react"
+import { z } from "zod"
+
+interface OrderState {
+  order: {
+    item: string
+    quantity: number
+  }
+  submission: {
+    message: string
+  } | null
+}
+
+const submitOrderInput = z.object({
+  item: z.string(),
+  quantity: z.number(),
+})
+
+const currentOrderDraft = tag<ScopedValueAccess<OrderState>>({
+  label: "current.order-draft",
+})
 
 const orderDraft = scopedValue({
   name: "order-draft",
-  initial: () => ({ order: { item: "Coffee", quantity: 1 } }),
+  initial: (): OrderState => ({
+    order: { item: "Coffee", quantity: 1 },
+    submission: null,
+  }),
 })
 
-function GeneratedOrder({ children }: { children: React.ReactNode }) {
+const submitOrder = flow({
+  name: "submit-order",
+  parse: submitOrderInput.parse,
+  factory: (ctx) => {
+    const draft = ctx.data.getTag(currentOrderDraft)!
+    const message = `Submitted ${ctx.input.item} x ${ctx.input.quantity}`
+    draft.patch({ submission: { message } })
+    return message
+  },
+})
+
+function GeneratedOrder(
+  { registry, children }: { registry: ComponentRegistry; children: React.ReactNode }
+) {
   const draft = useResource(orderDraft)
-  const store = useMemo(() => scopedValueStateStore({ value: draft }), [draft])
 
   return (
-    <StateProvider store={store}>
+    <GeneratedOrderReady registry={registry} draft={draft}>
       {children}
-    </StateProvider>
+    </GeneratedOrderReady>
+  )
+}
+
+function GeneratedOrderReady(
+  { registry, draft, children }: {
+    registry: ComponentRegistry
+    draft: ScopedValueAccess<OrderState>
+    children: React.ReactNode
+  }
+) {
+  const store = useMemo(() => scopedValueStateStore({ value: draft }), [draft])
+  const actions = useMemo(() => ({
+    submitOrder: flowAction({
+      flow: submitOrder,
+      tags: [currentOrderDraft(draft)],
+    }),
+  }), [draft])
+  const handlers = useFlowActionHandlers(actions)
+
+  return (
+    <JSONUIProvider registry={registry} store={store} handlers={handlers}>
+      {children}
+    </JSONUIProvider>
   )
 }
 ```
 
 The adapter exposes json-render's `StateStore` shape: JSON Pointer `get`, `set`, batched `update`,
 `getSnapshot`, server snapshot, and `subscribe`.
+
+`flowActionHandlers` returns json-render `ActionHandler` functions. Bare flows receive resolved
+json-render params as `rawInput`, so a flow parser can validate generated params. Use `flowAction` when
+the boundary needs to map input, set an execution name, or pass tags.
+
+`useFlowActionHandlers` returns stable proxy handlers that read the latest Lite context and action
+configuration. That matches json-render's action provider, which registers the handler map at provider mount.
+
+## Behavior Surface
+
+Pass the returned `handlers` to `JSONUIProvider` for json-render `on` and `watch` bindings. json-render
+continues to own event binding, action param resolution, confirmation, `onSuccess`, `onError`, and loading
+state; Lite owns the executed flows and their resources/tags/extensions.
+
+json-render also accepts `navigate`, `validationFunctions`, `functions`, and `directives`. Keep those as
+native `JSONUIProvider` props. Validation and computed functions are synchronous json-render contracts, so
+do not hide async Lite flows behind them. If they need Lite-owned data, adapt already-resolved graph values
+into sync functions at the integration boundary, or have action flows write derived results back into the
+scoped value.
 
 ## Nested Slices
 
@@ -69,9 +148,9 @@ json-render slice.
 
 ## Testing
 
-Logic tests can resolve the scoped value through `createScope`, adapt it, and assert `StateStore`
-behavior without React. Browser observer tests should render the real json-render provider under
-`ScopeProvider` and `ExecutionContextProvider`.
+Logic tests can resolve the scoped value through `createScope`, adapt it, call action handlers, and assert
+`StateStore` plus flow behavior without React. Browser observer tests should render the real json-render
+provider under `ScopeProvider` and `ExecutionContextProvider`.
 
 ## License
 

--- a/packages/lite-react-json-render/README.md
+++ b/packages/lite-react-json-render/README.md
@@ -1,0 +1,65 @@
+# @pumped-fn/lite-react-json-render
+
+json-render `StateStore` adapter for `@pumped-fn/lite-react` scoped values.
+
+Use this package when a json-render spec should bind to Lite-owned frontend state. `@pumped-fn/lite-react`
+still owns the scope, execution context, and scoped value; json-render reads and writes through its normal
+controlled `StateProvider` store prop.
+
+## Install
+
+```bash
+npm install @pumped-fn/lite @pumped-fn/lite-react @pumped-fn/lite-react-json-render
+npm install @json-render/core @json-render/react zod
+```
+
+## Usage
+
+```tsx
+import { StateProvider } from "@json-render/react"
+import { scopedValue, useResource } from "@pumped-fn/lite-react"
+import { scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
+
+const orderDraft = scopedValue({
+  name: "order-draft",
+  initial: () => ({ order: { item: "Coffee", quantity: 1 } }),
+})
+
+function GeneratedOrder({ children }: { children: React.ReactNode }) {
+  const draft = useResource(orderDraft)
+
+  return (
+    <StateProvider store={scopedValueStateStore({ value: draft })}>
+      {children}
+    </StateProvider>
+  )
+}
+```
+
+The adapter exposes json-render's `StateStore` shape: JSON Pointer `get`, `set`, batched `update`,
+`getSnapshot`, server snapshot, and `subscribe`.
+
+## Nested Slices
+
+For a nested state model, pass a selector and updater:
+
+```ts
+const store = scopedValueStateStore({
+  value: appDraft,
+  selector: (state) => state.ui,
+  updater: (next, value) => value.set({ ...value.getSnapshot(), ui: next as { count: number } }),
+})
+```
+
+The updater is required for selected slices so unrelated graph-owned state is not replaced by the
+json-render slice.
+
+## Testing
+
+Logic tests can resolve the scoped value through `createScope`, adapt it, and assert `StateStore`
+behavior without React. Browser observer tests should render the real json-render provider under
+`ScopeProvider` and `ExecutionContextProvider`.
+
+## License
+
+MIT

--- a/packages/lite-react-json-render/README.md
+++ b/packages/lite-react-json-render/README.md
@@ -31,7 +31,7 @@ npm install @json-render/core @json-render/react zod
 import { JSONUIProvider, type ComponentRegistry } from "@json-render/react"
 import { flow, tag } from "@pumped-fn/lite"
 import { scopedValue, type ScopedValueAccess, useResource } from "@pumped-fn/lite-react"
-import { flowAction, scopedValueStateStore, useFlowActionHandlers } from "@pumped-fn/lite-react-json-render"
+import { flowAction, scopedValueStateStore, useFlowHandlers } from "@pumped-fn/lite-react-json-render"
 import { useMemo } from "react"
 import { z } from "zod"
 
@@ -79,13 +79,13 @@ function GeneratedOrder(
   const draft = useResource(orderDraft)
 
   return (
-    <GeneratedOrderReady registry={registry} draft={draft}>
+    <OrderBridge registry={registry} draft={draft}>
       {children}
-    </GeneratedOrderReady>
+    </OrderBridge>
   )
 }
 
-function GeneratedOrderReady(
+function OrderBridge(
   { registry, draft, children }: {
     registry: ComponentRegistry
     draft: ScopedValueAccess<OrderState>
@@ -99,7 +99,7 @@ function GeneratedOrderReady(
       tags: [currentOrderDraft(draft)],
     }),
   }), [draft])
-  const handlers = useFlowActionHandlers(actions)
+  const handlers = useFlowHandlers(actions)
 
   return (
     <JSONUIProvider registry={registry} store={store} handlers={handlers}>
@@ -112,11 +112,11 @@ function GeneratedOrderReady(
 The adapter exposes json-render's `StateStore` shape: JSON Pointer `get`, `set`, batched `update`,
 `getSnapshot`, server snapshot, and `subscribe`.
 
-`flowActionHandlers` returns json-render `ActionHandler` functions. Bare flows receive resolved
+`flowHandlers` returns json-render `ActionHandler` functions. Bare flows receive resolved
 json-render params as `rawInput`, so a flow parser can validate generated params. Use `flowAction` when
 the boundary needs to map input, set an execution name, or pass tags.
 
-`useFlowActionHandlers` returns stable proxy handlers that read the latest Lite context and action
+`useFlowHandlers` returns stable proxy handlers that read the latest Lite context and action
 configuration. That matches json-render's action provider, which registers the handler map at provider mount.
 
 ## Behavior Surface

--- a/packages/lite-react-json-render/README.md
+++ b/packages/lite-react-json-render/README.md
@@ -6,6 +6,17 @@ Use this package when a json-render spec should bind to Lite-owned frontend stat
 still owns the scope, execution context, and scoped value; json-render reads and writes through its normal
 controlled `StateProvider` store prop.
 
+## When to Use
+
+Use this adapter when json-render is already the right UI boundary: generated specs, server-authored forms,
+schema-driven editors, or embedded surfaces that need json-render's `$state` and `$bindState` expressions.
+The timing is the integration edge, after the draft/form/editor state has a clear Lite owner.
+
+Do not use it to make ordinary React components more indirect. If the UI is hand-authored React, render forms
+and drafts from `useScopedValue` and mutate through scoped actions. Use `useResource` when an integration
+boundary needs the resolved access object. If json-render should own isolated state that never needs Lite
+flows, resources, resets, or tests, use json-render's own store instead.
+
 ## Install
 
 ```bash
@@ -19,6 +30,7 @@ npm install @json-render/core @json-render/react zod
 import { StateProvider } from "@json-render/react"
 import { scopedValue, useResource } from "@pumped-fn/lite-react"
 import { scopedValueStateStore } from "@pumped-fn/lite-react-json-render"
+import { useMemo } from "react"
 
 const orderDraft = scopedValue({
   name: "order-draft",
@@ -27,9 +39,10 @@ const orderDraft = scopedValue({
 
 function GeneratedOrder({ children }: { children: React.ReactNode }) {
   const draft = useResource(orderDraft)
+  const store = useMemo(() => scopedValueStateStore({ value: draft }), [draft])
 
   return (
-    <StateProvider store={scopedValueStateStore({ value: draft })}>
+    <StateProvider store={store}>
       {children}
     </StateProvider>
   )

--- a/packages/lite-react-json-render/package.json
+++ b/packages/lite-react-json-render/package.json
@@ -25,7 +25,7 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "tsdown --config-loader native",
+    "build": "tsdown --config-loader tsx",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/packages/lite-react-json-render/package.json
+++ b/packages/lite-react-json-render/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@pumped-fn/lite-react-json-render",
+  "version": "0.0.0",
+  "description": "json-render StateStore adapter for @pumped-fn/lite-react scoped values",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsdown --config-loader native",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@json-render/core": "catalog:"
+  },
+  "peerDependencies": {
+    "@pumped-fn/lite-react": "^2.3.0"
+  },
+  "devDependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-react": "workspace:*",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "directory": "packages/lite-react-json-render",
+    "url": "git+https://github.com/pumped-fn/pumped-fn.git"
+  },
+  "keywords": [
+    "json-render",
+    "state-store",
+    "pumped-fn",
+    "lite-react",
+    "react",
+    "scoped-value"
+  ],
+  "license": "MIT"
+}

--- a/packages/lite-react-json-render/package.json
+++ b/packages/lite-react-json-render/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pumped-fn/lite-react-json-render",
   "version": "0.0.0",
-  "description": "json-render StateStore adapter for @pumped-fn/lite-react scoped values",
+  "description": "json-render state and action adapters for @pumped-fn/lite-react",
   "type": "module",
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
@@ -34,11 +34,14 @@
     "@json-render/core": "catalog:"
   },
   "peerDependencies": {
-    "@pumped-fn/lite-react": "^2.3.0"
+    "@pumped-fn/lite-react": "^2.3.0",
+    "react": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@pumped-fn/lite": "workspace:*",
     "@pumped-fn/lite-react": "workspace:*",
+    "@types/react": "catalog:",
+    "react": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",

--- a/packages/lite-react-json-render/src/index.ts
+++ b/packages/lite-react-json-render/src/index.ts
@@ -1,8 +1,22 @@
 import { createStoreAdapter } from '@json-render/core/store-utils'
-import type { StateModel, StateStore } from '@json-render/core'
-import type { ScopedValueAccess } from '@pumped-fn/lite-react'
+import type { ActionHandler, StateModel, StateStore } from '@json-render/core'
+import { useExecutionContext } from '@pumped-fn/lite-react'
+import type { Lite, ScopedValueAccess } from '@pumped-fn/lite-react'
+import { useRef } from 'react'
 
 type ScopedValueStateSource<State extends object> = Pick<ScopedValueAccess<State>, 'getSnapshot' | 'set' | 'subscribe'>
+type JsonRenderActionParams = Record<string, unknown>
+type FlowActionHandlerResult<Target> =
+  Target extends Lite.Flow<infer Output, any>
+    ? Output
+    : Target extends FlowActionOptions<infer Flow>
+      ? Lite.Utils.FlowOutput<Flow>
+      : never
+type FlowActionHandlers<Actions extends FlowActionTargets> = {
+  [Name in keyof Actions]: ActionHandler<JsonRenderActionParams, FlowActionHandlerResult<Actions[Name]>>
+}
+type FlowActionTargets = Record<string, FlowActionTarget<Lite.Flow<any, any>>>
+type FlowActionTarget<Flow extends Lite.Flow<any, any>> = Flow | FlowActionOptions<Flow>
 
 interface ScopedValueStateStoreOptions<State extends object = StateModel> {
   value: ScopedValueStateSource<State>
@@ -12,6 +26,41 @@ interface ScopedValueStateStoreSliceOptions<State extends object> {
   value: ScopedValueStateSource<State>
   selector(state: State): StateModel
   updater(nextState: StateModel, value: ScopedValueStateSource<State>): void
+}
+
+interface FlowActionBaseOptions<Flow extends Lite.Flow<any, any>> {
+  flow: Flow
+  name?: string
+  tags?: Lite.Tagged<any>[]
+}
+
+interface FlowActionInputOptions<Flow extends Lite.Flow<any, any>> extends FlowActionBaseOptions<Flow> {
+  input(params: JsonRenderActionParams): Lite.Utils.FlowInput<Flow>
+  rawInput?: never
+}
+
+interface FlowActionRawInputOptions<Flow extends Lite.Flow<any, any>> extends FlowActionBaseOptions<Flow> {
+  rawInput?(params: JsonRenderActionParams): unknown
+  input?: never
+}
+
+type FlowActionOptions<Flow extends Lite.Flow<any, any>> =
+  | FlowActionInputOptions<Flow>
+  | FlowActionRawInputOptions<Flow>
+
+interface FlowActionHandlersOptions<Actions extends FlowActionTargets> {
+  ctx: Lite.ExecutionContext
+  actions: Actions
+}
+
+interface FlowActionHandlerCell {
+  ctx: Lite.ExecutionContext
+  target: FlowActionTarget<Lite.Flow<any, any>>
+}
+
+interface FlowActionHandlersRef {
+  handlers: Record<string, ActionHandler<JsonRenderActionParams, unknown>>
+  cells: Map<string, FlowActionHandlerCell>
 }
 
 function scopedValueStateStore<State extends object>(
@@ -48,5 +97,99 @@ function scopedValueStateStore<State extends object>(
   })
 }
 
-export { scopedValueStateStore }
-export type { ScopedValueStateSource, ScopedValueStateStoreOptions, ScopedValueStateStoreSliceOptions }
+function flowAction<Flow extends Lite.Flow<any, any>>(options: FlowActionOptions<Flow>): FlowActionOptions<Flow> {
+  return options
+}
+
+function flowActionHandlers<const Actions extends FlowActionTargets>(
+  options: FlowActionHandlersOptions<Actions>
+): FlowActionHandlers<Actions> {
+  return Object.fromEntries(
+    Object.entries(options.actions).map(([name, target]) => [
+      name,
+      flowActionHandler(options.ctx, target),
+    ])
+  ) as FlowActionHandlers<Actions>
+}
+
+function useFlowActionHandlers<const Actions extends FlowActionTargets>(
+  actions: Actions
+): FlowActionHandlers<Actions> {
+  const ctx = useExecutionContext()
+  const ref = useRef<FlowActionHandlersRef | null>(null)
+  if (!ref.current) {
+    ref.current = {
+      handlers: {},
+      cells: new Map(),
+    }
+  }
+
+  const { handlers, cells } = ref.current
+  const actionNames = new Set(Object.keys(actions))
+
+  for (const name of Object.keys(handlers)) {
+    if (!actionNames.has(name)) {
+      delete handlers[name]
+      cells.delete(name)
+    }
+  }
+
+  for (const [name, target] of Object.entries(actions)) {
+    let cell = cells.get(name)
+    if (!cell) {
+      const nextCell = { ctx, target }
+      cell = nextCell
+      cells.set(name, nextCell)
+      handlers[name] = (params) => flowActionHandler(nextCell.ctx, nextCell.target)(params)
+    }
+    cell.ctx = ctx
+    cell.target = target
+  }
+
+  return handlers as FlowActionHandlers<Actions>
+}
+
+function flowActionHandler<Flow extends Lite.Flow<any, any>>(
+  ctx: Lite.ExecutionContext,
+  target: FlowActionTarget<Flow>
+): ActionHandler<JsonRenderActionParams, Lite.Utils.FlowOutput<Flow>> {
+  if ('flow' in target) {
+    return (params) => {
+      if (target.input) {
+        return ctx.exec<Lite.Utils.FlowOutput<Flow>, Lite.Utils.FlowInput<Flow>>({
+          flow: target.flow,
+          input: target.input(params),
+          name: target.name,
+          tags: target.tags,
+        })
+      }
+
+      return ctx.exec<Lite.Utils.FlowOutput<Flow>, Lite.Utils.FlowInput<Flow>>({
+        flow: target.flow,
+        rawInput: target.rawInput ? target.rawInput(params) : params,
+        name: target.name,
+        tags: target.tags,
+      })
+    }
+  }
+
+  return (params) => ctx.exec<Lite.Utils.FlowOutput<Flow>, Lite.Utils.FlowInput<Flow>>({
+    flow: target,
+    rawInput: params,
+  })
+}
+
+export { flowAction, flowActionHandlers, scopedValueStateStore, useFlowActionHandlers }
+export type {
+  FlowActionHandlers,
+  FlowActionHandlersOptions,
+  FlowActionInputOptions,
+  FlowActionOptions,
+  FlowActionRawInputOptions,
+  FlowActionTarget,
+  FlowActionTargets,
+  JsonRenderActionParams,
+  ScopedValueStateSource,
+  ScopedValueStateStoreOptions,
+  ScopedValueStateStoreSliceOptions,
+}

--- a/packages/lite-react-json-render/src/index.ts
+++ b/packages/lite-react-json-render/src/index.ts
@@ -1,11 +1,8 @@
 import { createStoreAdapter } from '@json-render/core/store-utils'
 import type { StateModel, StateStore } from '@json-render/core'
+import type { ScopedValueAccess } from '@pumped-fn/lite-react'
 
-interface ScopedValueStateSource<State extends object> {
-  getSnapshot(): State
-  set(value: State): void
-  subscribe(listener: () => void): () => void
-}
+type ScopedValueStateSource<State extends object> = Pick<ScopedValueAccess<State>, 'getSnapshot' | 'set' | 'subscribe'>
 
 interface ScopedValueStateStoreOptions<State extends object = StateModel> {
   value: ScopedValueStateSource<State>

--- a/packages/lite-react-json-render/src/index.ts
+++ b/packages/lite-react-json-render/src/index.ts
@@ -12,7 +12,7 @@ type FlowActionHandlerResult<Target> =
     : Target extends FlowActionOptions<infer Flow>
       ? Lite.Utils.FlowOutput<Flow>
       : never
-type FlowActionHandlers<Actions extends FlowActionTargets> = {
+type FlowHandlers<Actions extends FlowActionTargets> = {
   [Name in keyof Actions]: ActionHandler<JsonRenderActionParams, FlowActionHandlerResult<Actions[Name]>>
 }
 type FlowActionTargets = Record<string, FlowActionTarget<Lite.Flow<any, any>>>
@@ -48,7 +48,7 @@ type FlowActionOptions<Flow extends Lite.Flow<any, any>> =
   | FlowActionInputOptions<Flow>
   | FlowActionRawInputOptions<Flow>
 
-interface FlowActionHandlersOptions<Actions extends FlowActionTargets> {
+interface FlowHandlersOptions<Actions extends FlowActionTargets> {
   ctx: Lite.ExecutionContext
   actions: Actions
 }
@@ -58,7 +58,7 @@ interface FlowActionHandlerCell {
   target: FlowActionTarget<Lite.Flow<any, any>>
 }
 
-interface FlowActionHandlersRef {
+interface FlowHandlersRef {
   handlers: Record<string, ActionHandler<JsonRenderActionParams, unknown>>
   cells: Map<string, FlowActionHandlerCell>
 }
@@ -101,22 +101,22 @@ function flowAction<Flow extends Lite.Flow<any, any>>(options: FlowActionOptions
   return options
 }
 
-function flowActionHandlers<const Actions extends FlowActionTargets>(
-  options: FlowActionHandlersOptions<Actions>
-): FlowActionHandlers<Actions> {
+function flowHandlers<const Actions extends FlowActionTargets>(
+  options: FlowHandlersOptions<Actions>
+): FlowHandlers<Actions> {
   return Object.fromEntries(
     Object.entries(options.actions).map(([name, target]) => [
       name,
       flowActionHandler(options.ctx, target),
     ])
-  ) as FlowActionHandlers<Actions>
+  ) as FlowHandlers<Actions>
 }
 
-function useFlowActionHandlers<const Actions extends FlowActionTargets>(
+function useFlowHandlers<const Actions extends FlowActionTargets>(
   actions: Actions
-): FlowActionHandlers<Actions> {
+): FlowHandlers<Actions> {
   const ctx = useExecutionContext()
-  const ref = useRef<FlowActionHandlersRef | null>(null)
+  const ref = useRef<FlowHandlersRef | null>(null)
   if (!ref.current) {
     ref.current = {
       handlers: {},
@@ -146,7 +146,7 @@ function useFlowActionHandlers<const Actions extends FlowActionTargets>(
     cell.target = target
   }
 
-  return handlers as FlowActionHandlers<Actions>
+  return handlers as FlowHandlers<Actions>
 }
 
 function flowActionHandler<Flow extends Lite.Flow<any, any>>(
@@ -179,10 +179,10 @@ function flowActionHandler<Flow extends Lite.Flow<any, any>>(
   })
 }
 
-export { flowAction, flowActionHandlers, scopedValueStateStore, useFlowActionHandlers }
+export { flowAction, flowHandlers, scopedValueStateStore, useFlowHandlers }
 export type {
-  FlowActionHandlers,
-  FlowActionHandlersOptions,
+  FlowHandlers,
+  FlowHandlersOptions,
   FlowActionInputOptions,
   FlowActionOptions,
   FlowActionRawInputOptions,

--- a/packages/lite-react-json-render/src/index.ts
+++ b/packages/lite-react-json-render/src/index.ts
@@ -1,0 +1,55 @@
+import { createStoreAdapter } from '@json-render/core/store-utils'
+import type { StateModel, StateStore } from '@json-render/core'
+
+interface ScopedValueStateSource<State extends object> {
+  getSnapshot(): State
+  set(value: State): void
+  subscribe(listener: () => void): () => void
+}
+
+interface ScopedValueStateStoreOptions<State extends object = StateModel> {
+  value: ScopedValueStateSource<State>
+}
+
+interface ScopedValueStateStoreSliceOptions<State extends object> {
+  value: ScopedValueStateSource<State>
+  selector(state: State): StateModel
+  updater(nextState: StateModel, value: ScopedValueStateSource<State>): void
+}
+
+function scopedValueStateStore<State extends object>(
+  options: ScopedValueStateStoreOptions<State>
+): StateStore
+function scopedValueStateStore<State extends object>(
+  options: ScopedValueStateStoreSliceOptions<State>
+): StateStore
+function scopedValueStateStore<State extends object>(
+  options: ScopedValueStateStoreOptions<State> | ScopedValueStateStoreSliceOptions<State>
+): StateStore {
+  const source = options.value
+  const selector: (state: State) => StateModel = 'selector' in options
+    ? options.selector
+    : (state) => state as unknown as StateModel
+  const updater: (next: StateModel, value: ScopedValueStateSource<State>) => void = 'updater' in options
+    ? options.updater
+    : (next, value) => value.set(next as unknown as State)
+
+  return createStoreAdapter({
+    getSnapshot: () => selector(source.getSnapshot()),
+    setSnapshot: (next) => updater(next, source),
+    subscribe(listener) {
+      let prev = selector(source.getSnapshot())
+      return source.subscribe(() => {
+        const current = selector(source.getSnapshot())
+        if (current !== prev) {
+          prev = current
+          listener()
+          prev = selector(source.getSnapshot())
+        }
+      })
+    },
+  })
+}
+
+export { scopedValueStateStore }
+export type { ScopedValueStateSource, ScopedValueStateStoreOptions, ScopedValueStateStoreSliceOptions }

--- a/packages/lite-react-json-render/tests/index.test.ts
+++ b/packages/lite-react-json-render/tests/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { createScope } from '@pumped-fn/lite'
+import { createScope, flow, tag, typed } from '@pumped-fn/lite'
 import { scopedValue } from '@pumped-fn/lite-react'
 import type { StateStore } from '@json-render/core'
-import { scopedValueStateStore } from '../src'
+import { flowAction, flowActionHandlers, scopedValueStateStore } from '../src'
 
 interface FormState {
   user: {
@@ -46,6 +46,8 @@ const app = scopedValue({
     },
   }),
 })
+
+const actionSource = tag<string>({ label: 'json-render.action-source' })
 
 describe('scopedValueStateStore', () => {
   it('adapts whole scopedValue access to json-render StateStore', async () => {
@@ -113,6 +115,89 @@ describe('scopedValueStateStore', () => {
         token: 'secret',
       },
     })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+})
+
+describe('flowActionHandlers', () => {
+  it('runs a flow with json-render params as raw input', async () => {
+    const submit = flow({
+      name: 'submit-json-render-order',
+      parse(raw) {
+        const params = raw as { item: unknown; quantity: unknown }
+        if (typeof params.item !== 'string') throw new Error('missing item')
+        if (typeof params.quantity !== 'number') throw new Error('missing quantity')
+        return {
+          item: params.item,
+          quantity: params.quantity,
+        }
+      },
+      factory: (ctx) => `${ctx.input.quantity}x ${ctx.input.item}`,
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const handlers = flowActionHandlers({ ctx, actions: { submit } })
+
+    await expect(handlers.submit({ item: 'Coffee', quantity: 2 })).resolves.toBe('2x Coffee')
+    await expect(handlers.submit({ item: 'Coffee', quantity: '2' })).rejects.toThrow(
+      'Failed to parse flow input "submit-json-render-order"'
+    )
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it('runs configured actions with typed input, execution name, and tags', async () => {
+    const record = flow({
+      name: 'record-json-render-action',
+      parse: typed<{ quantity: number }>(),
+      factory: (ctx) => ({
+        input: ctx.input,
+        name: ctx.name,
+        source: ctx.data.getTag(actionSource),
+      }),
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const handlers = flowActionHandlers({
+      ctx,
+      actions: {
+        record: flowAction({
+          flow: record,
+          input: (params) => ({ quantity: Number(params.quantity) }),
+          name: 'json-render.record',
+          tags: [actionSource('json-render')],
+        }),
+      },
+    })
+
+    await expect(handlers.record({ quantity: '5' })).resolves.toEqual({
+      input: {
+        quantity: 5,
+      },
+      name: 'json-render.record',
+      source: 'json-render',
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it('lets flow errors propagate to json-render action handling', async () => {
+    const fail = flow({
+      name: 'fail-json-render-action',
+      parse: typed<{ message: string }>(),
+      factory: (ctx) => {
+        throw new Error(ctx.input.message)
+      },
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const handlers = flowActionHandlers({ ctx, actions: { fail } })
+
+    await expect(handlers.fail({ message: 'rejected by Lite' })).rejects.toThrow('rejected by Lite')
 
     await ctx.close()
     await scope.dispose()

--- a/packages/lite-react-json-render/tests/index.test.ts
+++ b/packages/lite-react-json-render/tests/index.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+import { createScope } from '@pumped-fn/lite'
+import { scopedValue } from '@pumped-fn/lite-react'
+import type { StateStore } from '@json-render/core'
+import { scopedValueStateStore } from '../src'
+
+interface FormState {
+  user: {
+    name: string
+    labels: string[]
+    escaped: Record<string, string>
+  }
+}
+
+interface AppState {
+  ui: {
+    count: number
+  }
+  auth: {
+    token: string | null
+  }
+}
+
+const form = scopedValue({
+  name: 'json-render-form',
+  initial: (): FormState => ({
+    user: {
+      name: 'Alice',
+      labels: ['one'],
+      escaped: {
+        'a/b': 'slash',
+        'tilde~key': 'tilde',
+      },
+    },
+  }),
+})
+
+const app = scopedValue({
+  name: 'json-render-app',
+  initial: (): AppState => ({
+    ui: {
+      count: 1,
+    },
+    auth: {
+      token: 'secret',
+    },
+  }),
+})
+
+describe('scopedValueStateStore', () => {
+  it('adapts whole scopedValue access to json-render StateStore', async () => {
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const access = await form.resolve(ctx)
+    const store = scopedValueStateStore({ value: access }) satisfies StateStore
+    const calls: FormState[] = []
+    const unsubscribe = store.subscribe(() => {
+      calls.push(access.getSnapshot())
+    })
+
+    expect(store.get('/user/name')).toBe('Alice')
+    expect(store.get('/user/labels/0')).toBe('one')
+    expect(store.get('/user/escaped/a~1b')).toBe('slash')
+    expect(store.get('/user/escaped/tilde~0key')).toBe('tilde')
+    expect(store.getSnapshot()).toBe(access.getSnapshot())
+    expect(store.getServerSnapshot?.()).toBe(access.getSnapshot())
+
+    store.set('/user/name', 'Bob')
+    store.set('/user/name', 'Bob')
+    store.update({
+      '/user/labels/1': 'two',
+      '/user/escaped/a~1b': 'changed',
+    })
+
+    expect(access.getSnapshot()).toEqual({
+      user: {
+        name: 'Bob',
+        labels: ['one', 'two'],
+        escaped: {
+          'a/b': 'changed',
+          'tilde~key': 'tilde',
+        },
+      },
+    })
+    expect(calls).toHaveLength(2)
+
+    unsubscribe()
+    store.set('/user/name', 'Cara')
+    expect(calls).toHaveLength(2)
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it('adapts a selected nested slice with an explicit updater', async () => {
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const access = await app.resolve(ctx)
+    const store = scopedValueStateStore({
+      value: access,
+      selector: (state) => state.ui,
+      updater: (next, value) => value.set({ ...value.getSnapshot(), ui: next as AppState['ui'] }),
+    })
+
+    expect(store.get('/count')).toBe(1)
+    store.set('/count', 2)
+
+    expect(access.getSnapshot()).toEqual({
+      ui: {
+        count: 2,
+      },
+      auth: {
+        token: 'secret',
+      },
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+})

--- a/packages/lite-react-json-render/tests/index.test.ts
+++ b/packages/lite-react-json-render/tests/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { createScope, flow, tag, typed } from '@pumped-fn/lite'
 import { scopedValue } from '@pumped-fn/lite-react'
 import type { StateStore } from '@json-render/core'
-import { flowAction, flowActionHandlers, scopedValueStateStore } from '../src'
+import { flowAction, flowHandlers, scopedValueStateStore } from '../src'
 
 interface FormState {
   user: {
@@ -121,7 +121,7 @@ describe('scopedValueStateStore', () => {
   })
 })
 
-describe('flowActionHandlers', () => {
+describe('flowHandlers', () => {
   it('runs a flow with json-render params as raw input', async () => {
     const submit = flow({
       name: 'submit-json-render-order',
@@ -138,7 +138,7 @@ describe('flowActionHandlers', () => {
     })
     const scope = createScope()
     const ctx = scope.createContext()
-    const handlers = flowActionHandlers({ ctx, actions: { submit } })
+    const handlers = flowHandlers({ ctx, actions: { submit } })
 
     await expect(handlers.submit({ item: 'Coffee', quantity: 2 })).resolves.toBe('2x Coffee')
     await expect(handlers.submit({ item: 'Coffee', quantity: '2' })).rejects.toThrow(
@@ -161,7 +161,7 @@ describe('flowActionHandlers', () => {
     })
     const scope = createScope()
     const ctx = scope.createContext()
-    const handlers = flowActionHandlers({
+    const handlers = flowHandlers({
       ctx,
       actions: {
         record: flowAction({
@@ -195,7 +195,7 @@ describe('flowActionHandlers', () => {
     })
     const scope = createScope()
     const ctx = scope.createContext()
-    const handlers = flowActionHandlers({ ctx, actions: { fail } })
+    const handlers = flowHandlers({ ctx, actions: { fail } })
 
     await expect(handlers.fail({ message: 'rejected by Lite' })).rejects.toThrow('rejected by Lite')
 

--- a/packages/lite-react-json-render/tsconfig.json
+++ b/packages/lite-react-json-render/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/lite-react-json-render/tsconfig.test.json
+++ b/packages/lite-react-json-render/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["node", "vitest"]
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/lite-react-json-render/tsdown.config.ts
+++ b/packages/lite-react-json-render/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  format: ["cjs", "esm"],
+  clean: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -515,6 +515,12 @@ importers:
       '@pumped-fn/lite-react':
         specifier: workspace:*
         version: link:../lite-react
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
       tsdown:
         specifier: 'catalog:'
         version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,12 @@ catalogs:
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
+    '@json-render/core':
+      specifier: 0.19.0
+      version: 0.19.0
+    '@json-render/react':
+      specifier: 0.19.0
+      version: 0.19.0
     '@opentelemetry/api':
       specifier: 1.9.1
       version: 1.9.1
@@ -87,6 +93,9 @@ catalogs:
     vitest:
       specifier: 4.1.7
       version: 4.1.7
+    zod:
+      specifier: 4.3.6
+      version: 4.3.6
 
 overrides:
   esbuild: 0.27.7
@@ -201,12 +210,24 @@ importers:
 
   examples/lite-react-practical:
     dependencies:
+      '@json-render/core':
+        specifier: 'catalog:'
+        version: 0.19.0(zod@4.3.6)
+      '@json-render/react':
+        specifier: 'catalog:'
+        version: 0.19.0(react@19.2.6)(zod@4.3.6)
       '@pumped-fn/lite':
         specifier: workspace:*
         version: link:../../packages/lite
       '@pumped-fn/lite-react':
         specifier: workspace:*
         version: link:../../packages/lite-react
+      '@pumped-fn/lite-react-json-render':
+        specifier: workspace:*
+        version: link:../../packages/lite-react-json-render
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@testing-library/jest-dom':
         specifier: 'catalog:'
@@ -478,6 +499,31 @@ importers:
       tsdown:
         specifier: 'catalog:'
         version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
+
+  packages/lite-react-json-render:
+    dependencies:
+      '@json-render/core':
+        specifier: 'catalog:'
+        version: 0.19.0(zod@4.3.6)
+    devDependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../lite
+      '@pumped-fn/lite-react':
+        specifier: workspace:*
+        version: link:../lite-react
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.27.7)(tsx@4.22.3))
@@ -1064,6 +1110,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@json-render/core@0.19.0':
+    resolution: {integrity: sha512-vvcyZ+10EDZKbEyB1J2kXOGfDaiZR2LurZGSqi2r5STHyKr+Te85DWaBxTwRGgM7U1LtIvNx85BzzjElRKoAIg==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@json-render/react@0.19.0':
+    resolution: {integrity: sha512-kTW6b6cSNRrlEfCUf/69SLoLn+CufC968ruge9tnQlp9pDTGG/SK8pgM541FdgwMFA4zm3s5mpM3G8rdODKc/A==}
+    peerDependencies:
+      react: ^19.2.3
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -2555,6 +2611,9 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
@@ -3174,6 +3233,15 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@json-render/core@0.19.0(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
+
+  '@json-render/react@0.19.0(react@19.2.6)(zod@4.3.6)':
+    dependencies:
+      '@json-render/core': 0.19.0(zod@4.3.6)
+      react: 19.2.6
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -4504,5 +4572,7 @@ snapshots:
     optional: true
 
   yallist@3.1.1: {}
+
+  zod@4.3.6: {}
 
 time: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,6 +53,8 @@ peerDependencyRules:
 catalog:
   "@changesets/changelog-github": 0.7.0
   "@changesets/cli": 2.31.0
+  "@json-render/core": 0.19.0
+  "@json-render/react": 0.19.0
   "@opentelemetry/api": 1.9.1
   "@opentelemetry/exporter-trace-otlp-http": 0.218.0
   "@opentelemetry/resources": 2.7.1
@@ -78,6 +80,7 @@ catalog:
   typescript: 6.0.3
   vite: 8.0.14
   vitest: 4.1.7
+  zod: 4.3.6
 
 minimumReleaseAgeExclude:
   - '@babel/helpers@7.29.7'


### PR DESCRIPTION
## Summary

Adds a dedicated `@pumped-fn/lite-react-json-render` package so json-render can use Lite React without moving this integration into `@pumped-fn/lite-react`.

The package now covers both directions needed by the integration:

- json-render reads/writes Lite-owned `scopedValue` state through json-render's normal `StateStore` contract.
- json-render `on.*` actions can execute Lite flows through `flowHandlers`, `flowAction`, and `useFlowHandlers`.

This keeps json-render rendering, validation, computed values, functions, and directives native to `JSONUIProvider`, while Lite owns the app behavior that naturally belongs in flows/resources/scopes.

## Changes

- Add `scopedValueStateStore` backed by `@json-render/core/store-utils`.
- Add flow-backed json-render action handlers for pure and React usage.
- Make the React action hook use stable proxy handlers so json-render's provider can keep one mounted handler object while the latest Lite scope/action targets are still used.
- Keep names succinct against local precedent: `flowHandlers` / `useFlowHandlers` match the `handlers` prop, while `scopedValueStateStore` mirrors `@json-render/zustand`'s `zustandStateStore` adapter naming.
- Add package README, package metadata, Changesets entry, and package-local tests.
- Extend the F14 practical example to demonstrate `$bindState` state writes plus an `on.press` action executing a Lite flow.
- Update root/practical docs to describe the dedicated package boundary and when to use it.

## Integration Boundary

Use this package when json-render owns the schema/rendering surface and Lite needs to provide state or behavior at the app boundary. Keep json-render-native surfaces native: validation functions, computed functions, directives, navigation, and handler registration still belong on `JSONUIProvider`.

The Lite bridge is intentionally narrow: state via `scopedValueStateStore`, behavior via `ctx.exec` action handlers, and testability through the usual `createScope({ presets, tags, extensions })` seam.

## No Single LLM Truth

Two independent review passes checked the integration shape. Both found the same must-fix: json-render's action provider snapshots handler maps, so a React hook that recreates handlers can go stale. This PR fixes that with stable proxy handlers and adds OI3 coverage proving a mounted `JSONUIProvider` dispatches to the latest Lite execution boundary after rerender.

A follow-up naming pass compared this adapter to `@json-render/zustand` and nearby Lite React examples, then shortened the handler API without renaming the package or over-churning example paths.

## Testing

- `pnpm install --frozen-lockfile --offline`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test`
- `pnpm -F @pumped-fn/lite-react-json-render typecheck`
- `pnpm -F @pumped-fn/lite-react-json-render test`
- `pnpm -F @pumped-fn/lite-react-json-render build`
- `pnpm -F @pumped-fn/lite-react-practical exec vitest run patterns/F14-json-render-state-store/after.test.ts patterns/F14-json-render-state-store/view.browser.test.tsx`
- `pnpm -F @pumped-fn/lite-react-json-render exec npm pack --dry-run --json`
- `pnpm changeset status --verbose`
