### PR TITLE
Add Hono and TanStack Start adapters

### DIFF
--- a/.changeset/tidy-frameworks-carry.md
+++ b/.changeset/tidy-frameworks-carry.md
@@ -1,0 +1,6 @@
+---
+"@pumped-fn/lite-hono": minor
+"@pumped-fn/lite-tanstack-start": minor
+---
+
+Add first-class framework-lane adapters for Hono and TanStack Start with request-scoped Lite execution contexts, namespace-scoped public handles, extension-bound integration methods, docs, runtime tests, type-contract checks, and stress integration guardrails.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Current source packages live under one-word lanes in `pkg/`.
 | `pkg/core/lite` | `@pumped-fn/lite` | Core runtime: scopes, atoms, flows, resources, tags, presets, controllers, extensions |
 | `pkg/react/lite-react` | `@pumped-fn/lite-react` | React integration: providers, Suspense/ErrorBoundary-aware observers, scoped frontend state |
 | `pkg/react/json` | `@pumped-fn/lite-react-json-render` | json-render state and action adapters for Lite React scoped values and flows |
+| `pkg/framework/hono` | `@pumped-fn/lite-hono` | Hono middleware and request helpers for per-request Lite execution contexts |
+| `pkg/framework/tanstack-start` | `@pumped-fn/lite-tanstack-start` | TanStack Start request/function middleware and server-function flow helpers |
 | `pkg/render/core` | `@pumped-fn/lite-render-core` | Platform-neutral strict spec and catalog render contract |
 | `pkg/render/react` | `@pumped-fn/lite-render-react` | React renderer for verified render specs over Lite scopes |
 | `pkg/ext/suspense` | `@pumped-fn/lite-extension-suspense` | Replay and external-resolution extension support |
@@ -336,6 +338,9 @@ pnpm -F @pumped-fn/lite-lint test
 - React runtime: [`pkg/react/lite-react/README.md`](pkg/react/lite-react/README.md)
 - React patterns: [`pkg/react/lite-react/PATTERNS.md`](pkg/react/lite-react/PATTERNS.md)
 - json-render adapter: [`pkg/react/json/README.md`](pkg/react/json/README.md)
+- Framework lane: [`pkg/framework/README.md`](pkg/framework/README.md)
+- Hono adapter: [`pkg/framework/hono/README.md`](pkg/framework/hono/README.md)
+- TanStack Start adapter: [`pkg/framework/tanstack-start/README.md`](pkg/framework/tanstack-start/README.md)
 - Anti-pattern scanner: [`pkg/tool/lint/README.md`](pkg/tool/lint/README.md)
 
 ## License

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,8 @@ surfaces for documented patterns, not publishing targets.
 | `lite-practical/` | `@pumped-fn/lite-practical` | Backend and framework-neutral Lite patterns. |
 | `lite-react-practical/` | `@pumped-fn/lite-react-practical` | React patterns, capstones, and browser checks. |
 | `lite-bff-practical/` | `@pumped-fn/lite-bff-practical` | BFF-style composition examples. |
+| `lite-hono-todo-practical/` | `@pumped-fn/lite-hono-todo-practical` | Hono backend integration for a todo API. |
+| `lite-tanstack-start-todo-practical/` | `@pumped-fn/lite-tanstack-start-todo-practical` | TanStack Start fullstack integration for todos. |
 | `agent-practical/` | `@pumped-fn/agent-practical` | Agent workflow examples. |
 
 ## Naming

--- a/examples/lite-hono-todo-practical/README.md
+++ b/examples/lite-hono-todo-practical/README.md
@@ -1,0 +1,24 @@
+# Hono Todo Backend Practical
+
+This example is a small HTTP todo backend using `@pumped-fn/lite-hono`.
+
+The domain module owns todos, validation, and flows. The Hono module only creates the request context, supplies request tags, and executes public flows through `context.var.lite`.
+
+## Shape
+
+- `src/domain.ts` defines tags, the store atom, and todo flows.
+- `src/app.ts` wires `hono.adapter()` into Hono middleware.
+- `tests/domain.test.ts` exercises the domain through `createScope`.
+- `tests/http.test.ts` exercises the same flows through real Hono requests.
+- `tests/guardrails.test.ts` checks the example for implicit external reads and scope helper drift.
+
+Framework values enter the graph only as required deps:
+
+```ts
+deps: {
+  requestId: tags.required(requestId),
+  tenantId: tags.required(tenantId),
+  actorId: tags.required(actorId),
+  operation: tags.required(operation),
+}
+```

--- a/examples/lite-hono-todo-practical/README.md
+++ b/examples/lite-hono-todo-practical/README.md
@@ -2,12 +2,12 @@
 
 This example is a small HTTP todo backend using `@pumped-fn/lite-hono`.
 
-The domain module owns todos, validation, and flows. The Hono module only creates the request context, supplies request tags, and executes public flows through `context.var.lite`.
+The domain module owns todos, validation, and flows. The Hono app stays shaped like a Hono app: it exports `app`, installs middleware with `app.use`, and executes public flows from route handlers through `context.var.lite`.
 
 ## Shape
 
 - `src/domain.ts` defines tags, the store atom, and todo flows.
-- `src/app.ts` wires `hono.adapter()` into Hono middleware.
+- `src/app.ts` exports the Hono app and wires `hono.adapter()` through normal Hono middleware.
 - `tests/domain.test.ts` exercises the domain through `createScope`.
 - `tests/http.test.ts` exercises the same flows through real Hono requests.
 - `tests/guardrails.test.ts` checks the example for implicit external reads and scope helper drift.

--- a/examples/lite-hono-todo-practical/package.json
+++ b/examples/lite-hono-todo-practical/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pumped-fn/lite-hono-todo-practical",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-hono": "workspace:*",
+    "hono": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/lite-hono-todo-practical/package.json
+++ b/examples/lite-hono-todo-practical/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@pumped-fn/lite": "workspace:*",
     "@pumped-fn/lite-hono": "workspace:*",
-    "hono": "catalog:"
+    "hono": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/examples/lite-hono-todo-practical/src/app.ts
+++ b/examples/lite-hono-todo-practical/src/app.ts
@@ -1,0 +1,84 @@
+import { createScope, type Lite } from "@pumped-fn/lite"
+import { hono } from "@pumped-fn/lite-hono"
+import { Hono } from "hono"
+import {
+  actorId,
+  clearCompleted,
+  createTodo,
+  listTodos,
+  operation,
+  requestId,
+  tenantId,
+  TodoNotFound,
+  TodoValidationError,
+  toggleTodo,
+  type CreateTodoInput,
+} from "./domain"
+
+export interface TodoBackend {
+  app: Hono<hono.Env>
+  scope: Lite.Scope
+  dispose(): Promise<void>
+}
+
+export function createTodoBackend(options: Lite.ScopeOptions = {}): TodoBackend {
+  const lite = hono.adapter()
+  const scope = createScope({
+    ...options,
+    extensions: [...(options.extensions ?? []), lite],
+  })
+  const app = new Hono<hono.Env>()
+
+  app.use(
+    "*",
+    lite.middleware({
+      tags: (request) => [
+        requestId(request.headers.get("x-request-id") ?? "missing"),
+        tenantId(request.headers.get("x-tenant-id") ?? "default"),
+        actorId(request.headers.get("x-actor-id") ?? "anonymous"),
+        operation(`${request.method}:${new URL(request.url).pathname}`),
+      ],
+    })
+  )
+
+  app.get("/todos", async (context) =>
+    context.json(await context.var.lite.exec({ flow: listTodos }))
+  )
+
+  app.post("/todos", async (context) =>
+    context.json(
+      await context.var.lite.exec({
+        flow: createTodo,
+        input: (await context.req.json()) as CreateTodoInput,
+      }),
+      201
+    )
+  )
+
+  app.post("/todos/:id/toggle", async (context) =>
+    context.json(
+      await context.var.lite.exec({
+        flow: toggleTodo,
+        input: { id: context.req.param("id") },
+      })
+    )
+  )
+
+  app.delete("/todos/completed", async (context) =>
+    context.json({
+      deleted: await context.var.lite.exec({ flow: clearCompleted }),
+    })
+  )
+
+  app.onError((error, context) => {
+    if (error instanceof TodoValidationError) return context.json({ error: error.message }, 400)
+    if (error instanceof TodoNotFound) return context.json({ error: error.message }, 404)
+    return context.json({ error: "todo backend failed" }, 500)
+  })
+
+  return {
+    app,
+    scope,
+    dispose: () => scope.dispose(),
+  }
+}

--- a/examples/lite-hono-todo-practical/src/app.ts
+++ b/examples/lite-hono-todo-practical/src/app.ts
@@ -1,4 +1,4 @@
-import { createScope, type Lite } from "@pumped-fn/lite"
+import { createScope } from "@pumped-fn/lite"
 import { hono } from "@pumped-fn/lite-hono"
 import { Hono } from "hono"
 import {
@@ -15,70 +15,59 @@ import {
   type CreateTodoInput,
 } from "./domain"
 
-export interface TodoBackend {
-  app: Hono<hono.Env>
-  scope: Lite.Scope
-  dispose(): Promise<void>
-}
+export const lite = hono.adapter()
 
-export function createTodoBackend(options: Lite.ScopeOptions = {}): TodoBackend {
-  const lite = hono.adapter()
-  const scope = createScope({
-    ...options,
-    extensions: [...(options.extensions ?? []), lite],
+const scope = createScope({
+  extensions: [lite],
+})
+
+export const app = new Hono<hono.Env>()
+
+app.use(
+  "*",
+  lite.middleware({
+    tags: (request) => [
+      requestId(request.headers.get("x-request-id") ?? "missing"),
+      tenantId(request.headers.get("x-tenant-id") ?? "default"),
+      actorId(request.headers.get("x-actor-id") ?? "anonymous"),
+      operation(`${request.method}:${new URL(request.url).pathname}`),
+    ],
   })
-  const app = new Hono<hono.Env>()
+)
 
-  app.use(
-    "*",
-    lite.middleware({
-      tags: (request) => [
-        requestId(request.headers.get("x-request-id") ?? "missing"),
-        tenantId(request.headers.get("x-tenant-id") ?? "default"),
-        actorId(request.headers.get("x-actor-id") ?? "anonymous"),
-        operation(`${request.method}:${new URL(request.url).pathname}`),
-      ],
+app.get("/todos", async (context) => context.json(await context.var.lite.exec({ flow: listTodos })))
+
+app.post("/todos", async (context) =>
+  context.json(
+    await context.var.lite.exec({
+      flow: createTodo,
+      input: (await context.req.json()) as CreateTodoInput,
+    }),
+    201
+  )
+)
+
+app.post("/todos/:id/toggle", async (context) =>
+  context.json(
+    await context.var.lite.exec({
+      flow: toggleTodo,
+      input: { id: context.req.param("id") },
     })
   )
+)
 
-  app.get("/todos", async (context) =>
-    context.json(await context.var.lite.exec({ flow: listTodos }))
-  )
-
-  app.post("/todos", async (context) =>
-    context.json(
-      await context.var.lite.exec({
-        flow: createTodo,
-        input: (await context.req.json()) as CreateTodoInput,
-      }),
-      201
-    )
-  )
-
-  app.post("/todos/:id/toggle", async (context) =>
-    context.json(
-      await context.var.lite.exec({
-        flow: toggleTodo,
-        input: { id: context.req.param("id") },
-      })
-    )
-  )
-
-  app.delete("/todos/completed", async (context) =>
-    context.json({
-      deleted: await context.var.lite.exec({ flow: clearCompleted }),
-    })
-  )
-
-  app.onError((error, context) => {
-    if (error instanceof TodoValidationError) return context.json({ error: error.message }, 400)
-    if (error instanceof TodoNotFound) return context.json({ error: error.message }, 404)
-    return context.json({ error: "todo backend failed" }, 500)
+app.delete("/todos/completed", async (context) =>
+  context.json({
+    deleted: await context.var.lite.exec({ flow: clearCompleted }),
   })
+)
 
-  return {
-    app,
-    scope,
-    dispose: () => scope.dispose(),
-  }
-}
+app.onError((error, context) => {
+  if (error instanceof TodoValidationError) return context.json({ error: error.message }, 400)
+  if (error instanceof TodoNotFound) return context.json({ error: error.message }, 404)
+  return context.json({ error: "todo backend failed" }, 500)
+})
+
+export const dispose = () => scope.dispose()
+
+export default app

--- a/examples/lite-hono-todo-practical/src/app.ts
+++ b/examples/lite-hono-todo-practical/src/app.ts
@@ -1,4 +1,4 @@
-import { createScope } from "@pumped-fn/lite"
+import { createScope, ParseError } from "@pumped-fn/lite"
 import { hono } from "@pumped-fn/lite-hono"
 import { Hono } from "hono"
 import {
@@ -12,7 +12,6 @@ import {
   TodoNotFound,
   TodoValidationError,
   toggleTodo,
-  type CreateTodoInput,
 } from "./domain"
 
 export const lite = hono.adapter()
@@ -41,7 +40,7 @@ app.post("/todos", async (context) =>
   context.json(
     await context.var.lite.exec({
       flow: createTodo,
-      input: (await context.req.json()) as CreateTodoInput,
+      rawInput: await context.req.json(),
     }),
     201
   )
@@ -63,6 +62,9 @@ app.delete("/todos/completed", async (context) =>
 )
 
 app.onError((error, context) => {
+  if (error instanceof ParseError && error.cause instanceof TodoValidationError) {
+    return context.json({ error: error.cause.message }, 400)
+  }
   if (error instanceof TodoValidationError) return context.json({ error: error.message }, 400)
   if (error instanceof TodoNotFound) return context.json({ error: error.message }, 404)
   return context.json({ error: "todo backend failed" }, 500)

--- a/examples/lite-hono-todo-practical/src/app.ts
+++ b/examples/lite-hono-todo-practical/src/app.ts
@@ -1,6 +1,7 @@
 import { createScope, ParseError } from "@pumped-fn/lite"
 import { hono } from "@pumped-fn/lite-hono"
 import { Hono } from "hono"
+import { ZodError } from "zod"
 import {
   actorId,
   clearCompleted,
@@ -10,7 +11,6 @@ import {
   requestId,
   tenantId,
   TodoNotFound,
-  TodoValidationError,
   toggleTodo,
 } from "./domain"
 
@@ -62,13 +62,16 @@ app.delete("/todos/completed", async (context) =>
 )
 
 app.onError((error, context) => {
-  if (error instanceof ParseError && error.cause instanceof TodoValidationError) {
-    return context.json({ error: error.cause.message }, 400)
+  if (error instanceof ParseError && error.cause instanceof ZodError) {
+    return context.json({ error: zodMessage(error.cause) }, 400)
   }
-  if (error instanceof TodoValidationError) return context.json({ error: error.message }, 400)
   if (error instanceof TodoNotFound) return context.json({ error: error.message }, 404)
   return context.json({ error: "todo backend failed" }, 500)
 })
+
+function zodMessage(error: ZodError): string {
+  return error.issues.map((issue) => issue.message).join("; ")
+}
 
 export const dispose = () => scope.dispose()
 

--- a/examples/lite-hono-todo-practical/src/domain.ts
+++ b/examples/lite-hono-todo-practical/src/domain.ts
@@ -1,4 +1,5 @@
-import { atom, flow, tag, tags, typed } from "@pumped-fn/lite"
+import { atom, flow, tag, tags } from "@pumped-fn/lite"
+import { z } from "zod"
 
 export type TodoStatus = "open" | "done"
 
@@ -13,13 +14,17 @@ export interface Todo {
   lastOperation: string
 }
 
-export interface CreateTodoInput {
-  title: string
-}
+const createTodoInput = z.object({
+  title: z.string({ error: "title is required" }).trim().min(1, "title is required"),
+})
 
-export interface ToggleTodoInput {
-  id: string
-}
+const toggleTodoInput = z.object({
+  id: z.string({ error: "id is required" }).min(1, "id is required"),
+})
+
+export type CreateTodoInput = z.infer<typeof createTodoInput>
+
+export type ToggleTodoInput = z.infer<typeof toggleTodoInput>
 
 interface MutationInput {
   tenantId: string
@@ -41,13 +46,6 @@ export interface TodoStore {
   create(input: StoreCreateInput): Promise<Todo>
   toggle(input: StoreToggleInput): Promise<Todo>
   clearCompleted(input: MutationInput): Promise<Todo[]>
-}
-
-export class TodoValidationError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = "TodoValidationError"
-  }
 }
 
 export class TodoNotFound extends Error {
@@ -122,7 +120,7 @@ export const listTodos = flow({
 
 export const createTodo = flow({
   name: "todo.create",
-  parse: parseCreateTodo,
+  parse: (input) => createTodoInput.parse(input),
   deps: {
     store,
     tenantId: tags.required(tenantId),
@@ -142,7 +140,7 @@ export const createTodo = flow({
 
 export const toggleTodo = flow({
   name: "todo.toggle",
-  parse: typed<ToggleTodoInput>(),
+  parse: (input) => toggleTodoInput.parse(input),
   deps: {
     store,
     tenantId: tags.required(tenantId),
@@ -177,19 +175,3 @@ export const clearCompleted = flow({
       operation: deps.operation,
     }),
 })
-
-function parseCreateTodo(input: unknown): CreateTodoInput {
-  if (!isRecord(input)) throw new TodoValidationError("title is required")
-  if (typeof input["title"] !== "string") throw new TodoValidationError("title is required")
-  return { title: normalizeTitle(input["title"]) }
-}
-
-function normalizeTitle(input: string): string {
-  const title = input.trim()
-  if (title.length === 0) throw new TodoValidationError("title is required")
-  return title
-}
-
-function isRecord(input: unknown): input is Record<string, unknown> {
-  return typeof input === "object" && input !== null
-}

--- a/examples/lite-hono-todo-practical/src/domain.ts
+++ b/examples/lite-hono-todo-practical/src/domain.ts
@@ -1,0 +1,185 @@
+import { atom, flow, tag, tags, typed } from "@pumped-fn/lite"
+
+export type TodoStatus = "open" | "done"
+
+export interface Todo {
+  id: string
+  tenantId: string
+  title: string
+  status: TodoStatus
+  createdBy: string
+  updatedBy: string
+  lastRequestId: string
+  lastOperation: string
+}
+
+export interface CreateTodoInput {
+  title: string
+}
+
+export interface ToggleTodoInput {
+  id: string
+}
+
+interface MutationInput {
+  tenantId: string
+  actorId: string
+  requestId: string
+  operation: string
+}
+
+interface StoreCreateInput extends MutationInput {
+  title: string
+}
+
+interface StoreToggleInput extends MutationInput {
+  id: string
+}
+
+export interface TodoStore {
+  list(tenantId: string): Promise<Todo[]>
+  create(input: StoreCreateInput): Promise<Todo>
+  toggle(input: StoreToggleInput): Promise<Todo>
+  clearCompleted(input: MutationInput): Promise<Todo[]>
+}
+
+export class TodoValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "TodoValidationError"
+  }
+}
+
+export class TodoNotFound extends Error {
+  constructor(id: string) {
+    super(`todo not found: ${id}`)
+    this.name = "TodoNotFound"
+  }
+}
+
+export const requestId = tag<string>({ label: "todo.request.id" })
+export const tenantId = tag<string>({ label: "todo.tenant.id" })
+export const actorId = tag<string>({ label: "todo.actor.id" })
+export const operation = tag<string>({ label: "todo.operation" })
+
+export function createMemoryStore(): TodoStore {
+  let next = 1
+  const rows = new Map<string, Todo>()
+
+  return {
+    async list(tenantId) {
+      return [...rows.values()].filter((todo) => todo.tenantId === tenantId)
+    },
+    async create(input) {
+      const todo: Todo = {
+        id: `todo-${next++}`,
+        tenantId: input.tenantId,
+        title: input.title,
+        status: "open",
+        createdBy: input.actorId,
+        updatedBy: input.actorId,
+        lastRequestId: input.requestId,
+        lastOperation: input.operation,
+      }
+      rows.set(todo.id, todo)
+      return todo
+    },
+    async toggle(input) {
+      const existing = rows.get(input.id)
+      if (!existing || existing.tenantId !== input.tenantId) throw new TodoNotFound(input.id)
+      const todo: Todo = {
+        ...existing,
+        status: existing.status === "open" ? "done" : "open",
+        updatedBy: input.actorId,
+        lastRequestId: input.requestId,
+        lastOperation: input.operation,
+      }
+      rows.set(todo.id, todo)
+      return todo
+    },
+    async clearCompleted(input) {
+      const removed = [...rows.values()].filter(
+        (todo) => todo.tenantId === input.tenantId && todo.status === "done"
+      )
+      for (const todo of removed) rows.delete(todo.id)
+      return removed
+    },
+  }
+}
+
+export const store = atom({
+  factory: () => createMemoryStore(),
+})
+
+export const listTodos = flow({
+  name: "todo.list",
+  deps: {
+    store,
+    tenantId: tags.required(tenantId),
+  },
+  factory: (_ctx, deps) => deps.store.list(deps.tenantId),
+})
+
+export const createTodo = flow({
+  name: "todo.create",
+  parse: typed<CreateTodoInput>(),
+  deps: {
+    store,
+    tenantId: tags.required(tenantId),
+    actorId: tags.required(actorId),
+    requestId: tags.required(requestId),
+    operation: tags.required(operation),
+  },
+  factory: (ctx, deps) =>
+    deps.store.create({
+      tenantId: deps.tenantId,
+      actorId: deps.actorId,
+      requestId: deps.requestId,
+      operation: deps.operation,
+      title: normalizeTitle(ctx.input.title),
+    }),
+})
+
+export const toggleTodo = flow({
+  name: "todo.toggle",
+  parse: typed<ToggleTodoInput>(),
+  deps: {
+    store,
+    tenantId: tags.required(tenantId),
+    actorId: tags.required(actorId),
+    requestId: tags.required(requestId),
+    operation: tags.required(operation),
+  },
+  factory: (ctx, deps) =>
+    deps.store.toggle({
+      id: ctx.input.id,
+      tenantId: deps.tenantId,
+      actorId: deps.actorId,
+      requestId: deps.requestId,
+      operation: deps.operation,
+    }),
+})
+
+export const clearCompleted = flow({
+  name: "todo.clearCompleted",
+  deps: {
+    store,
+    tenantId: tags.required(tenantId),
+    actorId: tags.required(actorId),
+    requestId: tags.required(requestId),
+    operation: tags.required(operation),
+  },
+  factory: (_ctx, deps) =>
+    deps.store.clearCompleted({
+      tenantId: deps.tenantId,
+      actorId: deps.actorId,
+      requestId: deps.requestId,
+      operation: deps.operation,
+    }),
+})
+
+function normalizeTitle(input: string): string {
+  const title = input.trim()
+  if (title.length === 0) throw new TodoValidationError("title is required")
+  return title
+}

--- a/examples/lite-hono-todo-practical/src/domain.ts
+++ b/examples/lite-hono-todo-practical/src/domain.ts
@@ -178,7 +178,8 @@ export const clearCompleted = flow({
     }),
 })
 
-function normalizeTitle(input: string): string {
+function normalizeTitle(input: unknown): string {
+  if (typeof input !== "string") throw new TodoValidationError("title is required")
   const title = input.trim()
   if (title.length === 0) throw new TodoValidationError("title is required")
   return title

--- a/examples/lite-hono-todo-practical/src/domain.ts
+++ b/examples/lite-hono-todo-practical/src/domain.ts
@@ -122,7 +122,7 @@ export const listTodos = flow({
 
 export const createTodo = flow({
   name: "todo.create",
-  parse: typed<CreateTodoInput>(),
+  parse: parseCreateTodo,
   deps: {
     store,
     tenantId: tags.required(tenantId),
@@ -136,7 +136,7 @@ export const createTodo = flow({
       actorId: deps.actorId,
       requestId: deps.requestId,
       operation: deps.operation,
-      title: normalizeTitle(ctx.input.title),
+      title: ctx.input.title,
     }),
 })
 
@@ -178,9 +178,18 @@ export const clearCompleted = flow({
     }),
 })
 
-function normalizeTitle(input: unknown): string {
-  if (typeof input !== "string") throw new TodoValidationError("title is required")
+function parseCreateTodo(input: unknown): CreateTodoInput {
+  if (!isRecord(input)) throw new TodoValidationError("title is required")
+  if (typeof input["title"] !== "string") throw new TodoValidationError("title is required")
+  return { title: normalizeTitle(input["title"]) }
+}
+
+function normalizeTitle(input: string): string {
   const title = input.trim()
   if (title.length === 0) throw new TodoValidationError("title is required")
   return title
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null
 }

--- a/examples/lite-hono-todo-practical/tests/domain.test.ts
+++ b/examples/lite-hono-todo-practical/tests/domain.test.ts
@@ -1,4 +1,4 @@
-import { createScope, preset } from "@pumped-fn/lite"
+import { createScope, ParseError, preset } from "@pumped-fn/lite"
 import { describe, expect, it } from "vitest"
 import {
   actorId,
@@ -80,9 +80,9 @@ describe("todo domain", () => {
       input: { title: "Keep tenant local" },
     })
 
-    await expect(context.exec({ flow: createTodo, input: { title: "  " } })).rejects.toBeInstanceOf(
-      TodoValidationError
-    )
+    const invalidTitle = context.exec({ flow: createTodo, input: { title: "  " } })
+    await expect(invalidTitle).rejects.toBeInstanceOf(ParseError)
+    await expect(invalidTitle).rejects.toMatchObject({ cause: expect.any(TodoValidationError) })
     await expect(
       context.exec({
         flow: toggleTodo,

--- a/examples/lite-hono-todo-practical/tests/domain.test.ts
+++ b/examples/lite-hono-todo-practical/tests/domain.test.ts
@@ -1,0 +1,96 @@
+import { createScope, preset } from "@pumped-fn/lite"
+import { describe, expect, it } from "vitest"
+import {
+  actorId,
+  clearCompleted,
+  createMemoryStore,
+  createTodo,
+  listTodos,
+  operation,
+  requestId,
+  store,
+  tenantId,
+  TodoNotFound,
+  TodoValidationError,
+  toggleTodo,
+} from "../src/domain"
+
+describe("todo domain", () => {
+  it("runs the same flows with explicit presets and tags", async () => {
+    const scope = createScope({
+      presets: [preset(store, createMemoryStore())],
+      tags: [
+        tenantId("tenant-a"),
+        actorId("actor-a"),
+        requestId("request-a"),
+        operation("test:create"),
+      ],
+    })
+    const context = scope.createContext()
+
+    const created = await context.exec({
+      flow: createTodo,
+      input: { title: "  Write adapter example  " },
+    })
+    const toggled = await context.exec({
+      flow: toggleTodo,
+      input: { id: created.id },
+      tags: [requestId("request-b"), operation("test:toggle")],
+    })
+    const listed = await context.exec({ flow: listTodos })
+    const deleted = await context.exec({
+      flow: clearCompleted,
+      tags: [requestId("request-c"), operation("test:clear")],
+    })
+
+    expect(created).toMatchObject({
+      tenantId: "tenant-a",
+      title: "Write adapter example",
+      status: "open",
+      createdBy: "actor-a",
+      lastRequestId: "request-a",
+      lastOperation: "test:create",
+    })
+    expect(toggled).toMatchObject({
+      id: created.id,
+      status: "done",
+      lastRequestId: "request-b",
+      lastOperation: "test:toggle",
+    })
+    expect(listed).toEqual([toggled])
+    expect(deleted).toEqual([toggled])
+    expect(await context.exec({ flow: listTodos })).toEqual([])
+    await context.close({ ok: true })
+    await scope.dispose()
+  })
+
+  it("rejects empty titles and tenant-mismatched ids at the scope seam", async () => {
+    const scope = createScope({
+      presets: [preset(store, createMemoryStore())],
+      tags: [
+        tenantId("tenant-a"),
+        actorId("actor-a"),
+        requestId("request-a"),
+        operation("test:create"),
+      ],
+    })
+    const context = scope.createContext()
+    const created = await context.exec({
+      flow: createTodo,
+      input: { title: "Keep tenant local" },
+    })
+
+    await expect(context.exec({ flow: createTodo, input: { title: "  " } })).rejects.toBeInstanceOf(
+      TodoValidationError
+    )
+    await expect(
+      context.exec({
+        flow: toggleTodo,
+        input: { id: created.id },
+        tags: [tenantId("tenant-b"), requestId("request-b"), operation("test:toggle")],
+      })
+    ).rejects.toBeInstanceOf(TodoNotFound)
+    await context.close({ ok: true })
+    await scope.dispose()
+  })
+})

--- a/examples/lite-hono-todo-practical/tests/domain.test.ts
+++ b/examples/lite-hono-todo-practical/tests/domain.test.ts
@@ -1,5 +1,6 @@
 import { createScope, ParseError, preset } from "@pumped-fn/lite"
 import { describe, expect, it } from "vitest"
+import { ZodError } from "zod"
 import {
   actorId,
   clearCompleted,
@@ -11,7 +12,6 @@ import {
   store,
   tenantId,
   TodoNotFound,
-  TodoValidationError,
   toggleTodo,
 } from "../src/domain"
 
@@ -82,7 +82,7 @@ describe("todo domain", () => {
 
     const invalidTitle = context.exec({ flow: createTodo, input: { title: "  " } })
     await expect(invalidTitle).rejects.toBeInstanceOf(ParseError)
-    await expect(invalidTitle).rejects.toMatchObject({ cause: expect.any(TodoValidationError) })
+    await expect(invalidTitle).rejects.toMatchObject({ cause: expect.any(ZodError) })
     await expect(
       context.exec({
         flow: toggleTodo,

--- a/examples/lite-hono-todo-practical/tests/guardrails.test.ts
+++ b/examples/lite-hono-todo-practical/tests/guardrails.test.ts
@@ -13,8 +13,9 @@ describe("example guardrails", () => {
       "tests/http.test.ts",
     ].map((path) => [path, readFileSync(resolve(root, path), "utf8")] as const)
     const forbidden = [
+      ["exported scope", /\bexport\s+const\s+scope\b/],
       ["scope parameter helper", /\b(?:middleware|get|exec|handler)\s*\(\s*scope\b/],
-      ["context parameter helper", /\b(?:get|exec)\s*\(\s*context\b/],
+      ["context parameter helper", /\b(?:get|exec|tags)\s*\(\s*(?:parent|context)\b/],
       ["ambient tag read", new RegExp(`\\.data\\.${["seek", "Tag"].join("")}\\s*\\(`)],
       ["ambient data read", /\.data\.(?:get|seek)\s*\(/],
     ] as const

--- a/examples/lite-hono-todo-practical/tests/guardrails.test.ts
+++ b/examples/lite-hono-todo-practical/tests/guardrails.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+describe("example guardrails", () => {
+  it("keeps framework values explicit through deps and composition roots", () => {
+    const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+    const files = [
+      "src/app.ts",
+      "src/domain.ts",
+      "tests/domain.test.ts",
+      "tests/http.test.ts",
+    ].map((path) => [path, readFileSync(resolve(root, path), "utf8")] as const)
+    const forbidden = [
+      ["scope parameter helper", /\b(?:middleware|get|exec|handler)\s*\(\s*scope\b/],
+      ["context parameter helper", /\b(?:get|exec)\s*\(\s*context\b/],
+      ["ambient tag read", new RegExp(`\\.data\\.${["seek", "Tag"].join("")}\\s*\\(`)],
+      ["ambient data read", /\.data\.(?:get|seek)\s*\(/],
+    ] as const
+
+    for (const [path, source] of files) {
+      for (const [name, pattern] of forbidden) {
+        expect(source, `${path} contains ${name}`).not.toMatch(pattern)
+      }
+    }
+  })
+})

--- a/examples/lite-hono-todo-practical/tests/http.test.ts
+++ b/examples/lite-hono-todo-practical/tests/http.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest"
+import { createTodoBackend } from "../src/app"
+import type { Todo } from "../src/domain"
+
+describe("hono todo backend", () => {
+  it("serves tenant-scoped todos through real Hono requests", async () => {
+    const backend = createTodoBackend()
+    const first = await backend.app.request("/todos", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "req-a",
+        "x-tenant-id": "tenant-a",
+        "x-actor-id": "actor-a",
+      },
+      body: JSON.stringify({ title: " Ship backend example " }),
+    })
+    const second = await backend.app.request("/todos", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "req-b",
+        "x-tenant-id": "tenant-b",
+        "x-actor-id": "actor-b",
+      },
+      body: JSON.stringify({ title: "Keep separate" }),
+    })
+    const created = (await first.json()) as Todo
+    const other = (await second.json()) as Todo
+    const toggledResponse = await backend.app.request(`/todos/${created.id}/toggle`, {
+      method: "POST",
+      headers: {
+        "x-request-id": "req-c",
+        "x-tenant-id": "tenant-a",
+        "x-actor-id": "actor-c",
+      },
+    })
+    const tenantA = await backend.app.request("/todos", {
+      headers: { "x-tenant-id": "tenant-a" },
+    })
+    const tenantB = await backend.app.request("/todos", {
+      headers: { "x-tenant-id": "tenant-b" },
+    })
+    const deleted = await backend.app.request("/todos/completed", {
+      method: "DELETE",
+      headers: {
+        "x-request-id": "req-d",
+        "x-tenant-id": "tenant-a",
+        "x-actor-id": "actor-d",
+      },
+    })
+    const tenantAAfterDelete = await backend.app.request("/todos", {
+      headers: { "x-tenant-id": "tenant-a" },
+    })
+
+    expect(first.status).toBe(201)
+    expect(second.status).toBe(201)
+    expect(created).toMatchObject({
+      tenantId: "tenant-a",
+      title: "Ship backend example",
+      status: "open",
+      createdBy: "actor-a",
+      lastRequestId: "req-a",
+      lastOperation: "POST:/todos",
+    })
+    expect(other).toMatchObject({
+      tenantId: "tenant-b",
+      title: "Keep separate",
+    })
+    expect(await toggledResponse.json()).toMatchObject({
+      id: created.id,
+      status: "done",
+      updatedBy: "actor-c",
+      lastRequestId: "req-c",
+      lastOperation: `POST:/todos/${created.id}/toggle`,
+    })
+    expect(await tenantA.json()).toEqual([
+      {
+        ...created,
+        status: "done",
+        updatedBy: "actor-c",
+        lastRequestId: "req-c",
+        lastOperation: `POST:/todos/${created.id}/toggle`,
+      },
+    ])
+    expect(await tenantB.json()).toEqual([other])
+    expect(await deleted.json()).toEqual({
+      deleted: [
+        {
+          ...created,
+          status: "done",
+          updatedBy: "actor-c",
+          lastRequestId: "req-c",
+          lastOperation: `POST:/todos/${created.id}/toggle`,
+        },
+      ],
+    })
+    expect(await tenantAAfterDelete.json()).toEqual([])
+    await backend.dispose()
+  })
+
+  it("maps domain errors without route-level scope access", async () => {
+    const backend = createTodoBackend()
+    const invalid = await backend.app.request("/todos", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "req-a",
+        "x-tenant-id": "tenant-a",
+        "x-actor-id": "actor-a",
+      },
+      body: JSON.stringify({ title: " " }),
+    })
+    const missing = await backend.app.request("/todos/todo-missing/toggle", {
+      method: "POST",
+      headers: {
+        "x-request-id": "req-b",
+        "x-tenant-id": "tenant-a",
+        "x-actor-id": "actor-a",
+      },
+    })
+
+    expect(invalid.status).toBe(400)
+    expect(await invalid.json()).toEqual({ error: "title is required" })
+    expect(missing.status).toBe(404)
+    expect(await missing.json()).toEqual({ error: "todo not found: todo-missing" })
+    await backend.dispose()
+  })
+})

--- a/examples/lite-hono-todo-practical/tests/http.test.ts
+++ b/examples/lite-hono-todo-practical/tests/http.test.ts
@@ -1,11 +1,14 @@
-import { describe, expect, it } from "vitest"
-import { createTodoBackend } from "../src/app"
+import { afterAll, describe, expect, it } from "vitest"
+import { app, dispose } from "../src/app"
 import type { Todo } from "../src/domain"
 
 describe("hono todo backend", () => {
+  afterAll(async () => {
+    await dispose()
+  })
+
   it("serves tenant-scoped todos through real Hono requests", async () => {
-    const backend = createTodoBackend()
-    const first = await backend.app.request("/todos", {
+    const first = await app.request("/todos", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -15,7 +18,7 @@ describe("hono todo backend", () => {
       },
       body: JSON.stringify({ title: " Ship backend example " }),
     })
-    const second = await backend.app.request("/todos", {
+    const second = await app.request("/todos", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -27,7 +30,7 @@ describe("hono todo backend", () => {
     })
     const created = (await first.json()) as Todo
     const other = (await second.json()) as Todo
-    const toggledResponse = await backend.app.request(`/todos/${created.id}/toggle`, {
+    const toggledResponse = await app.request(`/todos/${created.id}/toggle`, {
       method: "POST",
       headers: {
         "x-request-id": "req-c",
@@ -35,13 +38,13 @@ describe("hono todo backend", () => {
         "x-actor-id": "actor-c",
       },
     })
-    const tenantA = await backend.app.request("/todos", {
+    const tenantA = await app.request("/todos", {
       headers: { "x-tenant-id": "tenant-a" },
     })
-    const tenantB = await backend.app.request("/todos", {
+    const tenantB = await app.request("/todos", {
       headers: { "x-tenant-id": "tenant-b" },
     })
-    const deleted = await backend.app.request("/todos/completed", {
+    const deleted = await app.request("/todos/completed", {
       method: "DELETE",
       headers: {
         "x-request-id": "req-d",
@@ -49,7 +52,7 @@ describe("hono todo backend", () => {
         "x-actor-id": "actor-d",
       },
     })
-    const tenantAAfterDelete = await backend.app.request("/todos", {
+    const tenantAAfterDelete = await app.request("/todos", {
       headers: { "x-tenant-id": "tenant-a" },
     })
 
@@ -96,26 +99,24 @@ describe("hono todo backend", () => {
       ],
     })
     expect(await tenantAAfterDelete.json()).toEqual([])
-    await backend.dispose()
   })
 
   it("maps domain errors without route-level scope access", async () => {
-    const backend = createTodoBackend()
-    const invalid = await backend.app.request("/todos", {
+    const invalid = await app.request("/todos", {
       method: "POST",
       headers: {
         "content-type": "application/json",
         "x-request-id": "req-a",
-        "x-tenant-id": "tenant-a",
+        "x-tenant-id": "tenant-error",
         "x-actor-id": "actor-a",
       },
       body: JSON.stringify({ title: " " }),
     })
-    const missing = await backend.app.request("/todos/todo-missing/toggle", {
+    const missing = await app.request("/todos/todo-missing/toggle", {
       method: "POST",
       headers: {
         "x-request-id": "req-b",
-        "x-tenant-id": "tenant-a",
+        "x-tenant-id": "tenant-error",
         "x-actor-id": "actor-a",
       },
     })
@@ -124,6 +125,5 @@ describe("hono todo backend", () => {
     expect(await invalid.json()).toEqual({ error: "title is required" })
     expect(missing.status).toBe(404)
     expect(await missing.json()).toEqual({ error: "todo not found: todo-missing" })
-    await backend.dispose()
   })
 })

--- a/examples/lite-hono-todo-practical/tests/http.test.ts
+++ b/examples/lite-hono-todo-practical/tests/http.test.ts
@@ -120,10 +120,22 @@ describe("hono todo backend", () => {
         "x-actor-id": "actor-a",
       },
     })
+    const malformed = await app.request("/todos", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "req-c",
+        "x-tenant-id": "tenant-error",
+        "x-actor-id": "actor-a",
+      },
+      body: JSON.stringify({}),
+    })
 
     expect(invalid.status).toBe(400)
     expect(await invalid.json()).toEqual({ error: "title is required" })
     expect(missing.status).toBe(404)
     expect(await missing.json()).toEqual({ error: "todo not found: todo-missing" })
+    expect(malformed.status).toBe(400)
+    expect(await malformed.json()).toEqual({ error: "title is required" })
   })
 })

--- a/examples/lite-hono-todo-practical/tsconfig.json
+++ b/examples/lite-hono-todo-practical/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/lite-hono-todo-practical/vitest.config.ts
+++ b/examples/lite-hono-todo-practical/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+})

--- a/examples/lite-tanstack-start-todo-practical/README.md
+++ b/examples/lite-tanstack-start-todo-practical/README.md
@@ -2,14 +2,15 @@
 
 This example is a small fullstack todo surface using `@pumped-fn/lite-tanstack-start`.
 
-The domain module owns todos and flows. `src/start.ts` is the application composition root: it creates the adapter, the scope, request middleware, and per-server-function call middleware. `src/functions.ts` exposes TanStack Start server functions, and `src/TodoApp.tsx` calls those functions from React.
+The domain module owns todos and flows. `src/start.ts` follows TanStack Start's global configuration shape with `createStart({ requestMiddleware })`. `src/functions.ts` exposes server functions with function-level operation middleware, and `src/routes/index.tsx` is the file route that loads and mutates todos.
 
 ## Shape
 
 - `src/domain.ts` defines tags, store, input types, and todo flows.
-- `src/start.ts` wires `tanstackStart.adapter()` once at the app root.
-- `src/functions.ts` attaches request and function middleware to server functions.
-- `src/TodoApp.tsx` is the client-facing fullstack todo UI.
+- `src/start.ts` wires `tanstackStart.adapter()` once at the app root and exports `startInstance`.
+- `src/functions.ts` attaches function middleware to server functions.
+- `src/routes/__root.tsx` and `src/routes/index.tsx` are normal TanStack Router file routes.
+- `src/routeTree.gen.ts` is the generated route-tree shape kept in this standalone package.
 - `tests/domain.test.ts` exercises the domain through a fresh scope.
 - `tests/server-functions.test.ts` drives the exported Start middleware chain with real `Request` objects.
 - `tests/guardrails.test.ts` checks the example for implicit external reads and scope helper drift.
@@ -17,8 +18,8 @@ The domain module owns todos and flows. `src/start.ts` is the application compos
 The framework integration stays narrow:
 
 ```ts
-export const createTodoFn = createServerFn({ method: "POST" })
-  .middleware([request, createCall])
-  .validator((input: CreateTodoInput) => input)
-  .handler(lite.handler(createTodo))
+export const Route = createFileRoute("/")({
+  loader: () => listTodosFn(),
+  component: TodoRoute,
+})
 ```

--- a/examples/lite-tanstack-start-todo-practical/README.md
+++ b/examples/lite-tanstack-start-todo-practical/README.md
@@ -1,0 +1,24 @@
+# TanStack Start Todo Practical
+
+This example is a small fullstack todo surface using `@pumped-fn/lite-tanstack-start`.
+
+The domain module owns todos and flows. `src/start.ts` is the application composition root: it creates the adapter, the scope, request middleware, and per-server-function call middleware. `src/functions.ts` exposes TanStack Start server functions, and `src/TodoApp.tsx` calls those functions from React.
+
+## Shape
+
+- `src/domain.ts` defines tags, store, input types, and todo flows.
+- `src/start.ts` wires `tanstackStart.adapter()` once at the app root.
+- `src/functions.ts` attaches request and function middleware to server functions.
+- `src/TodoApp.tsx` is the client-facing fullstack todo UI.
+- `tests/domain.test.ts` exercises the domain through a fresh scope.
+- `tests/server-functions.test.ts` drives the exported Start middleware chain with real `Request` objects.
+- `tests/guardrails.test.ts` checks the example for implicit external reads and scope helper drift.
+
+The framework integration stays narrow:
+
+```ts
+export const createTodoFn = createServerFn({ method: "POST" })
+  .middleware([request, createCall])
+  .validator((input: CreateTodoInput) => input)
+  .handler(lite.handler(createTodo))
+```

--- a/examples/lite-tanstack-start-todo-practical/package.json
+++ b/examples/lite-tanstack-start-todo-practical/package.json
@@ -13,7 +13,8 @@
     "@tanstack/react-router": "catalog:",
     "@tanstack/react-start": "catalog:",
     "react": "catalog:",
-    "react-dom": "catalog:"
+    "react-dom": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/examples/lite-tanstack-start-todo-practical/package.json
+++ b/examples/lite-tanstack-start-todo-practical/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@pumped-fn/lite-tanstack-start-todo-practical",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-tanstack-start": "workspace:*",
+    "@tanstack/react-start": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/lite-tanstack-start-todo-practical/package.json
+++ b/examples/lite-tanstack-start-todo-practical/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@pumped-fn/lite": "workspace:*",
     "@pumped-fn/lite-tanstack-start": "workspace:*",
+    "@tanstack/react-router": "catalog:",
     "@tanstack/react-start": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:"

--- a/examples/lite-tanstack-start-todo-practical/src/TodoApp.tsx
+++ b/examples/lite-tanstack-start-todo-practical/src/TodoApp.tsx
@@ -1,0 +1,72 @@
+import { useServerFn } from "@tanstack/react-start"
+import type { FormEvent } from "react"
+import {
+  clearCompletedFn,
+  createTodoFn,
+  listTodosFn,
+  toggleTodoFn,
+} from "./functions"
+import type { TodoList } from "./domain"
+
+export interface TodoAppProps {
+  initial: TodoList
+  onChanged(): Promise<void> | void
+}
+
+export function TodoApp({ initial, onChanged }: TodoAppProps) {
+  const list = useServerFn(listTodosFn)
+  const create = useServerFn(createTodoFn)
+  const toggle = useServerFn(toggleTodoFn)
+  const clear = useServerFn(clearCompletedFn)
+
+  async function refresh() {
+    await list()
+    await onChanged()
+  }
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const form = event.currentTarget
+    await create({ data: { title: String(new FormData(form).get("title") ?? "") } })
+    form.reset()
+    await onChanged()
+  }
+
+  async function toggleStatus(id: string) {
+    await toggle({ data: { id } })
+    await onChanged()
+  }
+
+  async function clearDone() {
+    await clear()
+    await onChanged()
+  }
+
+  return (
+    <main>
+      <header>
+        <h1>Todos</h1>
+        <button type="button" onClick={refresh}>
+          Refresh
+        </button>
+      </header>
+      <form onSubmit={submit}>
+        <input name="title" />
+        <button type="submit">Add</button>
+      </form>
+      <ul>
+        {initial.todos.map((todo) => (
+          <li key={todo.id}>
+            <button type="button" onClick={() => toggleStatus(todo.id)}>
+              {todo.status === "open" ? "Complete" : "Reopen"}
+            </button>
+            <span>{todo.title}</span>
+          </li>
+        ))}
+      </ul>
+      <button type="button" onClick={clearDone}>
+        Clear completed
+      </button>
+    </main>
+  )
+}

--- a/examples/lite-tanstack-start-todo-practical/src/domain.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/domain.ts
@@ -1,4 +1,5 @@
-import { atom, flow, tag, tags, typed } from "@pumped-fn/lite"
+import { atom, flow, tag, tags } from "@pumped-fn/lite"
+import { z } from "zod"
 
 export type TodoStatus = "open" | "done"
 
@@ -24,13 +25,17 @@ export interface DeleteCompletedResult {
   deleted: Todo[]
 }
 
-export interface CreateTodoInput {
-  title: string
-}
+const createTodoInput = z.object({
+  title: z.string({ error: "title is required" }).trim().min(1, "title is required"),
+})
 
-export interface ToggleTodoInput {
-  id: string
-}
+const toggleTodoInput = z.object({
+  id: z.string({ error: "id is required" }).min(1, "id is required"),
+})
+
+export type CreateTodoInput = z.infer<typeof createTodoInput>
+
+export type ToggleTodoInput = z.infer<typeof toggleTodoInput>
 
 interface MutationInput {
   tenantId: string
@@ -52,13 +57,6 @@ export interface TodoStore {
   create(input: StoreCreateInput): Promise<Todo>
   toggle(input: StoreToggleInput): Promise<Todo>
   clearCompleted(input: MutationInput): Promise<Todo[]>
-}
-
-export class TodoValidationError extends Error {
-  constructor(message: string) {
-    super(message)
-    this.name = "TodoValidationError"
-  }
 }
 
 export class TodoNotFound extends Error {
@@ -140,7 +138,7 @@ export const listTodos = flow({
 
 export const createTodo = flow({
   name: "todo.create",
-  parse: parseCreateTodo,
+  parse: (input) => createTodoInput.parse(input),
   deps: {
     store,
     tenantId: tags.required(tenantId),
@@ -160,7 +158,7 @@ export const createTodo = flow({
 
 export const toggleTodo = flow({
   name: "todo.toggle",
-  parse: typed<ToggleTodoInput>(),
+  parse: (input) => toggleTodoInput.parse(input),
   deps: {
     store,
     tenantId: tags.required(tenantId),
@@ -196,19 +194,3 @@ export const clearCompleted = flow({
     }),
   }),
 })
-
-function parseCreateTodo(input: unknown): CreateTodoInput {
-  if (!isRecord(input)) throw new TodoValidationError("title is required")
-  if (typeof input["title"] !== "string") throw new TodoValidationError("title is required")
-  return { title: normalizeTitle(input["title"]) }
-}
-
-function normalizeTitle(input: string): string {
-  const title = input.trim()
-  if (title.length === 0) throw new TodoValidationError("title is required")
-  return title
-}
-
-function isRecord(input: unknown): input is Record<string, unknown> {
-  return typeof input === "object" && input !== null
-}

--- a/examples/lite-tanstack-start-todo-practical/src/domain.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/domain.ts
@@ -140,7 +140,7 @@ export const listTodos = flow({
 
 export const createTodo = flow({
   name: "todo.create",
-  parse: typed<CreateTodoInput>(),
+  parse: parseCreateTodo,
   deps: {
     store,
     tenantId: tags.required(tenantId),
@@ -154,7 +154,7 @@ export const createTodo = flow({
       actorId: deps.actorId,
       requestId: deps.requestId,
       operation: deps.operation,
-      title: normalizeTitle(ctx.input.title),
+      title: ctx.input.title,
     }),
 })
 
@@ -197,9 +197,18 @@ export const clearCompleted = flow({
   }),
 })
 
-function normalizeTitle(input: unknown): string {
-  if (typeof input !== "string") throw new TodoValidationError("title is required")
+function parseCreateTodo(input: unknown): CreateTodoInput {
+  if (!isRecord(input)) throw new TodoValidationError("title is required")
+  if (typeof input["title"] !== "string") throw new TodoValidationError("title is required")
+  return { title: normalizeTitle(input["title"]) }
+}
+
+function normalizeTitle(input: string): string {
   const title = input.trim()
   if (title.length === 0) throw new TodoValidationError("title is required")
   return title
+}
+
+function isRecord(input: unknown): input is Record<string, unknown> {
+  return typeof input === "object" && input !== null
 }

--- a/examples/lite-tanstack-start-todo-practical/src/domain.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/domain.ts
@@ -1,0 +1,204 @@
+import { atom, flow, tag, tags, typed } from "@pumped-fn/lite"
+
+export type TodoStatus = "open" | "done"
+
+export interface Todo {
+  id: string
+  tenantId: string
+  title: string
+  status: TodoStatus
+  createdBy: string
+  updatedBy: string
+  lastRequestId: string
+  lastOperation: string
+}
+
+export interface TodoList {
+  todos: Todo[]
+  tenantId: string
+  requestId: string
+  operation: string
+}
+
+export interface DeleteCompletedResult {
+  deleted: Todo[]
+}
+
+export interface CreateTodoInput {
+  title: string
+}
+
+export interface ToggleTodoInput {
+  id: string
+}
+
+interface MutationInput {
+  tenantId: string
+  actorId: string
+  requestId: string
+  operation: string
+}
+
+interface StoreCreateInput extends MutationInput {
+  title: string
+}
+
+interface StoreToggleInput extends MutationInput {
+  id: string
+}
+
+export interface TodoStore {
+  list(tenantId: string): Promise<Todo[]>
+  create(input: StoreCreateInput): Promise<Todo>
+  toggle(input: StoreToggleInput): Promise<Todo>
+  clearCompleted(input: MutationInput): Promise<Todo[]>
+}
+
+export class TodoValidationError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "TodoValidationError"
+  }
+}
+
+export class TodoNotFound extends Error {
+  constructor(id: string) {
+    super(`todo not found: ${id}`)
+    this.name = "TodoNotFound"
+  }
+}
+
+export const requestId = tag<string>({ label: "todo.request.id" })
+export const tenantId = tag<string>({ label: "todo.tenant.id" })
+export const actorId = tag<string>({ label: "todo.actor.id" })
+export const operation = tag<string>({ label: "todo.operation" })
+
+export function createMemoryStore(): TodoStore {
+  let next = 1
+  const rows = new Map<string, Todo>()
+
+  return {
+    async list(tenantId) {
+      return [...rows.values()].filter((todo) => todo.tenantId === tenantId)
+    },
+    async create(input) {
+      const todo: Todo = {
+        id: `todo-${next++}`,
+        tenantId: input.tenantId,
+        title: input.title,
+        status: "open",
+        createdBy: input.actorId,
+        updatedBy: input.actorId,
+        lastRequestId: input.requestId,
+        lastOperation: input.operation,
+      }
+      rows.set(todo.id, todo)
+      return todo
+    },
+    async toggle(input) {
+      const existing = rows.get(input.id)
+      if (!existing || existing.tenantId !== input.tenantId) throw new TodoNotFound(input.id)
+      const todo: Todo = {
+        ...existing,
+        status: existing.status === "open" ? "done" : "open",
+        updatedBy: input.actorId,
+        lastRequestId: input.requestId,
+        lastOperation: input.operation,
+      }
+      rows.set(todo.id, todo)
+      return todo
+    },
+    async clearCompleted(input) {
+      const removed = [...rows.values()].filter(
+        (todo) => todo.tenantId === input.tenantId && todo.status === "done"
+      )
+      for (const todo of removed) rows.delete(todo.id)
+      return removed
+    },
+  }
+}
+
+export const store = atom({
+  factory: () => createMemoryStore(),
+})
+
+export const listTodos = flow({
+  name: "todo.list",
+  deps: {
+    store,
+    tenantId: tags.required(tenantId),
+    requestId: tags.required(requestId),
+    operation: tags.required(operation),
+  },
+  factory: async (_ctx, deps): Promise<TodoList> => ({
+    todos: await deps.store.list(deps.tenantId),
+    tenantId: deps.tenantId,
+    requestId: deps.requestId,
+    operation: deps.operation,
+  }),
+})
+
+export const createTodo = flow({
+  name: "todo.create",
+  parse: typed<CreateTodoInput>(),
+  deps: {
+    store,
+    tenantId: tags.required(tenantId),
+    actorId: tags.required(actorId),
+    requestId: tags.required(requestId),
+    operation: tags.required(operation),
+  },
+  factory: (ctx, deps) =>
+    deps.store.create({
+      tenantId: deps.tenantId,
+      actorId: deps.actorId,
+      requestId: deps.requestId,
+      operation: deps.operation,
+      title: normalizeTitle(ctx.input.title),
+    }),
+})
+
+export const toggleTodo = flow({
+  name: "todo.toggle",
+  parse: typed<ToggleTodoInput>(),
+  deps: {
+    store,
+    tenantId: tags.required(tenantId),
+    actorId: tags.required(actorId),
+    requestId: tags.required(requestId),
+    operation: tags.required(operation),
+  },
+  factory: (ctx, deps) =>
+    deps.store.toggle({
+      id: ctx.input.id,
+      tenantId: deps.tenantId,
+      actorId: deps.actorId,
+      requestId: deps.requestId,
+      operation: deps.operation,
+    }),
+})
+
+export const clearCompleted = flow({
+  name: "todo.clearCompleted",
+  deps: {
+    store,
+    tenantId: tags.required(tenantId),
+    actorId: tags.required(actorId),
+    requestId: tags.required(requestId),
+    operation: tags.required(operation),
+  },
+  factory: async (_ctx, deps): Promise<DeleteCompletedResult> => ({
+    deleted: await deps.store.clearCompleted({
+      tenantId: deps.tenantId,
+      actorId: deps.actorId,
+      requestId: deps.requestId,
+      operation: deps.operation,
+    }),
+  }),
+})
+
+function normalizeTitle(input: string): string {
+  const title = input.trim()
+  if (title.length === 0) throw new TodoValidationError("title is required")
+  return title
+}

--- a/examples/lite-tanstack-start-todo-practical/src/domain.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/domain.ts
@@ -197,7 +197,8 @@ export const clearCompleted = flow({
   }),
 })
 
-function normalizeTitle(input: string): string {
+function normalizeTitle(input: unknown): string {
+  if (typeof input !== "string") throw new TodoValidationError("title is required")
   const title = input.trim()
   if (title.length === 0) throw new TodoValidationError("title is required")
   return title

--- a/examples/lite-tanstack-start-todo-practical/src/functions.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/functions.ts
@@ -1,0 +1,28 @@
+import { createServerFn } from "@tanstack/react-start"
+import {
+  clearCompleted,
+  createTodo,
+  listTodos,
+  toggleTodo,
+  type CreateTodoInput,
+  type ToggleTodoInput,
+} from "./domain"
+import { clearCall, createCall, listCall, lite, request, toggleCall } from "./start"
+
+export const listTodosFn = createServerFn({ method: "GET" })
+  .middleware([request, listCall])
+  .handler(lite.handler(listTodos))
+
+export const createTodoFn = createServerFn({ method: "POST" })
+  .middleware([request, createCall])
+  .validator((input: CreateTodoInput) => input)
+  .handler(lite.handler(createTodo))
+
+export const toggleTodoFn = createServerFn({ method: "POST" })
+  .middleware([request, toggleCall])
+  .validator((input: ToggleTodoInput) => input)
+  .handler(lite.handler(toggleTodo))
+
+export const clearCompletedFn = createServerFn({ method: "POST" })
+  .middleware([request, clearCall])
+  .handler(lite.handler(clearCompleted))

--- a/examples/lite-tanstack-start-todo-practical/src/functions.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/functions.ts
@@ -15,12 +15,12 @@ export const listTodosFn = createServerFn({ method: "GET" })
 
 export const createTodoFn = createServerFn({ method: "POST" })
   .middleware([createCall])
-  .inputValidator((input: CreateTodoInput) => input)
+  .validator((input: CreateTodoInput) => input)
   .handler(lite.handler(createTodo))
 
 export const toggleTodoFn = createServerFn({ method: "POST" })
   .middleware([toggleCall])
-  .inputValidator((input: ToggleTodoInput) => input)
+  .validator((input: ToggleTodoInput) => input)
   .handler(lite.handler(toggleTodo))
 
 export const clearCompletedFn = createServerFn({ method: "POST" })

--- a/examples/lite-tanstack-start-todo-practical/src/functions.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/functions.ts
@@ -7,22 +7,22 @@ import {
   type CreateTodoInput,
   type ToggleTodoInput,
 } from "./domain"
-import { clearCall, createCall, listCall, lite, request, toggleCall } from "./start"
+import { clearCall, createCall, listCall, lite, toggleCall } from "./start"
 
 export const listTodosFn = createServerFn({ method: "GET" })
-  .middleware([request, listCall])
+  .middleware([listCall])
   .handler(lite.handler(listTodos))
 
 export const createTodoFn = createServerFn({ method: "POST" })
-  .middleware([request, createCall])
-  .validator((input: CreateTodoInput) => input)
+  .middleware([createCall])
+  .inputValidator((input: CreateTodoInput) => input)
   .handler(lite.handler(createTodo))
 
 export const toggleTodoFn = createServerFn({ method: "POST" })
-  .middleware([request, toggleCall])
-  .validator((input: ToggleTodoInput) => input)
+  .middleware([toggleCall])
+  .inputValidator((input: ToggleTodoInput) => input)
   .handler(lite.handler(toggleTodo))
 
 export const clearCompletedFn = createServerFn({ method: "POST" })
-  .middleware([request, clearCall])
+  .middleware([clearCall])
   .handler(lite.handler(clearCompleted))

--- a/examples/lite-tanstack-start-todo-practical/src/routeTree.gen.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/routeTree.gen.ts
@@ -1,0 +1,16 @@
+import { Route as RootRoute } from "./routes/__root"
+import { Route as IndexRoute } from "./routes/index"
+
+export const routeTree = RootRoute.addChildren([IndexRoute])
+
+declare module "@tanstack/react-router" {
+  interface FileRoutesByPath {
+    "/": {
+      id: "/"
+      path: "/"
+      fullPath: "/"
+      preLoaderRoute: typeof IndexRoute
+      parentRoute: typeof RootRoute
+    }
+  }
+}

--- a/examples/lite-tanstack-start-todo-practical/src/routes/__root.tsx
+++ b/examples/lite-tanstack-start-todo-practical/src/routes/__root.tsx
@@ -1,0 +1,5 @@
+import { Outlet, createRootRoute } from "@tanstack/react-router"
+
+export const Route = createRootRoute({
+  component: () => <Outlet />,
+})

--- a/examples/lite-tanstack-start-todo-practical/src/routes/index.tsx
+++ b/examples/lite-tanstack-start-todo-practical/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { createFileRoute, useRouter } from "@tanstack/react-router"
 import { useServerFn } from "@tanstack/react-start"
 import type { FormEvent } from "react"
 import {
@@ -5,23 +6,23 @@ import {
   createTodoFn,
   listTodosFn,
   toggleTodoFn,
-} from "./functions"
-import type { TodoList } from "./domain"
+} from "../functions"
+import type { TodoList } from "../domain"
 
-export interface TodoAppProps {
-  initial: TodoList
-  onChanged(): Promise<void> | void
-}
+export const Route = createFileRoute("/")({
+  loader: async (): Promise<TodoList> => listTodosFn(),
+  component: TodoRoute,
+})
 
-export function TodoApp({ initial, onChanged }: TodoAppProps) {
-  const list = useServerFn(listTodosFn)
+function TodoRoute() {
+  const router = useRouter()
+  const initial: TodoList = Route.useLoaderData()
   const create = useServerFn(createTodoFn)
   const toggle = useServerFn(toggleTodoFn)
   const clear = useServerFn(clearCompletedFn)
 
   async function refresh() {
-    await list()
-    await onChanged()
+    await router.invalidate()
   }
 
   async function submit(event: FormEvent<HTMLFormElement>) {
@@ -29,17 +30,17 @@ export function TodoApp({ initial, onChanged }: TodoAppProps) {
     const form = event.currentTarget
     await create({ data: { title: String(new FormData(form).get("title") ?? "") } })
     form.reset()
-    await onChanged()
+    await router.invalidate()
   }
 
   async function toggleStatus(id: string) {
     await toggle({ data: { id } })
-    await onChanged()
+    await router.invalidate()
   }
 
   async function clearDone() {
     await clear()
-    await onChanged()
+    await router.invalidate()
   }
 
   return (

--- a/examples/lite-tanstack-start-todo-practical/src/start.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/start.ts
@@ -1,0 +1,33 @@
+import { createScope } from "@pumped-fn/lite"
+import { tanstackStart } from "@pumped-fn/lite-tanstack-start"
+import { actorId, operation, requestId, tenantId } from "./domain"
+
+export const lite = tanstackStart.adapter()
+
+export const scope = createScope({
+  extensions: [lite],
+})
+
+export const request = lite.request({
+  tags: (request) => [
+    requestId(request.headers.get("x-request-id") ?? "missing"),
+    tenantId(request.headers.get("x-tenant-id") ?? "default"),
+    actorId(request.headers.get("x-actor-id") ?? "anonymous"),
+  ],
+})
+
+export const listCall = lite.call({
+  tags: () => [operation("todo.list")],
+})
+
+export const createCall = lite.call({
+  tags: () => [operation("todo.create")],
+})
+
+export const toggleCall = lite.call({
+  tags: () => [operation("todo.toggle")],
+})
+
+export const clearCall = lite.call({
+  tags: () => [operation("todo.clearCompleted")],
+})

--- a/examples/lite-tanstack-start-todo-practical/src/start.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/start.ts
@@ -1,10 +1,11 @@
 import { createScope } from "@pumped-fn/lite"
 import { tanstackStart } from "@pumped-fn/lite-tanstack-start"
+import { createStart } from "@tanstack/react-start"
 import { actorId, operation, requestId, tenantId } from "./domain"
 
 export const lite = tanstackStart.adapter()
 
-export const scope = createScope({
+const scope = createScope({
   extensions: [lite],
 })
 
@@ -31,3 +32,8 @@ export const toggleCall = lite.call({
 export const clearCall = lite.call({
   tags: () => [operation("todo.clearCompleted")],
 })
+
+export const startInstance = createStart(() => ({
+  requestMiddleware: [request],
+  functionMiddleware: [],
+}))

--- a/examples/lite-tanstack-start-todo-practical/src/start.ts
+++ b/examples/lite-tanstack-start-todo-practical/src/start.ts
@@ -18,18 +18,22 @@ export const request = lite.request({
 })
 
 export const listCall = lite.call({
+  middleware: [request],
   tags: () => [operation("todo.list")],
 })
 
 export const createCall = lite.call({
+  middleware: [request],
   tags: () => [operation("todo.create")],
 })
 
 export const toggleCall = lite.call({
+  middleware: [request],
   tags: () => [operation("todo.toggle")],
 })
 
 export const clearCall = lite.call({
+  middleware: [request],
   tags: () => [operation("todo.clearCompleted")],
 })
 

--- a/examples/lite-tanstack-start-todo-practical/tests/domain.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/domain.test.ts
@@ -1,5 +1,6 @@
 import { createScope, ParseError, preset } from "@pumped-fn/lite"
 import { describe, expect, it } from "vitest"
+import { ZodError } from "zod"
 import {
   actorId,
   clearCompleted,
@@ -11,7 +12,6 @@ import {
   store,
   tenantId,
   TodoNotFound,
-  TodoValidationError,
   toggleTodo,
 } from "../src/domain"
 
@@ -88,7 +88,7 @@ describe("todo domain", () => {
 
     const invalidTitle = context.exec({ flow: createTodo, input: { title: " " } })
     await expect(invalidTitle).rejects.toBeInstanceOf(ParseError)
-    await expect(invalidTitle).rejects.toMatchObject({ cause: expect.any(TodoValidationError) })
+    await expect(invalidTitle).rejects.toMatchObject({ cause: expect.any(ZodError) })
     await expect(
       context.exec({
         flow: toggleTodo,

--- a/examples/lite-tanstack-start-todo-practical/tests/domain.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/domain.test.ts
@@ -1,0 +1,102 @@
+import { createScope, preset } from "@pumped-fn/lite"
+import { describe, expect, it } from "vitest"
+import {
+  actorId,
+  clearCompleted,
+  createMemoryStore,
+  createTodo,
+  listTodos,
+  operation,
+  requestId,
+  store,
+  tenantId,
+  TodoNotFound,
+  TodoValidationError,
+  toggleTodo,
+} from "../src/domain"
+
+describe("todo domain", () => {
+  it("runs fullstack flows with only scope presets and tags", async () => {
+    const scope = createScope({
+      presets: [preset(store, createMemoryStore())],
+      tags: [
+        tenantId("tenant-a"),
+        actorId("actor-a"),
+        requestId("request-a"),
+        operation("todo.create"),
+      ],
+    })
+    const context = scope.createContext()
+    const created = await context.exec({
+      flow: createTodo,
+      input: { title: "  Render server function state  " },
+    })
+    const toggled = await context.exec({
+      flow: toggleTodo,
+      input: { id: created.id },
+      tags: [requestId("request-b"), operation("todo.toggle")],
+    })
+    const listed = await context.exec({
+      flow: listTodos,
+      tags: [requestId("request-c"), operation("todo.list")],
+    })
+    const cleared = await context.exec({
+      flow: clearCompleted,
+      tags: [requestId("request-d"), operation("todo.clearCompleted")],
+    })
+
+    expect(created).toMatchObject({
+      tenantId: "tenant-a",
+      title: "Render server function state",
+      status: "open",
+      createdBy: "actor-a",
+      lastRequestId: "request-a",
+      lastOperation: "todo.create",
+    })
+    expect(toggled).toMatchObject({
+      id: created.id,
+      status: "done",
+      lastRequestId: "request-b",
+      lastOperation: "todo.toggle",
+    })
+    expect(listed).toEqual({
+      todos: [toggled],
+      tenantId: "tenant-a",
+      requestId: "request-c",
+      operation: "todo.list",
+    })
+    expect(cleared).toEqual({ deleted: [toggled] })
+    await context.close({ ok: true })
+    await scope.dispose()
+  })
+
+  it("fails invalid mutations at the same public seam", async () => {
+    const scope = createScope({
+      presets: [preset(store, createMemoryStore())],
+      tags: [
+        tenantId("tenant-a"),
+        actorId("actor-a"),
+        requestId("request-a"),
+        operation("todo.create"),
+      ],
+    })
+    const context = scope.createContext()
+    const created = await context.exec({
+      flow: createTodo,
+      input: { title: "Keep tenant boundary" },
+    })
+
+    await expect(context.exec({ flow: createTodo, input: { title: " " } })).rejects.toBeInstanceOf(
+      TodoValidationError
+    )
+    await expect(
+      context.exec({
+        flow: toggleTodo,
+        input: { id: created.id },
+        tags: [tenantId("tenant-b"), requestId("request-b"), operation("todo.toggle")],
+      })
+    ).rejects.toBeInstanceOf(TodoNotFound)
+    await context.close({ ok: true })
+    await scope.dispose()
+  })
+})

--- a/examples/lite-tanstack-start-todo-practical/tests/domain.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/domain.test.ts
@@ -1,4 +1,4 @@
-import { createScope, preset } from "@pumped-fn/lite"
+import { createScope, ParseError, preset } from "@pumped-fn/lite"
 import { describe, expect, it } from "vitest"
 import {
   actorId,
@@ -86,9 +86,9 @@ describe("todo domain", () => {
       input: { title: "Keep tenant boundary" },
     })
 
-    await expect(context.exec({ flow: createTodo, input: { title: " " } })).rejects.toBeInstanceOf(
-      TodoValidationError
-    )
+    const invalidTitle = context.exec({ flow: createTodo, input: { title: " " } })
+    await expect(invalidTitle).rejects.toBeInstanceOf(ParseError)
+    await expect(invalidTitle).rejects.toMatchObject({ cause: expect.any(TodoValidationError) })
     await expect(
       context.exec({
         flow: toggleTodo,

--- a/examples/lite-tanstack-start-todo-practical/tests/guardrails.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/guardrails.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+describe("example guardrails", () => {
+  it("keeps framework values explicit through deps and composition roots", () => {
+    const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+    const files = [
+      "src/domain.ts",
+      "src/start.ts",
+      "src/functions.ts",
+      "src/TodoApp.tsx",
+      "tests/domain.test.ts",
+      "tests/server-functions.test.ts",
+    ].map((path) => [path, readFileSync(resolve(root, path), "utf8")] as const)
+    const forbidden = [
+      ["scope parameter helper", /\b(?:request|call|get|exec|handler)\s*\(\s*scope\b/],
+      ["context parameter helper", /\b(?:get|exec)\s*\(\s*context\b/],
+      ["ambient tag read", new RegExp(`\\.data\\.${["seek", "Tag"].join("")}\\s*\\(`)],
+      ["ambient data read", /\.data\.(?:get|seek)\s*\(/],
+    ] as const
+
+    for (const [path, source] of files) {
+      for (const [name, pattern] of forbidden) {
+        expect(source, `${path} contains ${name}`).not.toMatch(pattern)
+      }
+    }
+  })
+})

--- a/examples/lite-tanstack-start-todo-practical/tests/guardrails.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/guardrails.test.ts
@@ -8,15 +8,18 @@ describe("example guardrails", () => {
     const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
     const files = [
       "src/domain.ts",
+      "src/routeTree.gen.ts",
       "src/start.ts",
       "src/functions.ts",
-      "src/TodoApp.tsx",
+      "src/routes/__root.tsx",
+      "src/routes/index.tsx",
       "tests/domain.test.ts",
       "tests/server-functions.test.ts",
     ].map((path) => [path, readFileSync(resolve(root, path), "utf8")] as const)
     const forbidden = [
+      ["exported scope", /\bexport\s+const\s+scope\b/],
       ["scope parameter helper", /\b(?:request|call|get|exec|handler)\s*\(\s*scope\b/],
-      ["context parameter helper", /\b(?:get|exec)\s*\(\s*context\b/],
+      ["context parameter helper", /\b(?:get|exec|tags)\s*\(\s*(?:parent|context)\b/],
       ["ambient tag read", new RegExp(`\\.data\\.${["seek", "Tag"].join("")}\\s*\\(`)],
       ["ambient data read", /\.data\.(?:get|seek)\s*\(/],
     ] as const
@@ -26,5 +29,9 @@ describe("example guardrails", () => {
         expect(source, `${path} contains ${name}`).not.toMatch(pattern)
       }
     }
+    expect(readFileSync(resolve(root, "src/routes/index.tsx"), "utf8")).toContain(
+      'createFileRoute("/")'
+    )
+    expect(readFileSync(resolve(root, "src/start.ts"), "utf8")).toContain("requestMiddleware")
   })
 })

--- a/examples/lite-tanstack-start-todo-practical/tests/guardrails.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/guardrails.test.ts
@@ -33,5 +33,6 @@ describe("example guardrails", () => {
       'createFileRoute("/")'
     )
     expect(readFileSync(resolve(root, "src/start.ts"), "utf8")).toContain("requestMiddleware")
+    expect(readFileSync(resolve(root, "src/start.ts"), "utf8")).toContain("middleware: [request]")
   })
 })

--- a/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest"
+import {
+  clearCompleted,
+  createTodo,
+  listTodos,
+  toggleTodo,
+  type CreateTodoInput,
+  type Todo,
+  type TodoList,
+  type ToggleTodoInput,
+} from "../src/domain"
+import { clearCall, createCall, listCall, lite, request, toggleCall } from "../src/start"
+import { clearCompletedFn, createTodoFn, listTodosFn, toggleTodoFn } from "../src/functions"
+import { tanstackStart } from "@pumped-fn/lite-tanstack-start"
+
+describe("tanstack start todo functions", () => {
+  it("keeps request tags and function tags explicit across the middleware chain", async () => {
+    const tenant = "tenant-start-a"
+    const created = await invokeThroughStart({
+      path: "/todos",
+      method: "POST",
+      headers: {
+        "x-request-id": "req-a",
+        "x-tenant-id": tenant,
+        "x-actor-id": "actor-a",
+      },
+      call: createCall,
+      data: { title: " Ship fullstack example " },
+      run: (context) =>
+        lite.handler(createTodo)({
+          data: { title: " Ship fullstack example " },
+          context,
+        }),
+    })
+    const listed = await invokeThroughStart({
+      path: "/todos",
+      method: "GET",
+      headers: {
+        "x-request-id": "req-b",
+        "x-tenant-id": tenant,
+        "x-actor-id": "actor-b",
+      },
+      call: listCall,
+      data: undefined,
+      run: (context) => lite.handler(listTodos)({ data: undefined, context }),
+    })
+    const toggled = await invokeThroughStart({
+      path: `/todos/${created.id}/toggle`,
+      method: "POST",
+      headers: {
+        "x-request-id": "req-c",
+        "x-tenant-id": tenant,
+        "x-actor-id": "actor-c",
+      },
+      call: toggleCall,
+      data: { id: created.id },
+      run: (context) => lite.handler(toggleTodo)({ data: { id: created.id }, context }),
+    })
+    const cleared = await invokeThroughStart({
+      path: "/todos/completed",
+      method: "POST",
+      headers: {
+        "x-request-id": "req-d",
+        "x-tenant-id": tenant,
+        "x-actor-id": "actor-d",
+      },
+      call: clearCall,
+      data: undefined,
+      run: (context) => lite.handler(clearCompleted)({ data: undefined, context }),
+    })
+
+    expect(created).toMatchObject({
+      tenantId: tenant,
+      title: "Ship fullstack example",
+      status: "open",
+      createdBy: "actor-a",
+      lastRequestId: "req-a",
+      lastOperation: "todo.create",
+    })
+    expect(listed).toEqual({
+      todos: [created],
+      tenantId: tenant,
+      requestId: "req-b",
+      operation: "todo.list",
+    })
+    expect(toggled).toMatchObject({
+      id: created.id,
+      status: "done",
+      updatedBy: "actor-c",
+      lastRequestId: "req-c",
+      lastOperation: "todo.toggle",
+    })
+    expect(cleared).toEqual({ deleted: [toggled] })
+  })
+
+  it("exports callable TanStack Start functions for the React surface", () => {
+    expect(typeof listTodosFn).toBe("function")
+    expect(typeof createTodoFn).toBe("function")
+    expect(typeof toggleTodoFn).toBe("function")
+    expect(typeof clearCompletedFn).toBe("function")
+  })
+})
+
+async function invokeThroughStart<Output>(options: {
+  path: string
+  method: "GET" | "POST"
+  headers: Record<string, string>
+  call: typeof listCall
+  data: unknown
+  run(context: tanstackStart.Context): Promise<Output>
+}): Promise<Output> {
+  const incoming = new Request(`https://todo.test${options.path}`, { headers: options.headers })
+  const controller = new AbortController()
+  let output!: Output
+  const result = await request.options.server!({
+    request: incoming,
+    pathname: options.path,
+    context: {},
+    handlerType: "router",
+    next: async (requestOptions: { context: tanstackStart.Context }) => {
+      await options.call.options.server!({
+        data: options.data,
+        context: requestOptions.context,
+        method: options.method,
+        serverFnMeta: {
+          id: options.path,
+          name: options.path,
+          filename: "src/functions.ts",
+        },
+        signal: controller.signal,
+        next: async (callOptions: { context: tanstackStart.Context }) => {
+          output = await options.run(callOptions.context)
+          return functionResult(callOptions.context)
+        },
+      } as unknown as Parameters<NonNullable<typeof options.call.options.server>>[0])
+
+      return {
+        request: incoming,
+        pathname: options.path,
+        context: requestOptions.context,
+        response: Response.json(output),
+      }
+    },
+  } as unknown as Parameters<NonNullable<typeof request.options.server>>[0])
+
+  if (result instanceof Response) throw new Error("expected TanStack request result")
+  return output
+}
+
+function functionResult(context: tanstackStart.Context) {
+  return {
+    "use functions must return the result of next()": true,
+    "~types": {
+      context,
+      sendContext: undefined,
+    },
+    context,
+    sendContext: undefined,
+  }
+}

--- a/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
@@ -98,6 +98,23 @@ describe("tanstack start todo functions", () => {
     expect(toggleCall.options.middleware).toEqual([request])
     expect(clearCall.options.middleware).toEqual([request])
   })
+
+  it("keeps malformed runtime input inside domain validation", async () => {
+    await expect(
+      invokeThroughStart({
+        path: "/todos",
+        method: "POST",
+        headers: {
+          "x-request-id": "req-invalid",
+          "x-tenant-id": "tenant-start-invalid",
+          "x-actor-id": "actor-invalid",
+        },
+        call: createCall,
+        data: {} as { title: string },
+        handler: lite.handler(createTodo),
+      })
+    ).rejects.toThrow("title is required")
+  })
 })
 
 async function invokeThroughStart<Output, Input>(options: {

--- a/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
@@ -91,6 +91,13 @@ describe("tanstack start todo functions", () => {
     expect(typeof toggleTodoFn).toBe("function")
     expect(typeof clearCompletedFn).toBe("function")
   })
+
+  it("lets operation middleware carry request middleware through TanStack composition", () => {
+    expect(listCall.options.middleware).toEqual([request])
+    expect(createCall.options.middleware).toEqual([request])
+    expect(toggleCall.options.middleware).toEqual([request])
+    expect(clearCall.options.middleware).toEqual([request])
+  })
 })
 
 async function invokeThroughStart<Output, Input>(options: {

--- a/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
@@ -3,11 +3,13 @@ import {
   clearCompleted,
   createTodo,
   listTodos,
+  TodoValidationError,
   toggleTodo,
 } from "../src/domain"
 import { clearCall, createCall, listCall, lite, request, toggleCall } from "../src/start"
 import { clearCompletedFn, createTodoFn, listTodosFn, toggleTodoFn } from "../src/functions"
 import { tanstackStart } from "@pumped-fn/lite-tanstack-start"
+import { ParseError } from "@pumped-fn/lite"
 
 describe("tanstack start todo functions", () => {
   it("keeps request tags and function tags explicit across the middleware chain", async () => {
@@ -100,20 +102,21 @@ describe("tanstack start todo functions", () => {
   })
 
   it("keeps malformed runtime input inside domain validation", async () => {
-    await expect(
-      invokeThroughStart({
-        path: "/todos",
-        method: "POST",
-        headers: {
-          "x-request-id": "req-invalid",
-          "x-tenant-id": "tenant-start-invalid",
-          "x-actor-id": "actor-invalid",
-        },
-        call: createCall,
-        data: {} as { title: string },
-        handler: lite.handler(createTodo),
-      })
-    ).rejects.toThrow("title is required")
+    const failed = invokeThroughStart({
+      path: "/todos",
+      method: "POST",
+      headers: {
+        "x-request-id": "req-invalid",
+        "x-tenant-id": "tenant-start-invalid",
+        "x-actor-id": "actor-invalid",
+      },
+      call: createCall,
+      data: {} as { title: string },
+      handler: lite.handler(createTodo),
+    })
+
+    await expect(failed).rejects.toBeInstanceOf(ParseError)
+    await expect(failed).rejects.toMatchObject({ cause: expect.any(TodoValidationError) })
   })
 })
 

--- a/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
@@ -4,10 +4,6 @@ import {
   createTodo,
   listTodos,
   toggleTodo,
-  type CreateTodoInput,
-  type Todo,
-  type TodoList,
-  type ToggleTodoInput,
 } from "../src/domain"
 import { clearCall, createCall, listCall, lite, request, toggleCall } from "../src/start"
 import { clearCompletedFn, createTodoFn, listTodosFn, toggleTodoFn } from "../src/functions"
@@ -26,11 +22,7 @@ describe("tanstack start todo functions", () => {
       },
       call: createCall,
       data: { title: " Ship fullstack example " },
-      run: (context) =>
-        lite.handler(createTodo)({
-          data: { title: " Ship fullstack example " },
-          context,
-        }),
+      handler: lite.handler(createTodo),
     })
     const listed = await invokeThroughStart({
       path: "/todos",
@@ -42,7 +34,7 @@ describe("tanstack start todo functions", () => {
       },
       call: listCall,
       data: undefined,
-      run: (context) => lite.handler(listTodos)({ data: undefined, context }),
+      handler: lite.handler(listTodos),
     })
     const toggled = await invokeThroughStart({
       path: `/todos/${created.id}/toggle`,
@@ -54,7 +46,7 @@ describe("tanstack start todo functions", () => {
       },
       call: toggleCall,
       data: { id: created.id },
-      run: (context) => lite.handler(toggleTodo)({ data: { id: created.id }, context }),
+      handler: lite.handler(toggleTodo),
     })
     const cleared = await invokeThroughStart({
       path: "/todos/completed",
@@ -66,7 +58,7 @@ describe("tanstack start todo functions", () => {
       },
       call: clearCall,
       data: undefined,
-      run: (context) => lite.handler(clearCompleted)({ data: undefined, context }),
+      handler: lite.handler(clearCompleted),
     })
 
     expect(created).toMatchObject({
@@ -101,13 +93,13 @@ describe("tanstack start todo functions", () => {
   })
 })
 
-async function invokeThroughStart<Output>(options: {
+async function invokeThroughStart<Output, Input>(options: {
   path: string
   method: "GET" | "POST"
   headers: Record<string, string>
   call: typeof listCall
-  data: unknown
-  run(context: tanstackStart.Context): Promise<Output>
+  data: Input
+  handler: (event: tanstackStart.HandlerEvent<Input>) => Promise<Output>
 }): Promise<Output> {
   const incoming = new Request(`https://todo.test${options.path}`, { headers: options.headers })
   const controller = new AbortController()
@@ -129,8 +121,11 @@ async function invokeThroughStart<Output>(options: {
         },
         signal: controller.signal,
         next: async (callOptions: { context: tanstackStart.Context }) => {
-          output = await options.run(callOptions.context)
-          return functionResult(callOptions.context)
+          output = await options.handler({
+            data: options.data,
+            context: callOptions.context,
+          })
+          return functionResult({ context: callOptions.context })
         },
       } as unknown as Parameters<NonNullable<typeof options.call.options.server>>[0])
 
@@ -147,14 +142,14 @@ async function invokeThroughStart<Output>(options: {
   return output
 }
 
-function functionResult(context: tanstackStart.Context) {
+function functionResult(options: { context: tanstackStart.Context }) {
   return {
     "use functions must return the result of next()": true,
     "~types": {
-      context,
+      context: options.context,
       sendContext: undefined,
     },
-    context,
+    context: options.context,
     sendContext: undefined,
   }
 }

--- a/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
+++ b/examples/lite-tanstack-start-todo-practical/tests/server-functions.test.ts
@@ -3,13 +3,13 @@ import {
   clearCompleted,
   createTodo,
   listTodos,
-  TodoValidationError,
   toggleTodo,
 } from "../src/domain"
 import { clearCall, createCall, listCall, lite, request, toggleCall } from "../src/start"
 import { clearCompletedFn, createTodoFn, listTodosFn, toggleTodoFn } from "../src/functions"
 import { tanstackStart } from "@pumped-fn/lite-tanstack-start"
 import { ParseError } from "@pumped-fn/lite"
+import { ZodError } from "zod"
 
 describe("tanstack start todo functions", () => {
   it("keeps request tags and function tags explicit across the middleware chain", async () => {
@@ -116,7 +116,7 @@ describe("tanstack start todo functions", () => {
     })
 
     await expect(failed).rejects.toBeInstanceOf(ParseError)
-    await expect(failed).rejects.toMatchObject({ cause: expect.any(TodoValidationError) })
+    await expect(failed).rejects.toMatchObject({ cause: expect.any(ZodError) })
   })
 })
 

--- a/examples/lite-tanstack-start-todo-practical/tsconfig.json
+++ b/examples/lite-tanstack-start-todo-practical/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node", "vitest"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/lite-tanstack-start-todo-practical/vitest.config.ts
+++ b/examples/lite-tanstack-start-todo-practical/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "verify": "pnpm build && pnpm test && pnpm typecheck",
     "format": "echo 'Formatting disabled'",
     "format:check": "echo 'Format check disabled'",
-    "lint": "pnpm -F @pumped-fn/lite-lint build && node pkg/tool/lint/dist/cli.mjs pkg/core/lite/README.md pkg/core/lite/PATTERNS.md pkg/react/lite-react/README.md pkg/react/lite-react/PATTERNS.md examples/lite-practical examples/lite-react-practical examples/lite-bff-practical",
+    "lint": "pnpm -F @pumped-fn/lite-lint build && node pkg/tool/lint/dist/cli.mjs pkg/core/lite/README.md pkg/core/lite/PATTERNS.md pkg/react/lite-react/README.md pkg/react/lite-react/PATTERNS.md examples/lite-practical examples/lite-react-practical examples/lite-bff-practical examples/lite-hono-todo-practical examples/lite-tanstack-start-todo-practical",
     "lint:check": "pnpm lint",
     "actionlint": "github-actionlint .github/workflows/*.yml",
     "act": "node scripts/act.mjs",

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -11,6 +11,7 @@ names so new packages can be added without turning the workspace into a flat lis
 | --- | --- |
 | `core/` | The framework-neutral runtime. |
 | `react/` | React bindings and React-specific adapters. |
+| `framework/` | Server and full-stack framework adapters over Lite scopes. |
 | `ext/` | Optional Lite extensions and development add-ons. |
 | `agent/` | Agent workflow SDK packages and provider integrations. |
 | `render/` | Portable render contracts and renderer bindings. |

--- a/pkg/framework/README.md
+++ b/pkg/framework/README.md
@@ -1,0 +1,34 @@
+# Framework Lane
+
+`pkg/framework/` owns integrations for web and full-stack frameworks. A framework package may know
+about a framework's request context, middleware, route handler, or server-function API, but it does
+not own application scope construction.
+
+## Package Rules
+
+Framework packages use `@pumped-fn/lite-<framework>` npm names and short directory handles. The
+adapter installs through `createScope({ extensions })`, then passes request-local execution contexts
+through framework-native context surfaces.
+
+Extension-like package roots export a contextual namespace value such as `hono` or `tanstackStart`.
+Public handles under that namespace stay succinct because the namespace carries the framework
+context. Prefer names like `adapter`, `middleware`, `request`, `call`, and `handler` under the
+namespace over top-level destructurable handles that either lose context or repeat the package role.
+
+Do not add shared scope factories, global registries, or framework-shaped copies of Lite primitives.
+Users keep importing atoms, flows, resources, tags, presets, and `createScope` from `@pumped-fn/lite`.
+Do not add public helpers that accept Lite `scope` or execution `context` parameters.
+Framework-provided tags consumed by flows should use `tags.required(...)` so analysis can see the
+dependency contract explicitly.
+Any application unit that consumes external framework values is valid only when those values are
+declared through `deps`; do not read framework request, response, or ambient execution data inside
+the unit body.
+Each framework package keeps a stress integration test that demonstrates realistic framework use and
+cross-checks these anti-patterns.
+
+## Current Packages
+
+| Package | Role |
+| --- | --- |
+| `hono/` | Hono middleware plus request helpers. |
+| `tanstack-start/` | TanStack Start request/function middleware plus server-function flow helpers. |

--- a/pkg/framework/hono/CHANGELOG.md
+++ b/pkg/framework/hono/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @pumped-fn/lite-hono
+
+## 0.1.0
+
+- Add Hono middleware and request helper primitives for per-request Lite execution contexts.

--- a/pkg/framework/hono/LICENSE
+++ b/pkg/framework/hono/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pumped-fn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/framework/hono/README.md
+++ b/pkg/framework/hono/README.md
@@ -1,0 +1,51 @@
+# @pumped-fn/lite-hono
+
+Hono middleware for carrying a request-local `@pumped-fn/lite` execution context through Hono's
+typed `Variables`.
+
+```ts
+import { createScope, flow, tag, tags } from "@pumped-fn/lite"
+import { Hono } from "hono"
+import { hono } from "@pumped-fn/lite-hono"
+
+const requestId = tag<string>({ label: "request.id" })
+const readRequest = flow({
+  deps: { requestId: tags.required(requestId) },
+  factory: (_ctx, deps) => deps.requestId,
+})
+
+type AppEnv = hono.Env
+
+const lite = hono.adapter()
+const scope = createScope({ extensions: [lite] })
+const app = new Hono<AppEnv>()
+
+app.use(
+  "*",
+  lite.middleware({
+    tags: (request) => [requestId(request.headers.get("x-request-id") ?? "missing")],
+  })
+)
+
+app.get("/request-id", async (context) => {
+  return context.json({
+    requestId: await context.var.lite.exec({ flow: readRequest }),
+  })
+})
+```
+
+## API
+
+`hono.adapter(options)` creates a Lite extension with Hono middleware methods. Install the adapter
+object in `createScope({ extensions })`, then mount `lite.middleware(options)` in Hono.
+
+The middleware creates a fresh execution context per request and stores it in `context.var.lite`.
+Route handlers run flows from that framework-owned request surface.
+
+Use `tags.required(...)` for framework-provided request tags that a flow needs. This keeps tag
+requirements visible to dependency analysis instead of hiding them in ad hoc context reads.
+Flows and resources that consume request-derived values should declare those values in `deps`; route
+handlers seed tags at the framework boundary and then execute public Lite units.
+
+Pass `key` to use another Hono variable name. Pass `close: false` if an outer framework boundary owns
+`ctx.close(...)`.

--- a/pkg/framework/hono/package.json
+++ b/pkg/framework/hono/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@pumped-fn/lite-hono",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Hono middleware helpers for @pumped-fn/lite request execution contexts",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@pumped-fn/lite": "^3.1.0",
+    "hono": "^4.12.0"
+  },
+  "devDependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "hono": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "pumped-fn",
+    "lite",
+    "hono",
+    "middleware",
+    "dependency-injection"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "directory": "pkg/framework/hono",
+    "url": "git+https://github.com/pumped-fn/pumped-fn.git"
+  }
+}

--- a/pkg/framework/hono/src/index.ts
+++ b/pkg/framework/hono/src/index.ts
@@ -1,0 +1,79 @@
+import type { Lite } from "@pumped-fn/lite"
+import type { Env as HonoEnv, MiddlewareHandler } from "hono"
+
+type EnvVariables<E extends HonoEnv> = E extends { Variables: infer Variables extends object } ? Variables : {}
+
+const contextKey = "lite"
+
+interface HonoKeyOptions<Key extends string = typeof contextKey> {
+  key?: Key
+}
+
+type HonoEnvShape<
+  E extends HonoEnv = HonoEnv,
+  Key extends string = typeof contextKey,
+> = E & {
+  Variables: EnvVariables<E> & Record<Key, Lite.ExecutionContext>
+}
+
+interface HonoOptions<
+  E extends HonoEnv = HonoEnv,
+> {
+  tags?: (request: Request) => Lite.Tagged<any>[]
+  close?: boolean
+}
+
+interface HonoAdapter<Key extends string = typeof contextKey> {
+  readonly name: string
+  middleware<E extends HonoEnv = HonoEnv>(
+    middlewareOptions?: HonoOptions<E>
+  ): MiddlewareHandler<HonoEnvShape<E, Key>>
+}
+
+function adapter<Key extends string = typeof contextKey>(
+  options?: HonoKeyOptions<Key>
+): HonoAdapter<Key> {
+  const key = (options?.key ?? contextKey) as Key
+  let scope: Lite.Scope
+
+  const extension = {
+    name: "@pumped-fn/lite-hono",
+    init(nextScope: Lite.Scope) {
+      scope = nextScope
+    },
+    middleware<E extends HonoEnv = HonoEnv>(
+      middlewareOptions?: HonoOptions<E>
+    ): MiddlewareHandler<HonoEnvShape<E, Key>> {
+      const close = middlewareOptions?.close ?? true
+
+      return async (context, next) => {
+        const execution = scope.createContext({ tags: middlewareOptions?.tags?.(context.req.raw) })
+        const set = context.set as unknown as (key: Key, value: Lite.ExecutionContext) => void
+        set(key, execution)
+
+        try {
+          await next()
+        } catch (error) {
+          if (close) await execution.close({ ok: false, error })
+          throw error
+        }
+
+        if (close) await execution.close({ ok: true })
+      }
+    },
+  }
+
+  return extension
+}
+
+export const hono = { contextKey, adapter } as const
+
+export namespace hono {
+  export type KeyOptions<Key extends string = typeof contextKey> = HonoKeyOptions<Key>
+  export type Env<
+    E extends HonoEnv = HonoEnv,
+    Key extends string = typeof contextKey,
+  > = HonoEnvShape<E, Key>
+  export type Options<E extends HonoEnv = HonoEnv> = HonoOptions<E>
+  export type Adapter<Key extends string = typeof contextKey> = HonoAdapter<Key>
+}

--- a/pkg/framework/hono/src/index.ts
+++ b/pkg/framework/hono/src/index.ts
@@ -6,8 +6,8 @@ type EnvVariables<E extends HonoEnv> = E extends { Variables: infer Variables ex
 
 const contextKey = "lite"
 
-interface HonoKeyOptions<Key extends string = typeof contextKey> {
-  key?: Key
+interface HonoKeyOptions<Key extends string = string> {
+  key: Key
 }
 
 type HonoEnvShape<
@@ -31,13 +31,17 @@ interface HonoAdapter<Key extends string = typeof contextKey> {
   ): MiddlewareHandler<HonoEnvShape<E, Key>>
 }
 
-function adapter<Key extends string = typeof contextKey>(
-  options?: HonoKeyOptions<Key>
-): HonoAdapter<Key> {
-  const key = (options?.key ?? contextKey) as Key
+function adapter(): HonoAdapter
+function adapter<const Key extends string>(options: HonoKeyOptions<Key>): HonoAdapter<Key>
+function adapter<const Key extends string>(options?: HonoKeyOptions<Key>) {
+  if (options) return bindAdapter(options.key)
+  return bindAdapter(contextKey)
+}
+
+function bindAdapter<const Key extends string>(key: Key): HonoAdapter<Key> & Lite.Extension {
   let scope: Lite.Scope
 
-  const extension = {
+  return {
     name: "@pumped-fn/lite-hono",
     init(nextScope: Lite.Scope) {
       scope = nextScope
@@ -63,14 +67,12 @@ function adapter<Key extends string = typeof contextKey>(
       })
     },
   }
-
-  return extension
 }
 
 export const hono = { contextKey, adapter } as const
 
 export namespace hono {
-  export type KeyOptions<Key extends string = typeof contextKey> = HonoKeyOptions<Key>
+  export type KeyOptions<Key extends string = string> = HonoKeyOptions<Key>
   export type Env<
     E extends HonoEnv = HonoEnv,
     Key extends string = typeof contextKey,

--- a/pkg/framework/hono/src/index.ts
+++ b/pkg/framework/hono/src/index.ts
@@ -1,5 +1,6 @@
 import type { Lite } from "@pumped-fn/lite"
 import type { Env as HonoEnv, MiddlewareHandler } from "hono"
+import { createMiddleware } from "hono/factory"
 
 type EnvVariables<E extends HonoEnv> = E extends { Variables: infer Variables extends object } ? Variables : {}
 
@@ -46,7 +47,7 @@ function adapter<Key extends string = typeof contextKey>(
     ): MiddlewareHandler<HonoEnvShape<E, Key>> {
       const close = middlewareOptions?.close ?? true
 
-      return async (context, next) => {
+      return createMiddleware<HonoEnvShape<E, Key>>(async (context, next) => {
         const execution = scope.createContext({ tags: middlewareOptions?.tags?.(context.req.raw) })
         const set = context.set as unknown as (key: Key, value: Lite.ExecutionContext) => void
         set(key, execution)
@@ -59,7 +60,7 @@ function adapter<Key extends string = typeof contextKey>(
         }
 
         if (close) await execution.close({ ok: true })
-      }
+      })
     },
   }
 

--- a/pkg/framework/hono/tests/hono.test.ts
+++ b/pkg/framework/hono/tests/hono.test.ts
@@ -1,0 +1,82 @@
+import { createScope, flow, tag, tags, typed } from "@pumped-fn/lite"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { hono } from "../src/index"
+
+const requestId = tag<string>({ label: "request.id" })
+
+const readRequest = flow({
+  deps: { requestId: tags.required(requestId) },
+  factory: (_ctx, deps) => deps.requestId,
+})
+
+const echo = flow({
+  parse: typed<{ message: string }>(),
+  deps: { requestId: tags.required(requestId) },
+  factory: (ctx, deps) => ({
+    message: ctx.input.message,
+    requestId: deps.requestId,
+  }),
+})
+
+describe("middleware", () => {
+  it("creates one execution context per request", async () => {
+    type BaseEnv = { Variables: { user: string } }
+    type AppEnv = hono.Env<BaseEnv>
+
+    const lite = hono.adapter()
+    const scope = createScope({ extensions: [lite] })
+    const closed: string[] = []
+    const app = new Hono<AppEnv>()
+
+    app.use(
+      "*",
+      lite.middleware<BaseEnv>({
+        tags: (request) => [requestId(request.headers.get("x-request-id") ?? "missing")],
+      })
+    )
+    app.use("*", async (context, next) => {
+      context.var.lite.onClose((result) => {
+        closed.push(result.ok ? "ok" : "error")
+      })
+      await next()
+    })
+    app.get("/id", async (context) =>
+      context.json({ id: await context.var.lite.exec({ flow: readRequest }) })
+    )
+    app.get("/override", async (context) =>
+      context.json({
+        id: await context.var.lite.exec({ flow: readRequest, tags: [requestId("override")] }),
+      })
+    )
+    app.post("/echo", async (context) => {
+      const input = (await context.req.json()) as { message: string }
+      return context.json(await context.var.lite.exec({ flow: echo, input }))
+    })
+
+    const first = await app.request("/id", {
+      headers: { "x-request-id": "first" },
+    })
+    const second = await app.request("/id", {
+      headers: { "x-request-id": "second" },
+    })
+    const override = await app.request("/override", {
+      headers: { "x-request-id": "first" },
+    })
+    const echoed = await app.request("/echo", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "echo",
+      },
+      body: JSON.stringify({ message: "hello" }),
+    })
+
+    expect(await first.json()).toEqual({ id: "first" })
+    expect(await second.json()).toEqual({ id: "second" })
+    expect(await override.json()).toEqual({ id: "override" })
+    expect(await echoed.json()).toEqual({ message: "hello", requestId: "echo" })
+    expect(closed).toEqual(["ok", "ok", "ok", "ok"])
+    await scope.dispose()
+  })
+})

--- a/pkg/framework/hono/tests/stress.test.ts
+++ b/pkg/framework/hono/tests/stress.test.ts
@@ -1,0 +1,184 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { createScope, flow, resource, tag, tags, typed } from "@pumped-fn/lite"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { hono } from "../src/index"
+
+const requestId = tag<string>({ label: "stress.request.id" })
+const tenantId = tag<string>({ label: "stress.tenant.id" })
+const operation = tag<string>({ label: "stress.operation" })
+
+describe("stress integration", () => {
+  it("keeps framework values explicit through deps across request execution", async () => {
+    type BaseEnv = { Variables: { auth: string } }
+    type AppEnv = hono.Env<BaseEnv>
+
+    const cleanups: string[] = []
+    const audit = resource({
+      name: "stress.audit",
+      ownership: "current",
+      deps: {
+        requestId: tags.required(requestId),
+        tenantId: tags.required(tenantId),
+        operation: tags.required(operation),
+      },
+      factory: (ctx, deps) => {
+        const entries: string[] = []
+        ctx.cleanup(() => {
+          cleanups.push(`${deps.tenantId}:${deps.requestId}:${deps.operation}:${entries.length}`)
+        })
+        return {
+          record: (event: string) => {
+            entries.push(`${deps.tenantId}:${deps.requestId}:${deps.operation}:${event}`)
+          },
+          snapshot: () => [...entries],
+        }
+      },
+    })
+    const confirm = flow({
+      name: "stress.confirm",
+      deps: { audit },
+      factory: (_ctx, deps) => {
+        deps.audit.record("confirm")
+        return deps.audit.snapshot()
+      },
+    })
+    const checkout = flow({
+      name: "stress.checkout",
+      parse: typed<{ sku: string; quantity: number }>(),
+      deps: {
+        requestId: tags.required(requestId),
+        tenantId: tags.required(tenantId),
+        operation: tags.required(operation),
+        audit,
+      },
+      factory: async (ctx, deps) => {
+        deps.audit.record(`checkout:${ctx.input.sku}:${ctx.input.quantity}`)
+        return {
+          requestId: deps.requestId,
+          tenantId: deps.tenantId,
+          operation: deps.operation,
+          confirmation: await ctx.exec({ flow: confirm }),
+          events: deps.audit.snapshot(),
+        }
+      },
+    })
+    const lite = hono.adapter()
+    const scope = createScope({ extensions: [lite] })
+    const closed: string[] = []
+    const app = new Hono<AppEnv>()
+
+    expect(Object.keys(audit.deps ?? {}).sort()).toEqual(["operation", "requestId", "tenantId"])
+    expect(Object.keys(checkout.deps ?? {}).sort()).toEqual([
+      "audit",
+      "operation",
+      "requestId",
+      "tenantId",
+    ])
+
+    app.use(
+      "*",
+      lite.middleware<BaseEnv>({
+        tags: (request) => [
+          requestId(request.headers.get("x-request-id") ?? "missing"),
+          tenantId(request.headers.get("x-tenant-id") ?? "missing"),
+          operation(`${request.method}:${new URL(request.url).pathname}`),
+        ],
+      })
+    )
+    app.use("*", async (context, next) => {
+      context.var.lite.onClose((result) => {
+        closed.push(result.ok ? "request:ok" : "request:error")
+      })
+      await next()
+    })
+    app.post("/orders", async (context) =>
+      context.json(
+        await context.var.lite.exec({
+          flow: checkout,
+          input: (await context.req.json()) as { sku: string; quantity: number },
+        })
+      )
+    )
+
+    const first = await app.request("/orders", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "req-a",
+        "x-tenant-id": "tenant-a",
+      },
+      body: JSON.stringify({ sku: "sku-a", quantity: 2 }),
+    })
+    const second = await app.request("/orders", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-request-id": "req-b",
+        "x-tenant-id": "tenant-b",
+      },
+      body: JSON.stringify({ sku: "sku-b", quantity: 1 }),
+    })
+
+    expect(await first.json()).toEqual({
+      requestId: "req-a",
+      tenantId: "tenant-a",
+      operation: "POST:/orders",
+      confirmation: [
+        "tenant-a:req-a:POST:/orders:checkout:sku-a:2",
+        "tenant-a:req-a:POST:/orders:confirm",
+      ],
+      events: [
+        "tenant-a:req-a:POST:/orders:checkout:sku-a:2",
+        "tenant-a:req-a:POST:/orders:confirm",
+      ],
+    })
+    expect(await second.json()).toEqual({
+      requestId: "req-b",
+      tenantId: "tenant-b",
+      operation: "POST:/orders",
+      confirmation: [
+        "tenant-b:req-b:POST:/orders:checkout:sku-b:1",
+        "tenant-b:req-b:POST:/orders:confirm",
+      ],
+      events: [
+        "tenant-b:req-b:POST:/orders:checkout:sku-b:1",
+        "tenant-b:req-b:POST:/orders:confirm",
+      ],
+    })
+    expect(cleanups).toEqual([
+      "tenant-a:req-a:POST:/orders:2",
+      "tenant-b:req-b:POST:/orders:2",
+    ])
+    expect(closed).toEqual(["request:ok", "request:ok"])
+    await scope.dispose()
+  })
+})
+
+describe("anti-pattern guardrails", () => {
+  it("keeps adapter package surfaces free of implicit external reads", () => {
+    const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+    const files = [
+      "src/index.ts",
+      "README.md",
+      "tests/hono.test.ts",
+      "tests/stress.test.ts",
+      "tests/type-contracts.ts",
+    ].map((path) => [path, readFileSync(resolve(root, path), "utf8")] as const)
+    const forbidden = [
+      ["top-level generic export", /^export (?:const|function|interface|type) (?:contextKey|adapter|KeyOptions|Env|Options|Adapter)\b/m],
+      ["scope parameter helper", /\b(?:middleware|get|exec)\s*\(\s*scope\b/],
+      ["context parameter helper", /\b(?:get|exec)\s*\(\s*context\b/],
+      ["ambient tag read", new RegExp(`\\.data\\.${["seek", "Tag"].join("")}\\s*\\(`)],
+      ["ambient data read", /\.data\.(?:get|seek)\s*\(/],
+    ] as const
+
+    for (const [path, source] of files) {
+      for (const [name, pattern] of forbidden) {
+        expect(source, `${path} contains ${name}`).not.toMatch(pattern)
+      }
+    }
+  })
+})

--- a/pkg/framework/hono/tests/type-contracts.ts
+++ b/pkg/framework/hono/tests/type-contracts.ts
@@ -39,7 +39,7 @@ app.get("/bad-input", async (context) => {
   return context.text(await context.var.lite.exec({ flow: echo, input: { id: "bad" } }))
 })
 
-const liteCtx = hono.adapter<"ctx">({ key: "ctx" })
+const liteCtx = hono.adapter({ key: "ctx" })
 createScope({ extensions: [liteCtx] })
 const custom = new Hono<hono.Env<{}, "ctx">>()
 
@@ -52,3 +52,6 @@ custom.get("/", (context) => {
 
 // @ts-expect-error custom-key middleware does not add the default lite variable
 custom.get("/bad-key", (context) => context.text(String(context.var.lite)))
+
+// @ts-expect-error custom context keys must be provided as runtime options
+hono.adapter<"ctx">()

--- a/pkg/framework/hono/tests/type-contracts.ts
+++ b/pkg/framework/hono/tests/type-contracts.ts
@@ -1,0 +1,54 @@
+import { createScope, flow, typed, type Lite } from "@pumped-fn/lite"
+import { Hono } from "hono"
+import { hono } from "../src/index"
+// @ts-expect-error adapter is contextualized under the hono namespace
+import { adapter } from "../src/index"
+
+type BaseEnv = { Variables: { user: string } }
+
+const lite = hono.adapter()
+createScope({ extensions: [lite] })
+const app = new Hono<hono.Env<BaseEnv>>()
+const echo = flow({
+  parse: typed<{ message: string }>(),
+  factory: (ctx) => ctx.input.message,
+})
+
+app.use("*", lite.middleware<BaseEnv>())
+app.get("/user", (context) => {
+  const user: string = context.get("user")
+  const execution: Lite.ExecutionContext = context.var.lite
+
+  void user
+  void execution
+
+  return context.text("ok")
+})
+app.get("/echo", async (context) =>
+  context.text(await context.var.lite.exec({ flow: echo, input: { message: "ok" } }))
+)
+
+app.get("/bad-lite", (context) => {
+  // @ts-expect-error Hono variables expose the execution context, not a string
+  const value: string = context.var.lite
+  return context.text(value)
+})
+
+app.get("/bad-input", async (context) => {
+  // @ts-expect-error flow input must match the typed Lite flow input
+  return context.text(await context.var.lite.exec({ flow: echo, input: { id: "bad" } }))
+})
+
+const liteCtx = hono.adapter<"ctx">({ key: "ctx" })
+createScope({ extensions: [liteCtx] })
+const custom = new Hono<hono.Env<{}, "ctx">>()
+
+custom.use("*", liteCtx.middleware<{}>())
+custom.get("/", (context) => {
+  const execution: Lite.ExecutionContext = context.var.ctx
+  void execution
+  return context.text("ok")
+})
+
+// @ts-expect-error custom-key middleware does not add the default lite variable
+custom.get("/bad-key", (context) => context.text(String(context.var.lite)))

--- a/pkg/framework/hono/tsconfig.json
+++ b/pkg/framework/hono/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "../..",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
+    "paths": {
+      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pkg/framework/hono/tsconfig.test.json
+++ b/pkg/framework/hono/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/pkg/framework/hono/tsdown.config.ts
+++ b/pkg/framework/hono/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  format: ["cjs", "esm"],
+  clean: true,
+})

--- a/pkg/framework/hono/vitest.config.ts
+++ b/pkg/framework/hono/vitest.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from "node:path"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@pumped-fn/lite": resolve(__dirname, "../../core/lite/src/index.ts"),
+    },
+  },
+})

--- a/pkg/framework/tanstack-start/CHANGELOG.md
+++ b/pkg/framework/tanstack-start/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @pumped-fn/lite-tanstack-start
+
+## 0.1.0
+
+- Add TanStack Start request/function middleware and server-function flow helpers.

--- a/pkg/framework/tanstack-start/LICENSE
+++ b/pkg/framework/tanstack-start/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pumped-fn
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/framework/tanstack-start/README.md
+++ b/pkg/framework/tanstack-start/README.md
@@ -20,11 +20,11 @@ const scope = createScope({ extensions: [lite] })
 const req = lite.request({
   tags: (request) => [requestId(request.headers.get("x-request-id") ?? "missing")],
 })
-const serverFn = lite.call()
+const serverFn = lite.call({ middleware: [req] })
 
 export const echoMessage = createServerFn({ method: "POST" })
-  .middleware([req, serverFn])
-  .inputValidator((input: { message: string }) => input)
+  .middleware([serverFn])
+  .validator((input: { message: string }) => input)
   .handler(lite.handler(echo))
 ```
 
@@ -37,9 +37,10 @@ Install the adapter object in `createScope({ extensions })`, then use `lite.requ
 `lite.request(options)` creates a TanStack Start request middleware. The middleware creates a request
 execution context and passes it to `next(...)` as `context.lite`.
 
-`lite.call(options)` creates a server-function middleware. It reads the request execution
-context from `context.lite`, creates a child execution context for the function call, and passes that
-child to `next(...)`.
+`lite.call(options)` creates a server-function middleware. Pass native TanStack middleware through
+`middleware` to let Start carry and dedupe context through its own middleware graph. The call
+middleware reads the request execution context from `context.lite`, creates a child execution context
+for the function call, and passes that child to `next(...)`.
 
 `lite.handler(flow, options)` converts a typed Lite flow into a TanStack Start handler. The handler
 uses the server function's validated `data` as the Lite flow input.

--- a/pkg/framework/tanstack-start/README.md
+++ b/pkg/framework/tanstack-start/README.md
@@ -24,7 +24,7 @@ const serverFn = lite.call()
 
 export const echoMessage = createServerFn({ method: "POST" })
   .middleware([req, serverFn])
-  .validator((input: { message: string }) => input)
+  .inputValidator((input: { message: string }) => input)
   .handler(lite.handler(echo))
 ```
 

--- a/pkg/framework/tanstack-start/README.md
+++ b/pkg/framework/tanstack-start/README.md
@@ -1,0 +1,53 @@
+# @pumped-fn/lite-tanstack-start
+
+TanStack Start middleware helpers for carrying `@pumped-fn/lite` execution contexts through request
+middleware, function middleware, and typed server-function handlers.
+
+```ts
+import { createServerFn } from "@tanstack/react-start"
+import { createScope, flow, tag, tags, typed } from "@pumped-fn/lite"
+import { tanstackStart } from "@pumped-fn/lite-tanstack-start"
+
+const requestId = tag<string>({ label: "request.id" })
+const echo = flow({
+  parse: typed<{ message: string }>(),
+  deps: { requestId: tags.required(requestId) },
+  factory: (ctx, deps) => ({ message: ctx.input.message, requestId: deps.requestId }),
+})
+
+const lite = tanstackStart.adapter()
+const scope = createScope({ extensions: [lite] })
+const req = lite.request({
+  tags: (request) => [requestId(request.headers.get("x-request-id") ?? "missing")],
+})
+const serverFn = lite.call()
+
+export const echoMessage = createServerFn({ method: "POST" })
+  .middleware([req, serverFn])
+  .validator((input: { message: string }) => input)
+  .handler(lite.handler(echo))
+```
+
+## API
+
+`tanstackStart.adapter(options)` creates a Lite extension with TanStack Start middleware methods.
+Install the adapter object in `createScope({ extensions })`, then use `lite.request()`,
+`lite.call()`, and `lite.handler(flow)`.
+
+`lite.request(options)` creates a TanStack Start request middleware. The middleware creates a request
+execution context and passes it to `next(...)` as `context.lite`.
+
+`lite.call(options)` creates a server-function middleware. It reads the request execution
+context from `context.lite`, creates a child execution context for the function call, and passes that
+child to `next(...)`.
+
+`lite.handler(flow, options)` converts a typed Lite flow into a TanStack Start handler. The handler
+uses the server function's validated `data` as the Lite flow input.
+
+Use `tags.required(...)` for framework-provided request tags that a flow needs. This keeps tag
+requirements visible to dependency analysis instead of hiding them in ad hoc context reads.
+Flows and resources that consume request-derived values should declare those values in `deps`; Start
+middleware seeds tags at the framework boundary and handlers execute public Lite units.
+
+Pass `key` to use another context property. Pass `close: false` when another boundary owns
+`ctx.close(...)`.

--- a/pkg/framework/tanstack-start/package.json
+++ b/pkg/framework/tanstack-start/package.json
@@ -1,0 +1,67 @@
+{
+  "name": "@pumped-fn/lite-tanstack-start",
+  "version": "0.1.0",
+  "private": false,
+  "description": "TanStack Start middleware helpers for @pumped-fn/lite execution contexts",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@pumped-fn/lite": "^3.1.0",
+    "@tanstack/react-start": "^1.168.0"
+  },
+  "devDependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@tanstack/react-start": "catalog:",
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22.12.0"
+  },
+  "keywords": [
+    "pumped-fn",
+    "lite",
+    "tanstack-start",
+    "server-functions",
+    "middleware"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "directory": "pkg/framework/tanstack-start",
+    "url": "git+https://github.com/pumped-fn/pumped-fn.git"
+  }
+}

--- a/pkg/framework/tanstack-start/src/index.ts
+++ b/pkg/framework/tanstack-start/src/index.ts
@@ -15,7 +15,7 @@ interface StartRequestOptions {
 }
 
 interface StartCallOptions {
-  tags?: (parent: Lite.ExecutionContext) => Lite.Tagged<any>[]
+  tags?: () => Lite.Tagged<any>[]
   close?: boolean
 }
 
@@ -86,7 +86,7 @@ function adapter<Key extends string = typeof contextKey>(
       const parent = (event.context as unknown as StartContext<Key>)[key]
       const execution = parent.scope.createContext({
         parent,
-        tags: callOptions?.tags?.(parent),
+        tags: callOptions?.tags?.(),
       })
 
       const result = await (async () => {

--- a/pkg/framework/tanstack-start/src/index.ts
+++ b/pkg/framework/tanstack-start/src/index.ts
@@ -1,0 +1,160 @@
+import { createMiddleware } from "@tanstack/react-start"
+import type { Lite } from "@pumped-fn/lite"
+
+const contextKey = "lite"
+
+type StartContext<Key extends string = typeof contextKey> = Record<Key, Lite.ExecutionContext>
+
+interface StartKeyOptions<Key extends string = typeof contextKey> {
+  key?: Key
+}
+
+interface StartRequestOptions {
+  tags?: (request: Request) => Lite.Tagged<any>[]
+  close?: boolean
+}
+
+interface StartCallOptions {
+  tags?: (parent: Lite.ExecutionContext) => Lite.Tagged<any>[]
+  close?: boolean
+}
+
+type StartHandlerEvent<
+  Input,
+  Key extends string = typeof contextKey,
+> = {
+  data: Input
+  context: StartContext<Key>
+}
+
+interface StartAdapter<Key extends string = typeof contextKey> {
+  readonly name: string
+  request(
+    requestOptions?: StartRequestOptions
+  ): import("@tanstack/react-start").RequestMiddlewareAfterServer<{}, undefined, StartContext<Key>>
+  call(
+    callOptions?: StartCallOptions
+  ): import("@tanstack/react-start").FunctionMiddlewareAfterServer<
+    {},
+    unknown,
+    undefined,
+    StartContext<Key>,
+    undefined,
+    undefined,
+    undefined
+  >
+  handler<Output>(
+    flow: Lite.Flow<Output, void>,
+    runOptions?: Lite.FlowRunOptions
+  ): (event: StartHandlerEvent<void, Key>) => Promise<Output>
+  handler<Output, Input>(
+    flow: Lite.Flow<Output, Input>,
+    runOptions?: Lite.FlowRunOptions
+  ): (event: StartHandlerEvent<Input, Key>) => Promise<Output>
+}
+
+function adapter<Key extends string = typeof contextKey>(
+  options?: StartKeyOptions<Key>
+): StartAdapter<Key> {
+  const key = (options?.key ?? contextKey) as Key
+  let scope: Lite.Scope
+
+  function request(requestOptions?: StartRequestOptions) {
+    const close = requestOptions?.close ?? true
+
+    return createMiddleware({ type: "request" }).server(async ({ request, next }) => {
+      const execution = scope.createContext({ tags: requestOptions?.tags?.(request) })
+
+      const result = await (async () => {
+        try {
+          return await next({ context: { [key]: execution } as StartContext<Key> })
+        } catch (error) {
+          if (close) await execution.close({ ok: false, error })
+          throw error
+        }
+      })()
+
+      if (close) await execution.close({ ok: true })
+      return result
+    })
+  }
+
+  function call(callOptions?: StartCallOptions) {
+    const close = callOptions?.close ?? true
+
+    return createMiddleware({ type: "function" }).server(async (event) => {
+      const parent = (event.context as unknown as StartContext<Key>)[key]
+      const execution = parent.scope.createContext({
+        parent,
+        tags: callOptions?.tags?.(parent),
+      })
+
+      const result = await (async () => {
+        try {
+          return await event.next({ context: { [key]: execution } as StartContext<Key> })
+        } catch (error) {
+          if (close) await execution.close({ ok: false, error })
+          throw error
+        }
+      })()
+
+      if (close) await execution.close({ ok: true })
+      return result
+    })
+  }
+
+  function handler<
+    Output
+  >(
+    flow: Lite.Flow<Output, void>,
+    runOptions?: Lite.FlowRunOptions
+  ): (event: StartHandlerEvent<void, Key>) => Promise<Output>
+  function handler<
+    Output,
+    Input
+  >(
+    flow: Lite.Flow<Output, Input>,
+    runOptions?: Lite.FlowRunOptions
+  ): (event: StartHandlerEvent<Input, Key>) => Promise<Output>
+  function handler<
+    Output,
+    Input
+  >(
+    flow: Lite.Flow<Output, Input>,
+    runOptions?: Lite.FlowRunOptions
+  ) {
+    return (event: StartHandlerEvent<Input, Key>) =>
+      event.context[key].exec({
+        flow,
+        input: event.data,
+        name: runOptions?.name,
+        tags: runOptions?.tags,
+      } as Lite.ExecFlowOptions<Output, Input>)
+  }
+
+  const extension = {
+    name: "@pumped-fn/lite-tanstack-start",
+    init(nextScope: Lite.Scope) {
+      scope = nextScope
+    },
+    request,
+    call,
+    handler,
+  }
+
+  return extension
+}
+
+export const tanstackStart = { contextKey, adapter } as const
+
+export namespace tanstackStart {
+  export type Context<Key extends string = typeof contextKey> = StartContext<Key>
+  export type KeyOptions<Key extends string = typeof contextKey> = StartKeyOptions<Key>
+  export type RequestOptions = StartRequestOptions
+  export type CallOptions = StartCallOptions
+  export type HandlerEvent<
+    Input,
+    Key extends string = typeof contextKey,
+  > = StartHandlerEvent<Input, Key>
+  export type Adapter<Key extends string = typeof contextKey> = StartAdapter<Key>
+}

--- a/pkg/framework/tanstack-start/src/index.ts
+++ b/pkg/framework/tanstack-start/src/index.ts
@@ -139,10 +139,10 @@ function bindAdapter<const Key extends string>(key: Key): StartAdapter<Key> & Li
     return (event: StartHandlerEvent<Input, Key>) =>
       event.context[key].exec({
         flow,
-        input: event.data,
+        rawInput: event.data,
         name: runOptions?.name,
         tags: runOptions?.tags,
-      } as Lite.ExecFlowOptions<Output, Input>)
+      })
   }
 
   return {

--- a/pkg/framework/tanstack-start/src/index.ts
+++ b/pkg/framework/tanstack-start/src/index.ts
@@ -3,6 +3,10 @@ import type { Lite } from "@pumped-fn/lite"
 
 const contextKey = "lite"
 
+type StartMiddleware =
+  | import("@tanstack/react-start").AnyRequestMiddleware
+  | import("@tanstack/react-start").AnyFunctionMiddleware
+
 type StartContext<Key extends string = typeof contextKey> = Record<Key, Lite.ExecutionContext>
 
 interface StartKeyOptions<Key extends string = typeof contextKey> {
@@ -14,7 +18,8 @@ interface StartRequestOptions {
   close?: boolean
 }
 
-interface StartCallOptions {
+interface StartCallOptions<TMiddlewares extends readonly StartMiddleware[] = readonly []> {
+  middleware?: TMiddlewares
   tags?: () => Lite.Tagged<any>[]
   close?: boolean
 }
@@ -32,11 +37,11 @@ interface StartAdapter<Key extends string = typeof contextKey> {
   request(
     requestOptions?: StartRequestOptions
   ): import("@tanstack/react-start").RequestMiddlewareAfterServer<{}, undefined, StartContext<Key>>
-  call(
-    callOptions?: StartCallOptions
+  call<const TMiddlewares extends readonly StartMiddleware[] = readonly []>(
+    callOptions?: StartCallOptions<TMiddlewares>
   ): import("@tanstack/react-start").FunctionMiddlewareAfterServer<
     {},
-    unknown,
+    TMiddlewares,
     undefined,
     StartContext<Key>,
     undefined,
@@ -79,28 +84,32 @@ function adapter<Key extends string = typeof contextKey>(
     })
   }
 
-  function call(callOptions?: StartCallOptions) {
+  function call<const TMiddlewares extends readonly StartMiddleware[] = readonly []>(
+    callOptions?: StartCallOptions<TMiddlewares>
+  ) {
     const close = callOptions?.close ?? true
 
-    return createMiddleware({ type: "function" }).server(async (event) => {
-      const parent = (event.context as unknown as StartContext<Key>)[key]
-      const execution = parent.scope.createContext({
-        parent,
-        tags: callOptions?.tags?.(),
+    return createMiddleware({ type: "function" })
+      .middleware((callOptions?.middleware ?? []) as TMiddlewares)
+      .server(async (event) => {
+        const parent = (event.context as unknown as StartContext<Key>)[key]
+        const execution = parent.scope.createContext({
+          parent,
+          tags: callOptions?.tags?.(),
+        })
+
+        const result = await (async () => {
+          try {
+            return await event.next({ context: { [key]: execution } as StartContext<Key> })
+          } catch (error) {
+            if (close) await execution.close({ ok: false, error })
+            throw error
+          }
+        })()
+
+        if (close) await execution.close({ ok: true })
+        return result
       })
-
-      const result = await (async () => {
-        try {
-          return await event.next({ context: { [key]: execution } as StartContext<Key> })
-        } catch (error) {
-          if (close) await execution.close({ ok: false, error })
-          throw error
-        }
-      })()
-
-      if (close) await execution.close({ ok: true })
-      return result
-    })
   }
 
   function handler<
@@ -151,7 +160,8 @@ export namespace tanstackStart {
   export type Context<Key extends string = typeof contextKey> = StartContext<Key>
   export type KeyOptions<Key extends string = typeof contextKey> = StartKeyOptions<Key>
   export type RequestOptions = StartRequestOptions
-  export type CallOptions = StartCallOptions
+  export type CallOptions<TMiddlewares extends readonly StartMiddleware[] = readonly []> =
+    StartCallOptions<TMiddlewares>
   export type HandlerEvent<
     Input,
     Key extends string = typeof contextKey,

--- a/pkg/framework/tanstack-start/src/index.ts
+++ b/pkg/framework/tanstack-start/src/index.ts
@@ -9,8 +9,8 @@ type StartMiddleware =
 
 type StartContext<Key extends string = typeof contextKey> = Record<Key, Lite.ExecutionContext>
 
-interface StartKeyOptions<Key extends string = typeof contextKey> {
-  key?: Key
+interface StartKeyOptions<Key extends string = string> {
+  key: Key
 }
 
 interface StartRequestOptions {
@@ -58,10 +58,14 @@ interface StartAdapter<Key extends string = typeof contextKey> {
   ): (event: StartHandlerEvent<Input, Key>) => Promise<Output>
 }
 
-function adapter<Key extends string = typeof contextKey>(
-  options?: StartKeyOptions<Key>
-): StartAdapter<Key> {
-  const key = (options?.key ?? contextKey) as Key
+function adapter(): StartAdapter
+function adapter<const Key extends string>(options: StartKeyOptions<Key>): StartAdapter<Key>
+function adapter<const Key extends string>(options?: StartKeyOptions<Key>) {
+  if (options) return bindAdapter(options.key)
+  return bindAdapter(contextKey)
+}
+
+function bindAdapter<const Key extends string>(key: Key): StartAdapter<Key> & Lite.Extension {
   let scope: Lite.Scope
 
   function request(requestOptions?: StartRequestOptions) {
@@ -141,7 +145,7 @@ function adapter<Key extends string = typeof contextKey>(
       } as Lite.ExecFlowOptions<Output, Input>)
   }
 
-  const extension = {
+  return {
     name: "@pumped-fn/lite-tanstack-start",
     init(nextScope: Lite.Scope) {
       scope = nextScope
@@ -150,15 +154,13 @@ function adapter<Key extends string = typeof contextKey>(
     call,
     handler,
   }
-
-  return extension
 }
 
 export const tanstackStart = { contextKey, adapter } as const
 
 export namespace tanstackStart {
   export type Context<Key extends string = typeof contextKey> = StartContext<Key>
-  export type KeyOptions<Key extends string = typeof contextKey> = StartKeyOptions<Key>
+  export type KeyOptions<Key extends string = string> = StartKeyOptions<Key>
   export type RequestOptions = StartRequestOptions
   export type CallOptions<TMiddlewares extends readonly StartMiddleware[] = readonly []> =
     StartCallOptions<TMiddlewares>

--- a/pkg/framework/tanstack-start/tests/stress.test.ts
+++ b/pkg/framework/tanstack-start/tests/stress.test.ts
@@ -172,8 +172,9 @@ describe("anti-pattern guardrails", () => {
     ].map((path) => [path, readFileSync(resolve(root, path), "utf8")] as const)
     const forbidden = [
       ["top-level generic export", /^export (?:const|function|interface|type) (?:contextKey|adapter|KeyOptions|Context|RequestOptions|CallOptions|HandlerEvent|Adapter)\b/m],
+      ["exported scope", /\bexport\s+const\s+scope\b/],
       ["scope parameter helper", /\b(?:request|call|get|exec|handler)\s*\(\s*scope\b/],
-      ["context parameter helper", /\b(?:get|exec)\s*\(\s*context\b/],
+      ["context parameter helper", /\b(?:get|exec|tags)\s*\(\s*(?:parent|context)\b/],
       ["ambient tag read", new RegExp(`\\.data\\.${["seek", "Tag"].join("")}\\s*\\(`)],
       ["ambient data read", /\.data\.(?:get|seek)\s*\(/],
     ] as const

--- a/pkg/framework/tanstack-start/tests/stress.test.ts
+++ b/pkg/framework/tanstack-start/tests/stress.test.ts
@@ -1,0 +1,187 @@
+import { readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { createScope, flow, resource, tag, tags, typed } from "@pumped-fn/lite"
+import { describe, expect, it } from "vitest"
+import { tanstackStart } from "../src/index"
+
+const requestId = tag<string>({ label: "stress.request.id" })
+const tenantId = tag<string>({ label: "stress.tenant.id" })
+const operation = tag<string>({ label: "stress.operation" })
+
+describe("stress integration", () => {
+  it("keeps request and function values explicit through deps", async () => {
+    const cleanups: string[] = []
+    const audit = resource({
+      name: "stress.audit",
+      ownership: "current",
+      deps: {
+        requestId: tags.required(requestId),
+        tenantId: tags.required(tenantId),
+        operation: tags.required(operation),
+      },
+      factory: (ctx, deps) => {
+        const entries: string[] = []
+        ctx.cleanup(() => {
+          cleanups.push(`${deps.tenantId}:${deps.requestId}:${deps.operation}:${entries.length}`)
+        })
+        return {
+          record: (event: string) => {
+            entries.push(`${deps.tenantId}:${deps.requestId}:${deps.operation}:${event}`)
+          },
+          snapshot: () => [...entries],
+        }
+      },
+    })
+    const confirm = flow({
+      name: "stress.confirm",
+      deps: { audit },
+      factory: (_ctx, deps) => {
+        deps.audit.record("confirm")
+        return deps.audit.snapshot()
+      },
+    })
+    const checkout = flow({
+      name: "stress.checkout",
+      parse: typed<{ sku: string; quantity: number }>(),
+      deps: {
+        requestId: tags.required(requestId),
+        tenantId: tags.required(tenantId),
+        operation: tags.required(operation),
+        audit,
+      },
+      factory: async (ctx, deps) => {
+        deps.audit.record(`checkout:${ctx.input.sku}:${ctx.input.quantity}`)
+        return {
+          requestId: deps.requestId,
+          tenantId: deps.tenantId,
+          operation: deps.operation,
+          confirmation: await ctx.exec({ flow: confirm }),
+          events: deps.audit.snapshot(),
+        }
+      },
+    })
+    const lite = tanstackStart.adapter()
+    const scope = createScope({ extensions: [lite] })
+    const closed: string[] = []
+    const incoming = new Request("https://example.test/orders", {
+      headers: {
+        "x-request-id": "req-a",
+        "x-tenant-id": "tenant-a",
+      },
+    })
+    const withRequest = lite.request({
+      tags: (request) => [
+        requestId(request.headers.get("x-request-id") ?? "missing"),
+        tenantId(request.headers.get("x-tenant-id") ?? "missing"),
+      ],
+    })
+    const withCall = lite.call({
+      tags: () => [operation("POST:/orders")],
+    })
+    const handleCheckout = lite.handler(checkout)
+    const controller = new AbortController()
+    let output!: Awaited<ReturnType<typeof handleCheckout>>
+
+    expect(Object.keys(audit.deps ?? {}).sort()).toEqual(["operation", "requestId", "tenantId"])
+    expect(Object.keys(checkout.deps ?? {}).sort()).toEqual([
+      "audit",
+      "operation",
+      "requestId",
+      "tenantId",
+    ])
+
+    const result = await withRequest.options.server!({
+      request: incoming,
+      pathname: "/orders",
+      context: {},
+      handlerType: "router",
+      next: async (requestOptions: { context: tanstackStart.Context }) => {
+        requestOptions.context.lite.onClose((closeResult) => {
+          closed.push(closeResult.ok ? "request:ok" : "request:error")
+        })
+        await withCall.options.server!({
+          data: { sku: "sku-a", quantity: 2 },
+          context: requestOptions.context,
+          method: "POST",
+          serverFnMeta: {
+            id: "checkout",
+            name: "checkout",
+            filename: "src/routes/orders.tsx",
+          },
+          signal: controller.signal,
+          next: async (callOptions: { context: tanstackStart.Context }) => {
+            callOptions.context.lite.onClose((closeResult) => {
+              closed.push(closeResult.ok ? "call:ok" : "call:error")
+            })
+            output = await handleCheckout({
+              data: { sku: "sku-a", quantity: 2 },
+              context: callOptions.context,
+            })
+            return {
+              "use functions must return the result of next()": true,
+              "~types": {
+                context: callOptions.context,
+                sendContext: undefined,
+              },
+              context: callOptions.context,
+              sendContext: undefined,
+            }
+          },
+        } as unknown as Parameters<NonNullable<typeof withCall.options.server>>[0])
+
+        return {
+          request: incoming,
+          pathname: "/orders",
+          context: requestOptions.context,
+          response: Response.json(output),
+        }
+      },
+    } as unknown as Parameters<NonNullable<typeof withRequest.options.server>>[0])
+
+    if (result instanceof Response) throw new Error("expected TanStack request result")
+
+    expect(await result.response.json()).toEqual({
+      requestId: "req-a",
+      tenantId: "tenant-a",
+      operation: "POST:/orders",
+      confirmation: [
+        "tenant-a:req-a:POST:/orders:checkout:sku-a:2",
+        "tenant-a:req-a:POST:/orders:confirm",
+      ],
+      events: [
+        "tenant-a:req-a:POST:/orders:checkout:sku-a:2",
+        "tenant-a:req-a:POST:/orders:confirm",
+      ],
+    })
+    expect(cleanups).toEqual(["tenant-a:req-a:POST:/orders:2"])
+    expect(closed).toEqual(["call:ok", "request:ok"])
+    await scope.dispose()
+  })
+})
+
+describe("anti-pattern guardrails", () => {
+  it("keeps adapter package surfaces free of implicit external reads", () => {
+    const root = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+    const files = [
+      "src/index.ts",
+      "README.md",
+      "tests/tanstack-start.test.ts",
+      "tests/stress.test.ts",
+      "tests/type-contracts.ts",
+    ].map((path) => [path, readFileSync(resolve(root, path), "utf8")] as const)
+    const forbidden = [
+      ["top-level generic export", /^export (?:const|function|interface|type) (?:contextKey|adapter|KeyOptions|Context|RequestOptions|CallOptions|HandlerEvent|Adapter)\b/m],
+      ["scope parameter helper", /\b(?:request|call|get|exec|handler)\s*\(\s*scope\b/],
+      ["context parameter helper", /\b(?:get|exec)\s*\(\s*context\b/],
+      ["ambient tag read", new RegExp(`\\.data\\.${["seek", "Tag"].join("")}\\s*\\(`)],
+      ["ambient data read", /\.data\.(?:get|seek)\s*\(/],
+    ] as const
+
+    for (const [path, source] of files) {
+      for (const [name, pattern] of forbidden) {
+        expect(source, `${path} contains ${name}`).not.toMatch(pattern)
+      }
+    }
+  })
+})

--- a/pkg/framework/tanstack-start/tests/tanstack-start.test.ts
+++ b/pkg/framework/tanstack-start/tests/tanstack-start.test.ts
@@ -107,6 +107,14 @@ describe("TanStack Start helpers", () => {
     await scope.dispose()
   })
 
+  it("lets function middleware carry request middleware through TanStack composition", async () => {
+    const lite = tanstackStart.adapter()
+    const withRequest = lite.request()
+    const withCall = lite.call({ middleware: [withRequest] })
+
+    expect(withCall.options.middleware).toEqual([withRequest])
+  })
+
   it("runs flows from server-function handlers and escape hatches", async () => {
     const lite = tanstackStart.adapter()
     const scope = createScope({ extensions: [lite] })

--- a/pkg/framework/tanstack-start/tests/tanstack-start.test.ts
+++ b/pkg/framework/tanstack-start/tests/tanstack-start.test.ts
@@ -1,0 +1,123 @@
+import { createScope, flow, tag, tags, typed } from "@pumped-fn/lite"
+import { describe, expect, it } from "vitest"
+import { tanstackStart } from "../src/index"
+
+const requestId = tag<string>({ label: "request.id" })
+
+const readRequest = flow({
+  deps: { requestId: tags.required(requestId) },
+  factory: (_ctx, deps) => deps.requestId,
+})
+
+const echo = flow({
+  parse: typed<{ message: string }>(),
+  deps: { requestId: tags.required(requestId) },
+  factory: (ctx, deps) => ({
+    message: ctx.input.message,
+    requestId: deps.requestId,
+  }),
+})
+
+describe("TanStack Start helpers", () => {
+  it("creates a request execution context through request middleware", async () => {
+    const lite = tanstackStart.adapter()
+    const scope = createScope({ extensions: [lite] })
+    const closed: string[] = []
+    const incoming = new Request("https://example.test/users", {
+      headers: { "x-request-id": "request-a" },
+    })
+    const withRequest = lite.request({
+      tags: (request) => [requestId(request.headers.get("x-request-id") ?? "missing")],
+    })
+
+    const result = await withRequest.options.server!({
+      request: incoming,
+      pathname: "/users",
+      context: {},
+      handlerType: "router",
+      next: async (options: { context: tanstackStart.Context }) => {
+        const { context } = options
+        const execution = context.lite
+        execution.onClose((result) => {
+          closed.push(result.ok ? "ok" : "error")
+        })
+
+        return {
+          request: incoming,
+          pathname: "/users",
+          context,
+          response: new Response(await execution.exec({ flow: readRequest })),
+        }
+      },
+    } as unknown as Parameters<NonNullable<typeof withRequest.options.server>>[0])
+
+    if (result instanceof Response) throw new Error("expected TanStack request result")
+
+    expect(await result.response.text()).toBe("request-a")
+    expect(closed).toEqual(["ok"])
+    await scope.dispose()
+  })
+
+  it("creates a child execution context through function middleware", async () => {
+    const lite = tanstackStart.adapter()
+    const scope = createScope({ extensions: [lite] })
+    const parent = scope.createContext({ tags: [requestId("parent")] })
+    const closed: string[] = []
+    let childRequestId = ""
+    let parentRequestId: unknown
+    const controller = new AbortController()
+    const withCall = lite.call({
+      tags: () => [requestId("child")],
+    })
+
+    await withCall.options.server!({
+      data: undefined,
+      context: { lite: parent },
+      method: "POST",
+      serverFnMeta: {
+        id: "server-fn",
+        name: "serverFn",
+        filename: "src/routes/index.tsx",
+      },
+      signal: controller.signal,
+      next: async (options: { context: tanstackStart.Context }) => {
+        const { context } = options
+        const execution = context.lite
+        execution.onClose((result) => {
+          closed.push(result.ok ? "ok" : "error")
+        })
+        childRequestId = await execution.exec({ flow: readRequest })
+        parentRequestId = await execution.parent!.exec({ flow: readRequest })
+
+        return {
+          "use functions must return the result of next()": true,
+          "~types": {
+            context,
+            sendContext: undefined,
+          },
+          context,
+          sendContext: undefined,
+        }
+      },
+    } as unknown as Parameters<NonNullable<typeof withCall.options.server>>[0])
+
+    expect(childRequestId).toBe("child")
+    expect(parentRequestId).toBe("parent")
+    expect(closed).toEqual(["ok"])
+    await scope.dispose()
+  })
+
+  it("runs flows from server-function handlers and escape hatches", async () => {
+    const lite = tanstackStart.adapter()
+    const scope = createScope({ extensions: [lite] })
+    const context = { lite: scope.createContext({ tags: [requestId("handler")] }) }
+    const handleEcho = lite.handler(echo)
+
+    expect(await handleEcho({ data: { message: "hello" }, context })).toEqual({
+      message: "hello",
+      requestId: "handler",
+    })
+    expect(await context.lite.exec({ flow: readRequest, tags: [requestId("override")] })).toBe("override")
+    await scope.dispose()
+  })
+})

--- a/pkg/framework/tanstack-start/tests/type-contracts.ts
+++ b/pkg/framework/tanstack-start/tests/type-contracts.ts
@@ -1,0 +1,37 @@
+import { createServerFn } from "@tanstack/react-start"
+import { createScope, flow, typed, type Lite } from "@pumped-fn/lite"
+import { tanstackStart } from "../src/index"
+// @ts-expect-error adapter is contextualized under the tanstackStart namespace
+import { adapter } from "../src/index"
+
+const lite = tanstackStart.adapter()
+const scope = createScope({ extensions: [lite] })
+const echo = flow({
+  parse: typed<{ message: string }>(),
+  factory: (ctx) => ({ message: ctx.input.message }),
+})
+
+const req = lite.request()
+const serverFn = lite.call()
+const echoFn = createServerFn({ method: "POST" })
+  .middleware([req, serverFn])
+  .validator((input: { message: string }) => input)
+  .handler(lite.handler(echo))
+
+const result: Promise<{ message: string }> = echoFn({ data: { message: "ok" } })
+void result
+
+const context: tanstackStart.Context = { lite: scope.createContext() }
+const execution: Lite.ExecutionContext = context.lite
+void execution
+
+lite.handler(echo)({ data: { message: "ok" }, context })
+
+// @ts-expect-error server function input is checked by the validator
+echoFn({ data: { id: "bad" } })
+
+// @ts-expect-error flow handler input must match the Lite flow input
+lite.handler(echo)({ data: { id: "bad" }, context })
+
+// @ts-expect-error a Start context must carry the Lite execution context key
+lite.handler(echo)({ data: { message: "ok" }, context: {} })

--- a/pkg/framework/tanstack-start/tests/type-contracts.ts
+++ b/pkg/framework/tanstack-start/tests/type-contracts.ts
@@ -15,7 +15,7 @@ const req = lite.request()
 const serverFn = lite.call()
 const echoFn = createServerFn({ method: "POST" })
   .middleware([req, serverFn])
-  .validator((input: { message: string }) => input)
+  .inputValidator((input: { message: string }) => input)
   .handler(lite.handler(echo))
 
 const result: Promise<{ message: string }> = echoFn({ data: { message: "ok" } })

--- a/pkg/framework/tanstack-start/tests/type-contracts.ts
+++ b/pkg/framework/tanstack-start/tests/type-contracts.ts
@@ -35,3 +35,12 @@ lite.handler(echo)({ data: { id: "bad" }, context })
 
 // @ts-expect-error a Start context must carry the Lite execution context key
 lite.handler(echo)({ data: { message: "ok" }, context: {} })
+
+const liteCtx = tanstackStart.adapter({ key: "ctx" })
+const customScope = createScope({ extensions: [liteCtx] })
+const customContext: tanstackStart.Context<"ctx"> = { ctx: customScope.createContext() }
+const customExecution: Lite.ExecutionContext = customContext.ctx
+void customExecution
+
+// @ts-expect-error custom context keys must be provided as runtime options
+tanstackStart.adapter<"ctx">()

--- a/pkg/framework/tanstack-start/tests/type-contracts.ts
+++ b/pkg/framework/tanstack-start/tests/type-contracts.ts
@@ -12,10 +12,10 @@ const echo = flow({
 })
 
 const req = lite.request()
-const serverFn = lite.call()
+const serverFn = lite.call({ middleware: [req] })
 const echoFn = createServerFn({ method: "POST" })
-  .middleware([req, serverFn])
-  .inputValidator((input: { message: string }) => input)
+  .middleware([serverFn])
+  .validator((input: { message: string }) => input)
   .handler(lite.handler(echo))
 
 const result: Promise<{ message: string }> = echoFn({ data: { message: "ok" } })

--- a/pkg/framework/tanstack-start/tsconfig.json
+++ b/pkg/framework/tanstack-start/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "../..",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
+    "paths": {
+      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pkg/framework/tanstack-start/tsconfig.test.json
+++ b/pkg/framework/tanstack-start/tsconfig.test.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/pkg/framework/tanstack-start/tsdown.config.ts
+++ b/pkg/framework/tanstack-start/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  format: ["cjs", "esm"],
+  clean: true,
+})

--- a/pkg/framework/tanstack-start/vitest.config.ts
+++ b/pkg/framework/tanstack-start/vitest.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from "node:path"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+  resolve: {
+    alias: {
+      "@pumped-fn/lite": resolve(__dirname, "../../core/lite/src/index.ts"),
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@opentelemetry/api':
       specifier: 1.9.1
       version: 1.9.1
+    '@tanstack/react-router':
+      specifier: 1.170.16
+      version: 1.170.16
     '@tanstack/react-start':
       specifier: 1.168.26
       version: 1.168.26
@@ -364,6 +367,9 @@ importers:
       '@pumped-fn/lite-tanstack-start':
         specifier: workspace:*
         version: link:../../pkg/framework/tanstack-start
+      '@tanstack/react-router':
+        specifier: 'catalog:'
+        version: 1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/react-start':
         specifier: 'catalog:'
         version: 1.168.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -2476,8 +2482,8 @@ packages:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
-  isbot@5.1.44:
-    resolution: {integrity: sha512-PGEHtwMnKbZpeSEXW2Utx+/JWed7dp6DiH0WWg33vGSDA7RUvpUeJSVlLrVkQ1RCpvDOUc/eH9ql7VsdbBZ8pA==}
+  isbot@5.1.43:
+    resolution: {integrity: sha512-drJhFmibra4LO6Wd7D3Oi6UICRK9244vSZkmxzhlZP0TTdwCA2ueK4PEkUkzPYeuqug9+cqqdWPgihjk5+83Cg==}
     engines: {node: '>=18'}
 
   isexe@2.0.0:
@@ -3126,6 +3132,11 @@ packages:
 
   sql.js@1.14.1:
     resolution: {integrity: sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==}
+
+  srvx@0.11.16:
+    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
 
   srvx@0.11.17:
     resolution: {integrity: sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw==}
@@ -4329,7 +4340,7 @@ snapshots:
       '@tanstack/history': 1.162.0
       '@tanstack/react-store': 0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tanstack/router-core': 1.171.13
-      isbot: 5.1.44
+      isbot: 5.1.43
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -5095,7 +5106,7 @@ snapshots:
   h3@2.0.1-rc.20:
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.17
+      srvx: 0.11.16
 
   happy-dom@20.9.0:
     dependencies:
@@ -5172,7 +5183,7 @@ snapshots:
 
   is-windows@1.0.2: {}
 
-  isbot@5.1.44: {}
+  isbot@5.1.43: {}
 
   isexe@2.0.0: {}
 
@@ -5794,6 +5805,8 @@ snapshots:
   sprintf-js@1.1.3: {}
 
   sql.js@1.14.1: {}
+
+  srvx@0.11.16: {}
 
   srvx@0.11.17: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@opentelemetry/api':
       specifier: 1.9.1
       version: 1.9.1
+    '@tanstack/react-start':
+      specifier: 1.168.26
+      version: 1.168.26
     '@testing-library/jest-dom':
       specifier: 6.9.1
       version: 6.9.1
@@ -57,6 +60,9 @@ catalogs:
     github-actionlint:
       specifier: 1.7.12
       version: 1.7.12
+    hono:
+      specifier: 4.12.27
+      version: 4.12.27
     jscodeshift:
       specifier: 17.3.0
       version: 17.3.0
@@ -154,7 +160,7 @@ importers:
         version: 19.2.15
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
       playwright:
         specifier: 'catalog:'
         version: 1.61.0
@@ -169,7 +175,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   examples/agent-practical:
     dependencies:
@@ -203,10 +209,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   examples/lite-bff-practical:
     dependencies:
@@ -228,10 +234,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   examples/lite-practical:
     dependencies:
@@ -259,7 +265,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   examples/lite-react-practical:
     dependencies:
@@ -299,7 +305,7 @@ importers:
         version: 7.0.0-dev.20260526.1
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
@@ -317,10 +323,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/agent/bash:
     dependencies:
@@ -348,10 +354,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/agent/claude:
     devDependencies:
@@ -375,10 +381,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/agent/codex:
     devDependencies:
@@ -402,10 +408,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/agent/core:
     dependencies:
@@ -430,10 +436,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/agent/test:
     dependencies:
@@ -461,10 +467,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/core/lite:
     devDependencies:
@@ -485,10 +491,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/ext/hmr:
     dependencies:
@@ -516,10 +522,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/ext/logging:
     devDependencies:
@@ -537,10 +543,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/ext/logging-pino:
     devDependencies:
@@ -564,10 +570,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/ext/observable:
     devDependencies:
@@ -585,10 +591,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/ext/observable-otel:
     devDependencies:
@@ -612,10 +618,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/ext/suspense:
     devDependencies:
@@ -636,16 +642,70 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  pkg/framework/hono:
+    devDependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../core/lite
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      hono:
+        specifier: 'catalog:'
+        version: 4.12.27
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  pkg/framework/tanstack-start:
+    devDependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../core/lite
+      '@tanstack/react-start':
+        specifier: 'catalog:'
+        version: 1.168.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/react/json:
     dependencies:
       '@json-render/core':
         specifier: 'catalog:'
-        version: 0.19.0(zod@4.3.6)
+        version: 0.19.0(zod@4.4.3)
     devDependencies:
       '@pumped-fn/lite':
         specifier: workspace:*
@@ -667,10 +727,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/react/lite-react:
     devDependencies:
@@ -691,7 +751,7 @@ importers:
         version: 19.2.15
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
@@ -712,10 +772,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/render/core:
     devDependencies:
@@ -730,10 +790,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/render/react:
     dependencies:
@@ -761,7 +821,7 @@ importers:
         version: 19.2.15
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
       playwright:
         specifier: 'catalog:'
         version: 1.61.0
@@ -779,10 +839,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/tool/codemod:
     dependencies:
@@ -804,10 +864,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/tool/lint:
     dependencies:
@@ -826,7 +886,7 @@ importers:
         version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
 packages:
 
@@ -847,6 +907,10 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.27.1':
+    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1428,6 +1492,22 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oozcitak/dom@2.0.2':
+    resolution: {integrity: sha512-GjpKhkSYC3Mj4+lfwEyI1dqnsKTgwGy48ytZEhm4A/xnH/8z9M3ZVXKr/YGQi3uCLs1AEBS+x5T2JPiueEDW8w==}
+    engines: {node: '>=20.0'}
+
+  '@oozcitak/infra@2.0.2':
+    resolution: {integrity: sha512-2g+E7hoE2dgCz/APPOEK5s3rMhJvNxSMBrP+U+j1OWsIbtSpWxxlUjq1lU8RIsFJNYv7NMlnVsCuHcUzJW+8vA==}
+    engines: {node: '>=20.0'}
+
+  '@oozcitak/url@3.0.0':
+    resolution: {integrity: sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ==}
+    engines: {node: '>=20.0'}
+
+  '@oozcitak/util@10.0.0':
+    resolution: {integrity: sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA==}
+    engines: {node: '>=20.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
@@ -1544,6 +1624,139 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/react-router@1.170.16':
+    resolution: {integrity: sha512-w6eq1IJklujs1tESazaK/FxH0+H2l8vm/QPuu1cD3oRW/ubgKneQpd7b64ti/8gUyEimzimJQZDmJr6YHfP5+g==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-start-client@1.168.14':
+    resolution: {integrity: sha512-oaz43fdOhBWfOPsdLkp3IejwYEXRyeaZ4CYexOPZx3eVXzm4LLozvNkkkBE9aje1sM5MVC2Yo6+cyv2HdVzkHQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-start-rsc@0.1.25':
+    resolution: {integrity: sha512-Rwm6cjcS148y2XAebr8jyrwU0SqsRSkW4/CuXesoHg+G3IOnVRHV0HOylJfnznUTVuH1nVhfQRPI5uWPJaw2TA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@rspack/core': '>=2.0.0-0'
+      '@vitejs/plugin-rsc': '>=0.5.20'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      react-server-dom-rspack: '>=0.0.2'
+    peerDependenciesMeta:
+      '@rspack/core':
+        optional: true
+      '@vitejs/plugin-rsc':
+        optional: true
+      react-server-dom-rspack:
+        optional: true
+
+  '@tanstack/react-start-server@1.167.20':
+    resolution: {integrity: sha512-hg9xVI6yNDu+6NCalKz1h3Ea18HZEUu35i/ZMJz1WadwqcArLMp41nM1GNhOAtGIdpycrp9tT7ccqc9zuRMRpQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-start@1.168.26':
+    resolution: {integrity: sha512-ZzNecqKWC0p2643/kIcFUdsMrXZ8A4dXm4Yfe9zV/Y0u14MtSkh/Sk76RQYIU5S84VyDyKhHo0Ffh8HQbLdvFw==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+      '@vitejs/plugin-rsc': '*'
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+      vite: '>=7.0.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      '@vitejs/plugin-rsc':
+        optional: true
+      vite:
+        optional: true
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.13':
+    resolution: {integrity: sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/router-generator@1.167.17':
+    resolution: {integrity: sha512-xtB9tB2Ws0tWR6Pi7nc3Qk9IYgoh1mQCKWjHqIl9tf6BNUpKoqniJoPAQ4+LGrK8FeZYU0o0p/qlZEyj9FAulA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/router-plugin@1.168.18':
+    resolution: {integrity: sha512-MofS28/axfnfnhOD2RSgJEaU882aX5RsAzhGz5Vc4XhAmvCjy919u9JrNs4QsTWFbTD1P7IJ8WFlFVsrg0pStg==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@rsbuild/core': '>=1.0.2 || ^2.0.0'
+      '@tanstack/react-router': ^1.170.15
+      vite: '>=5.0.0 || >=6.0.0 || >=7.0.0 || >=8.0.0'
+      vite-plugin-solid: ^2.11.10 || ^3.0.0-0
+      webpack: '>=5.92.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      '@tanstack/react-router':
+        optional: true
+      vite:
+        optional: true
+      vite-plugin-solid:
+        optional: true
+      webpack:
+        optional: true
+
+  '@tanstack/router-utils@1.162.2':
+    resolution: {integrity: sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/start-client-core@1.170.12':
+    resolution: {integrity: sha512-gwtZRMPUIAxmDV2AIQUhC0kSW262SV7BkHXEgy5B1woHQdrdsELuGOdJwdweLxrjyefORxk+9MYGqDY0Cxn0bw==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/start-fn-stubs@1.162.0':
+    resolution: {integrity: sha512-QWfUZ3Yo923tdQn38LyKMU8rcTw69zc+T4dAvgTWV4O56SqFRsGfS0lSWIMhJRwXIx/bvdi7nTUBDdZtTHtpTQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/start-plugin-core@1.171.18':
+    resolution: {integrity: sha512-weuOOjRD03BiKcF9NYKL5QADEQOp3yGHb0qIsOX42ENz5XUE4in2fXcVYHjSwwpzs+XGhWIFLp5J385pOVPuZQ==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@rsbuild/core': ^2.0.0
+      vite: '>=7.0.0'
+    peerDependenciesMeta:
+      '@rsbuild/core':
+        optional: true
+      vite:
+        optional: true
+
+  '@tanstack/start-server-core@1.169.15':
+    resolution: {integrity: sha512-V8ie2G2Ecb3Nklk8/QuKzulxb+tDUqgz6rjJe8Isdp4iKVXZu/TscItkUP/4Q5Bu7W4gUy3P25O6soC1oW1SXQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/start-storage-context@1.167.15':
+    resolution: {integrity: sha512-Jy0q4vdG6pv76N92+X+ag3fuOV2zINQagYyMN1/es7tPI1vzpKECIU8AqHqzI6ahkwaph7XDvmfUkiLJ3i4LOA==}
+    engines: {node: '>=22.12.0'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/virtual-file-routes@1.162.0':
+    resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
+    engines: {node: '>=20.19'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -1773,6 +1986,9 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  babel-dead-code-elimination@1.0.12:
+    resolution: {integrity: sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1831,6 +2047,10 @@ packages:
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
 
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -1851,6 +2071,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1985,6 +2208,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  exsolve@1.1.0:
+    resolution: {integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -2010,6 +2236,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetchdts@0.1.7:
+    resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
   file-type@21.3.4:
     resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
@@ -2083,6 +2312,16 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  h3@2.0.1-rc.20:
+    resolution: {integrity: sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
+
   happy-dom@20.9.0:
     resolution: {integrity: sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==}
     engines: {node: '>=20.0.0'}
@@ -2090,6 +2329,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
@@ -2168,6 +2411,10 @@ packages:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
 
+  isbot@5.1.44:
+    resolution: {integrity: sha512-PGEHtwMnKbZpeSEXW2Utx+/JWed7dp6DiH0WWg33vGSDA7RUvpUeJSVlLrVkQ1RCpvDOUc/eH9ql7VsdbBZ8pA==}
+    engines: {node: '>=18'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2186,6 +2433,10 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -2570,6 +2821,11 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  prettier@3.8.4:
+    resolution: {integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -2630,6 +2886,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
@@ -2684,6 +2944,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rou3@0.8.1:
+    resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2720,6 +2983,16 @@ packages:
     resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
 
   shallow-clone@3.0.1:
     resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
@@ -2772,6 +3045,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -2784,6 +3061,11 @@ packages:
 
   sql.js@1.14.1:
     resolution: {integrity: sha512-gcj8zBWU5cFsi9WUP+4bFNXAyF1iRpA3LLyS/DP5xlrNzGmPIizUeBggKa8DbDwdqaKwUcTEnChtd2grWo/x/A==}
+
+  srvx@0.11.17:
+    resolution: {integrity: sha512-43yM4luKfCJamyCMhrUeHUPOrf8TdZe7kN8s5zayZCH5OeprYqi49Aso5ZvHXR4aB+DHaRNO/diNFgZSMNG8Xw==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -2953,6 +3235,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   uint8array-extras@1.5.0:
     resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
     engines: {node: '>=18'}
@@ -2971,6 +3256,10 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
+  unplugin@3.0.0:
+    resolution: {integrity: sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   unrun@0.3.1:
     resolution: {integrity: sha512-onIck/oNnCaytwths1ZVp1LK2Gq2hPoyFhiHebObuUXqR3S0uHuLLaBK8K6mRRgV7Ptip8AnNvaUsgzwWwBZuA==}
     engines: {node: ^22.13.0 || >=24.0.0}
@@ -2986,6 +3275,11 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -3031,6 +3325,14 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
         optional: true
 
   vitest@4.1.8:
@@ -3085,6 +3387,9 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
+  webpack-virtual-modules@0.6.2:
+    resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
     engines: {node: '>=12'}
@@ -3137,6 +3442,10 @@ packages:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
 
+  xmlbuilder2@4.0.3:
+    resolution: {integrity: sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA==}
+    engines: {node: '>=20.0'}
+
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
@@ -3154,6 +3463,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -3182,6 +3494,12 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9':
     optional: true
+
+  '@babel/code-frame@7.27.1':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -3801,6 +4119,10 @@ snapshots:
     dependencies:
       zod: 4.3.6
 
+  '@json-render/core@0.19.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
   '@json-render/react@0.19.0(react@19.2.6)(zod@4.3.6)':
     dependencies:
       '@json-render/core': 0.19.0(zod@4.3.6)
@@ -3852,6 +4174,23 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@oozcitak/dom@2.0.2':
+    dependencies:
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/url': 3.0.0
+      '@oozcitak/util': 10.0.0
+
+  '@oozcitak/infra@2.0.2':
+    dependencies:
+      '@oozcitak/util': 10.0.0
+
+  '@oozcitak/url@3.0.0':
+    dependencies:
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/util': 10.0.0
+
+  '@oozcitak/util@10.0.0': {}
 
   '@opentelemetry/api@1.9.1': {}
 
@@ -3917,6 +4256,196 @@ snapshots:
   '@rolldown/pluginutils@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tanstack/history@1.162.0': {}
+
+  '@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-core': 1.171.13
+      isbot: 5.1.44
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/react-start-client@1.168.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/start-client-core': 1.170.12
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@tanstack/react-start-rsc@0.1.25(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/start-fn-stubs': 1.162.0
+      '@tanstack/start-plugin-core': 1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@tanstack/start-server-core': 1.169.15
+      '@tanstack/start-storage-context': 1.167.15
+      pathe: 2.0.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - crossws
+      - supports-color
+      - vite
+      - vite-plugin-solid
+      - webpack
+
+  '@tanstack/react-start-server@1.167.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/start-server-core': 1.169.15
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    transitivePeerDependencies:
+      - crossws
+
+  '@tanstack/react-start@1.168.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-start-client': 1.168.14(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/react-start-rsc': 0.1.25(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@tanstack/react-start-server': 1.167.20(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/start-plugin-core': 1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@tanstack/start-server-core': 1.169.15
+      pathe: 2.0.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - crossws
+      - react-server-dom-rspack
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      use-sync-external-store: 1.6.0(react@19.2.6)
+
+  '@tanstack/router-core@1.171.13':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/router-generator@1.167.17':
+    dependencies:
+      '@babel/types': 7.29.7
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/virtual-file-routes': 1.162.0
+      jiti: 2.7.0
+      magic-string: 0.30.21
+      prettier: 3.8.4
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/router-plugin@1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-generator': 1.167.17
+      '@tanstack/router-utils': 1.162.2
+      chokidar: 5.0.0
+      unplugin: 3.0.0
+      zod: 4.4.3
+    optionalDependencies:
+      '@tanstack/react-router': 1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/router-utils@1.162.2':
+    dependencies:
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      ansis: 4.3.0
+      babel-dead-code-elimination: 1.0.12
+      diff: 8.0.4
+      pathe: 2.0.3
+      tinyglobby: 0.2.17
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tanstack/start-client-core@1.170.12':
+    dependencies:
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/start-fn-stubs': 1.162.0
+      '@tanstack/start-storage-context': 1.167.15
+      seroval: 1.5.4
+
+  '@tanstack/start-fn-stubs@1.162.0': {}
+
+  '@tanstack/start-plugin-core@1.171.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.29.7
+      '@babel/types': 7.29.7
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/router-generator': 1.167.17
+      '@tanstack/router-plugin': 1.168.18(@tanstack/react-router@1.170.16(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@tanstack/router-utils': 1.162.2
+      '@tanstack/start-server-core': 1.169.15
+      exsolve: 1.1.0
+      lightningcss: 1.32.0
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      seroval: 1.5.4
+      source-map: 0.7.6
+      srvx: 0.11.17
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      vitefu: 1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      xmlbuilder2: 4.0.3
+      zod: 4.4.3
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@tanstack/react-router'
+      - crossws
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+
+  '@tanstack/start-server-core@1.169.15':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/router-core': 1.171.13
+      '@tanstack/start-client-core': 1.170.12
+      '@tanstack/start-storage-context': 1.167.15
+      fetchdts: 0.1.7
+      h3-v2: h3@2.0.1-rc.20
+      seroval: 1.5.4
+    transitivePeerDependencies:
+      - crossws
+
+  '@tanstack/start-storage-context@1.167.15':
+    dependencies:
+      '@tanstack/router-core': 1.171.13
+
+  '@tanstack/store@0.9.3': {}
+
+  '@tanstack/virtual-file-routes@1.162.0': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -4034,29 +4563,29 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260526.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260526.1
 
-  '@vitest/browser-playwright@4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)':
+  '@vitest/browser-playwright@4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       playwright: 1.61.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)':
+  '@vitest/browser@4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/utils': 4.1.8
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -4076,9 +4605,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
     optionalDependencies:
-      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -4089,13 +4618,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -4165,6 +4694,15 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  babel-dead-code-elimination@1.0.12:
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1:
@@ -4222,6 +4760,10 @@ snapshots:
 
   chardet@2.1.1: {}
 
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
+
   chownr@1.1.4:
     optional: true
 
@@ -4238,6 +4780,8 @@ snapshots:
   commondir@1.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4367,6 +4911,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  exsolve@1.1.0: {}
+
   extendable-error@0.1.7: {}
 
   fast-glob@3.3.3:
@@ -4398,6 +4944,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetchdts@0.1.7: {}
 
   file-type@21.3.4:
     dependencies:
@@ -4479,6 +5027,11 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  h3@2.0.1-rc.20:
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.17
+
   happy-dom@20.9.0:
     dependencies:
       '@types/node': 25.9.1
@@ -4493,6 +5046,8 @@ snapshots:
     optional: true
 
   has-flag@4.0.0: {}
+
+  hono@4.12.27: {}
 
   hookable@6.1.1: {}
 
@@ -4552,6 +5107,8 @@ snapshots:
 
   is-windows@1.0.2: {}
 
+  isbot@5.1.44: {}
+
   isexe@2.0.0: {}
 
   isobject@3.0.1: {}
@@ -4568,6 +5125,8 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  jiti@2.7.0: {}
 
   js-tokens@10.0.0: {}
 
@@ -4939,6 +5498,8 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  prettier@3.8.4: {}
+
   pretty-format@27.5.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5007,6 +5568,8 @@ snapshots:
       util-deprecate: 1.0.2
     optional: true
 
+  readdirp@5.0.0: {}
+
   real-require@0.2.0: {}
 
   real-require@1.0.0: {}
@@ -5071,6 +5634,8 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.2
       '@rolldown/binding-win32-x64-msvc': 1.0.2
 
+  rou3@0.8.1: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -5098,6 +5663,12 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.8.1: {}
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
 
   shallow-clone@3.0.1:
     dependencies:
@@ -5146,6 +5717,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  source-map@0.7.6: {}
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -5156,6 +5729,8 @@ snapshots:
   sprintf-js@1.1.3: {}
 
   sql.js@1.14.1: {}
+
+  srvx@0.11.17: {}
 
   stackback@0.0.2: {}
 
@@ -5321,6 +5896,8 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  ufo@1.6.4: {}
+
   uint8array-extras@1.5.0: {}
 
   unconfig-core@7.5.0:
@@ -5335,6 +5912,12 @@ snapshots:
 
   universalify@0.1.2: {}
 
+  unplugin@3.0.0:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      picomatch: 4.0.4
+      webpack-virtual-modules: 0.6.2
+
   unrun@0.3.1:
     dependencies:
       rolldown: 1.0.2
@@ -5345,10 +5928,14 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
   util-deprecate@1.0.2:
     optional: true
 
-  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0):
+  vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -5359,13 +5946,18 @@ snapshots:
       '@types/node': 25.9.1
       esbuild: 0.28.1
       fsevents: 2.3.3
+      jiti: 2.7.0
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -5382,12 +5974,12 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.1
-      '@vitest/browser-playwright': 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/browser-playwright': 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
       '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       happy-dom: 20.9.0
       jsdom: 29.1.1
@@ -5403,6 +5995,8 @@ snapshots:
 
   webidl-conversions@8.0.1:
     optional: true
+
+  webpack-virtual-modules@0.6.2: {}
 
   whatwg-mimetype@3.0.0:
     optional: true
@@ -5448,6 +6042,13 @@ snapshots:
 
   xml-naming@0.1.0: {}
 
+  xmlbuilder2@4.0.3:
+    dependencies:
+      '@oozcitak/dom': 2.0.2
+      '@oozcitak/infra': 2.0.2
+      '@oozcitak/util': 10.0.0
+      js-yaml: 4.2.0
+
   xmlchars@2.2.0:
     optional: true
 
@@ -5458,5 +6059,7 @@ snapshots:
   yaml@2.9.0: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
 time: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,6 +239,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  examples/lite-hono-todo-practical:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+      '@pumped-fn/lite-hono':
+        specifier: workspace:*
+        version: link:../../pkg/framework/hono
+      hono:
+        specifier: 'catalog:'
+        version: 4.12.27
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
   examples/lite-practical:
     dependencies:
       '@pumped-fn/lite':
@@ -318,6 +346,43 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  examples/lite-tanstack-start-todo-practical:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+      '@pumped-fn/lite-tanstack-start':
+        specifier: workspace:*
+        version: link:../../pkg/framework/tanstack-start
+      '@tanstack/react-start':
+        specifier: 'catalog:'
+        version: 1.168.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,6 +253,9 @@ importers:
       hono:
         specifier: 'catalog:'
         version: 4.12.27
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -379,6 +382,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: 'catalog:'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,7 @@ catalog:
   "@changesets/cli": 2.31.0
   "@json-render/core": 0.19.0
   "@json-render/react": 0.19.0
+  "@tanstack/react-start": 1.168.26
   "@opentelemetry/api": 1.9.1
   "@testing-library/jest-dom": 6.9.1
   "@testing-library/react": 16.3.2
@@ -74,6 +75,7 @@ catalog:
   acorn: 8.16.0
   estree-walker: 3.0.3
   github-actionlint: 1.7.12
+  hono: 4.12.27
   jscodeshift: 17.3.0
   just-bash: 3.0.2
   magic-string: 0.30.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,7 @@ catalog:
   "@changesets/cli": 2.31.0
   "@json-render/core": 0.19.0
   "@json-render/react": 0.19.0
+  "@tanstack/react-router": 1.170.16
   "@tanstack/react-start": 1.168.26
   "@opentelemetry/api": 1.9.1
   "@testing-library/jest-dom": 6.9.1


### PR DESCRIPTION
## Summary

Adds a dedicated framework adapter lane with first-class Hono and TanStack Start packages. The adapters install as Lite extension objects through `createScope({ extensions })`, then expose contextual namespace entrypoints so users keep package context in call sites: `hono.adapter()` and `tanstackStart.adapter()`.

The examples follow the frameworks first and add Lite at their natural integration points. The Hono todo backend exports a normal `app`, installs native Hono middleware with `app.use`, and executes public flows from Hono route handlers through `context.var.lite`. The TanStack Start todo app uses `createStart({ requestMiddleware })`, TanStack server functions, file routes under `src/routes`, and a generated-style `src/routeTree.gen.ts` instead of a pumped-fn-owned React wrapper.

The TanStack adapter composes with Start's own middleware graph: `lite.call({ middleware: [request] })` accepts native TanStack middleware, so Start carries and dedupes request context while Lite creates only the child execution context needed to run a unit. Hono similarly stays native by implementing the adapter with `hono/factory` `createMiddleware` and typed `hono.Env`.

## Changes

- Add `pkg/framework` lane docs plus package map/catalog/lockfile updates.
- Add `@pumped-fn/lite-hono` with the `hono` namespace export, `hono.adapter()`, typed `hono.Env`, docs, runtime tests, stress integration tests, and type-contract tests.
- Add `@pumped-fn/lite-tanstack-start` with the `tanstackStart` namespace export, `tanstackStart.adapter()`, `lite.request()`, `lite.call()`, `lite.handler()`, typed `tanstackStart.Context`, native TanStack middleware passthrough, docs, runtime tests, stress integration tests, and type-contract tests.
- Keep TanStack function-call tags explicit as zero-arg providers; Lite execution context is not passed into tag callbacks as an integration parameter.
- Use `rawInput` at framework payload boundaries: Hono request bodies and TanStack handler `event.data` enter flow execution as raw input, then the flow parser owns runtime validation.
- Use Zod-backed flow parsers in both practical todo domains for create/toggle inputs; exported input types are inferred from the schemas instead of relying on `typed<T>()` no-op markers.
- Require custom adapter context keys to be supplied as runtime `key` options, so generic key types cannot drift from the variable written by middleware.
- Use TanStack server-function `.validator(...)` in docs/examples to match the installed Start API.
- Add `examples/lite-hono-todo-practical`: a tenant-scoped Hono todo API with domain flows, Hono request tests, Zod malformed-payload validation, scope-seam domain tests, and anti-pattern guardrails.
- Add `examples/lite-tanstack-start-todo-practical`: a TanStack Start todo app with `createStart`, request middleware, `lite.call({ middleware: [request] })`, server functions, file routes, generated-style route tree, middleware-chain tests, Zod malformed runtime input validation, scope-seam domain tests, and anti-pattern guardrails.
- Register both new examples in `examples/README.md`, root lint targets, and the workspace lockfile.
- Document guardrails for contextual namespace exports, no public scope/context parameter helpers, `tags.required(...)` for framework-provided tags, and explicit `deps` for external framework/runtime values consumed by units.
- Add stress integration guardrails that exercise realistic framework paths and scan package/example sources/docs/tests for forbidden adapter anti-patterns.
- Add changeset for both new packages.

## Review

- `claude ultrareview 299 --timeout 20` completed through the logged-in Claude Code CLI and returned 3 verified findings.
- All 3 findings were addressed: `bb3bb67d` fixed returned extension objects and custom adapter-key drift, `5aee388c` moved malformed todo payload handling to `rawInput` plus flow parse validation, and `3b5840a1` replaced handwritten/no-op practical example parsing with Zod schemas.

## Testing

- `pnpm install --frozen-lockfile --offline`
- `pnpm build`
- `pnpm lint`
- `pnpm -r typecheck`
- `timeout 360s pnpm -r test`
- `pnpm -F @pumped-fn/lite-hono typecheck`
- `pnpm -F @pumped-fn/lite-hono test`
- `pnpm -F @pumped-fn/lite-hono build`
- `pnpm -F @pumped-fn/lite-tanstack-start typecheck`
- `pnpm -F @pumped-fn/lite-tanstack-start test`
- `pnpm -F @pumped-fn/lite-tanstack-start build`
- `pnpm -F @pumped-fn/lite-hono-todo-practical typecheck`
- `pnpm -F @pumped-fn/lite-hono-todo-practical test`
- `pnpm -F @pumped-fn/lite-tanstack-start-todo-practical typecheck`
- `pnpm -F @pumped-fn/lite-tanstack-start-todo-practical test`
- `git diff --check`
- Declaration/source guardrails: no top-level generic adapter exports, no exported scope, no public `middleware(scope)`, `request(scope)`, `get(context)`, `exec(context, ...)`, `createAdapter`, or public `init(scope)` surface.
- Framework/example guardrails: no `seekTag(...)`, `.data.get(...)`, `.data.seek(...)`, or bare `any` reads in the new adapter docs/tests/examples, excluding ignored package caches.

Note: React/browser tests still emit existing passing `act(...)` and intentional error-boundary console warnings. One earlier unbounded `pnpm -r test` run was interrupted while the existing React practical browser coverage section was idle; the isolated React practical test passed immediately after, and the final bounded `timeout 360s pnpm -r test` rerun passed after the raw-input and Zod parser corrections.
