### PR TITLE
Add CLI practical examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,7 @@ The examples are part of the public contract for how code should be shaped:
 | `examples/lite-practical` | Backend and service-style patterns, plus a service health capstone |
 | `examples/lite-react-practical` | React observer patterns, provider-owned execution, scoped drafts, json-render, complex Kanban |
 | `examples/lite-bff-practical` | BFF transport/capability/feature layering and HTTP-shaped flow boundaries |
+| `examples/lite-cli-practical` | Commander, Yargs, and CAC parser integrations with per-command Lite scopes |
 | `benchmarks/lite-perf` | Runtime and React observer performance checks |
 
 ## Local Development

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,7 @@ surfaces for documented patterns, not publishing targets.
 | `lite-bff-practical/` | `@pumped-fn/lite-bff-practical` | BFF-style composition examples. |
 | `lite-hono-todo-practical/` | `@pumped-fn/lite-hono-todo-practical` | Hono backend integration for a todo API. |
 | `lite-tanstack-start-todo-practical/` | `@pumped-fn/lite-tanstack-start-todo-practical` | TanStack Start fullstack integration for todos. |
+| `lite-cli-practical/` | `@pumped-fn/lite-cli-practical` | CLI parser integrations with per-command Lite scopes. |
 | `agent-practical/` | `@pumped-fn/agent-practical` | Agent workflow examples. |
 
 ## Naming

--- a/examples/lite-cli-practical/README.md
+++ b/examples/lite-cli-practical/README.md
@@ -1,0 +1,20 @@
+# CLI practical examples
+
+Runnable `@pumped-fn/lite` examples for command-line programs where startup cost matters.
+
+The parser modules stay thin:
+
+- `src/commander-cli.ts` wires Commander commands.
+- `src/yargs-cli.ts` wires Yargs commands.
+- `src/cac-cli.ts` wires CAC commands.
+
+Each parser action dynamically imports the command implementation it needs. `--help`, parser setup, and
+unrelated commands do not import the Lite graph. Command modules create a fresh scope and execution
+context per operation, then install logging and observable extensions through normal tags.
+
+## Run
+
+```bash
+pnpm test
+pnpm typecheck
+```

--- a/examples/lite-cli-practical/package.json
+++ b/examples/lite-cli-practical/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@pumped-fn/lite-cli-practical",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-extension-logging": "workspace:*",
+    "@pumped-fn/lite-extension-observable": "workspace:*",
+    "cac": "catalog:",
+    "commander": "catalog:",
+    "yargs": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/lite-cli-practical/src/args.ts
+++ b/examples/lite-cli-practical/src/args.ts
@@ -1,0 +1,12 @@
+import type { Target } from "./graph"
+
+export type Write = (line: string) => void
+
+export function target(value: string): Target {
+  if (value === "staging" || value === "production") return value
+  throw new Error(`unknown target: ${value}`)
+}
+
+export function writeJson(write: Write, value: unknown): void {
+  write(JSON.stringify(value))
+}

--- a/examples/lite-cli-practical/src/cac-cli.ts
+++ b/examples/lite-cli-practical/src/cac-cli.ts
@@ -1,0 +1,36 @@
+import { cac, type CAC } from "cac"
+import { target, writeJson, type Write } from "./args"
+
+export function cacCli(write: Write = console.log): CAC {
+  const cli = cac("pumped-cac")
+
+  cli
+    .command("deploy <service>", "Build a deployment plan")
+    .option("--target <target>", "Deployment target")
+    .option("--dry-run", "Plan without changing state")
+    .option("--actor <actor>", "Actor attached to telemetry")
+    .action(async (service: string, options: { target: string; dryRun?: boolean; actor?: string }) => {
+      const { deploy } = await import("./commands/deploy")
+      writeJson(write, (await deploy({
+        service,
+        target: target(options.target),
+        dryRun: options.dryRun === true,
+        actor: options.actor,
+      })).output)
+    })
+
+  cli
+    .command("audit", "Summarize release readiness")
+    .option("--json", "Select JSON output mode")
+    .option("--actor <actor>", "Actor attached to telemetry")
+    .action(async (options: { json?: boolean; actor?: string }) => {
+      const { audit } = await import("./commands/audit")
+      writeJson(write, (await audit({
+        json: options.json === true,
+        actor: options.actor,
+      })).output)
+    })
+
+  cli.help()
+  return cli
+}

--- a/examples/lite-cli-practical/src/commander-cli.ts
+++ b/examples/lite-cli-practical/src/commander-cli.ts
@@ -1,0 +1,44 @@
+import { Command } from "commander"
+import { target, writeJson, type Write } from "./args"
+
+export function commanderCli(write: Write = console.log): Command {
+  const program = new Command()
+
+  program
+    .name("pumped-commander")
+    .exitOverride()
+    .configureOutput({
+      writeOut: (value) => write(value.trimEnd()),
+      writeErr: (value) => write(value.trimEnd()),
+    })
+
+  program
+    .command("deploy")
+    .argument("<service>")
+    .requiredOption("--target <target>")
+    .option("--dry-run")
+    .option("--actor <actor>")
+    .action(async (service: string, options: { target: string; dryRun?: boolean; actor?: string }) => {
+      const { deploy } = await import("./commands/deploy")
+      writeJson(write, (await deploy({
+        service,
+        target: target(options.target),
+        dryRun: options.dryRun === true,
+        actor: options.actor,
+      })).output)
+    })
+
+  program
+    .command("audit")
+    .option("--json")
+    .option("--actor <actor>")
+    .action(async (options: { json?: boolean; actor?: string }) => {
+      const { audit } = await import("./commands/audit")
+      writeJson(write, (await audit({
+        json: options.json === true,
+        actor: options.actor,
+      })).output)
+    })
+
+  return program
+}

--- a/examples/lite-cli-practical/src/commands/audit.ts
+++ b/examples/lite-cli-practical/src/commands/audit.ts
@@ -1,0 +1,38 @@
+import { createScope } from "@pumped-fn/lite"
+import { logging } from "@pumped-fn/lite-extension-logging"
+import { observable } from "@pumped-fn/lite-extension-observable"
+import { actor, auditReadiness, operation, type AuditInput, type AuditReport } from "../graph"
+import type { CommandResult } from "./result"
+
+export async function audit(input: AuditInput): Promise<CommandResult<AuditReport>> {
+  const logs = logging.memory()
+  const events = observable.memory()
+  const scope = createScope({
+    extensions: [logging.extension(), observable.extension()],
+    tags: [
+      actor(input.actor ?? "local"),
+      logging.runtime({
+        sinks: [logs],
+        level: "info",
+        flow: "all",
+        fields: { surface: "cli", library: "shared-command" },
+      }),
+      observable.runtime({
+        sinks: [events],
+        only: ["flow", "resource"],
+      }),
+    ],
+  })
+  const ctx = scope.createContext({ tags: [operation("audit")] })
+
+  try {
+    const output = await ctx.exec({ flow: auditReadiness, input })
+    await ctx.close({ ok: true })
+    return { output, logs: [...logs.records()], events: [...events.events()] }
+  } catch (error) {
+    await ctx.close({ ok: false, error })
+    throw error
+  } finally {
+    await scope.dispose()
+  }
+}

--- a/examples/lite-cli-practical/src/commands/deploy.ts
+++ b/examples/lite-cli-practical/src/commands/deploy.ts
@@ -1,0 +1,38 @@
+import { createScope } from "@pumped-fn/lite"
+import { logging } from "@pumped-fn/lite-extension-logging"
+import { observable } from "@pumped-fn/lite-extension-observable"
+import { actor, deploymentPlan, operation, type DeployInput, type DeployPlan } from "../graph"
+import type { CommandResult } from "./result"
+
+export async function deploy(input: DeployInput): Promise<CommandResult<DeployPlan>> {
+  const logs = logging.memory()
+  const events = observable.memory()
+  const scope = createScope({
+    extensions: [logging.extension(), observable.extension()],
+    tags: [
+      actor(input.actor ?? "local"),
+      logging.runtime({
+        sinks: [logs],
+        level: "info",
+        flow: "all",
+        fields: { surface: "cli", library: "shared-command" },
+      }),
+      observable.runtime({
+        sinks: [events],
+        only: ["flow", "resource"],
+      }),
+    ],
+  })
+  const ctx = scope.createContext({ tags: [operation("deploy")] })
+
+  try {
+    const output = await ctx.exec({ flow: deploymentPlan, input })
+    await ctx.close({ ok: true })
+    return { output, logs: [...logs.records()], events: [...events.events()] }
+  } catch (error) {
+    await ctx.close({ ok: false, error })
+    throw error
+  } finally {
+    await scope.dispose()
+  }
+}

--- a/examples/lite-cli-practical/src/commands/result.ts
+++ b/examples/lite-cli-practical/src/commands/result.ts
@@ -1,0 +1,8 @@
+import type { Logging } from "@pumped-fn/lite-extension-logging"
+import type { Observable } from "@pumped-fn/lite-extension-observable"
+
+export interface CommandResult<T> {
+  output: T
+  logs: readonly Logging.Record[]
+  events: readonly Observable.Event[]
+}

--- a/examples/lite-cli-practical/src/graph.ts
+++ b/examples/lite-cli-practical/src/graph.ts
@@ -1,0 +1,160 @@
+import { atom, flow, tag, tags, typed } from "@pumped-fn/lite"
+import { logging } from "@pumped-fn/lite-extension-logging"
+
+export type Target = "staging" | "production"
+
+export interface DeployInput {
+  service: string
+  target: Target
+  dryRun: boolean
+  actor?: string
+}
+
+export interface DeployPlan {
+  operation: string
+  actor: string
+  service: string
+  target: Target
+  current: string
+  next: string
+  dryRun: boolean
+  steps: string[]
+}
+
+export interface AuditInput {
+  json: boolean
+  actor?: string
+}
+
+export interface AuditReport {
+  operation: string
+  actor: string
+  format: "json" | "text"
+  services: ServiceReadiness[]
+  risky: number
+}
+
+export interface ServiceReadiness {
+  service: string
+  current: string
+  staging: string
+  production: string
+  pendingChecks: number
+}
+
+interface ReleaseRecord {
+  service: string
+  current: string
+  staging: string
+  production: string
+  pendingChecks: number
+}
+
+interface Registry {
+  service(name: string): ReleaseRecord
+  list(): ReleaseRecord[]
+  nextVersion(record: ReleaseRecord, target: Target): string
+}
+
+export const operation = tag<string>({ label: "cli.operation" })
+
+export const actor = tag<string>({ label: "cli.actor", default: "local" })
+
+export const registry = atom({
+  factory: (): Registry => {
+    const records = new Map<string, ReleaseRecord>([
+      ["api", { service: "api", current: "1.8.2", staging: "1.9.0-rc.2", production: "1.8.2", pendingChecks: 0 }],
+      ["worker", { service: "worker", current: "4.2.0", staging: "4.3.0-rc.1", production: "4.1.9", pendingChecks: 2 }],
+    ])
+
+    return {
+      service(name) {
+        const record = records.get(name)
+        if (record === undefined) throw new Error(`unknown service: ${name}`)
+        return record
+      },
+      list() {
+        return [...records.values()]
+      },
+      nextVersion(record, target) {
+        return target === "production" ? record.staging : `${record.current}-next`
+      },
+    }
+  },
+})
+
+export const deploymentPlan = flow({
+  name: "deployment-plan",
+  parse: typed<DeployInput>(),
+  deps: {
+    registry,
+    logger: logging.logger,
+    operation: tags.required(operation),
+    actor: tags.required(actor),
+  },
+  factory: (ctx, deps): DeployPlan => {
+    const record = deps.registry.service(ctx.input.service)
+    const next = deps.registry.nextVersion(record, ctx.input.target)
+    const steps = [
+      `load ${record.service}`,
+      `promote ${record.current} to ${next}`,
+      ctx.input.dryRun ? "write plan" : "execute release",
+    ]
+
+    deps.logger.info("deploy.plan", {
+      operation: deps.operation,
+      actor: deps.actor,
+      service: record.service,
+      target: ctx.input.target,
+      dryRun: ctx.input.dryRun,
+    })
+
+    return {
+      operation: deps.operation,
+      actor: deps.actor,
+      service: record.service,
+      target: ctx.input.target,
+      current: record.current,
+      next,
+      dryRun: ctx.input.dryRun,
+      steps,
+    }
+  },
+})
+
+export const auditReadiness = flow({
+  name: "audit-readiness",
+  parse: typed<AuditInput>(),
+  deps: {
+    registry,
+    logger: logging.logger,
+    operation: tags.required(operation),
+    actor: tags.required(actor),
+  },
+  factory: (ctx, deps): AuditReport => {
+    const services = deps.registry.list().map((record) => ({
+      service: record.service,
+      current: record.current,
+      staging: record.staging,
+      production: record.production,
+      pendingChecks: record.pendingChecks,
+    }))
+    const risky = services.filter((service) => service.pendingChecks > 0).length
+
+    deps.logger.info("audit.report", {
+      operation: deps.operation,
+      actor: deps.actor,
+      services: services.length,
+      risky,
+      json: ctx.input.json,
+    })
+
+    return {
+      operation: deps.operation,
+      actor: deps.actor,
+      format: ctx.input.json ? "json" : "text",
+      services,
+      risky,
+    }
+  },
+})

--- a/examples/lite-cli-practical/src/yargs-cli.ts
+++ b/examples/lite-cli-practical/src/yargs-cli.ts
@@ -1,0 +1,56 @@
+import yargs, { type Argv } from "yargs"
+import { target, writeJson, type Write } from "./args"
+
+interface DeployArgs {
+  service: string
+  target: string
+  dryRun?: boolean
+  actor?: string
+}
+
+interface AuditArgs {
+  json?: boolean
+  actor?: string
+}
+
+export function yargsCli(write: Write = console.log): Argv {
+  return yargs()
+    .scriptName("pumped-yargs")
+    .exitProcess(false)
+    .command(
+      "deploy <service>",
+      "Build a deployment plan",
+      (cmd) => cmd
+        .positional("service", { type: "string", demandOption: true })
+        .option("target", { type: "string", choices: ["staging", "production"], demandOption: true })
+        .option("dry-run", { type: "boolean", default: false })
+        .option("actor", { type: "string" }),
+      async (argv) => {
+        const { deploy } = await import("./commands/deploy")
+        const args = argv as DeployArgs
+        writeJson(write, (await deploy({
+          service: args.service,
+          target: target(args.target),
+          dryRun: args.dryRun === true,
+          actor: args.actor,
+        })).output)
+      },
+    )
+    .command(
+      "audit",
+      "Summarize release readiness",
+      (cmd) => cmd
+        .option("json", { type: "boolean", default: false })
+        .option("actor", { type: "string" }),
+      async (argv) => {
+        const { audit } = await import("./commands/audit")
+        const args = argv as AuditArgs
+        writeJson(write, (await audit({
+          json: args.json === true,
+          actor: args.actor,
+        })).output)
+      },
+    )
+    .strict()
+    .help()
+}

--- a/examples/lite-cli-practical/src/yargs.d.ts
+++ b/examples/lite-cli-practical/src/yargs.d.ts
@@ -1,0 +1,29 @@
+declare module "yargs" {
+  export interface PositionalOptions {
+    type: "string"
+    demandOption?: boolean
+  }
+
+  export interface OptionOptions {
+    type: "string" | "boolean"
+    choices?: readonly string[]
+    default?: string | boolean
+    demandOption?: boolean
+  }
+
+  export type Builder = (cmd: Argv) => Argv
+  export type Handler<T extends object> = (argv: T) => unknown | Promise<unknown>
+
+  export interface Argv {
+    scriptName(name: string): Argv
+    exitProcess(enabled: boolean): Argv
+    command<T extends object>(command: string, description: string, builder: Builder, handler: Handler<T>): Argv
+    positional(name: string, options: PositionalOptions): Argv
+    option(name: string, options: OptionOptions): Argv
+    strict(): Argv
+    help(): Argv
+    parseAsync(args: readonly string[]): Promise<unknown>
+  }
+
+  export default function yargs(args?: readonly string[]): Argv
+}

--- a/examples/lite-cli-practical/tests/cli.test.ts
+++ b/examples/lite-cli-practical/tests/cli.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest"
+import { cacCli } from "../src/cac-cli"
+import { commanderCli } from "../src/commander-cli"
+import { yargsCli } from "../src/yargs-cli"
+
+function writer(): [string[], (line: string) => void] {
+  const lines: string[] = []
+  return [lines, (line) => lines.push(line)]
+}
+
+function read<T>(lines: string[]): T {
+  return JSON.parse(lines[0]!) as T
+}
+
+describe("command libraries", () => {
+  test("Commander runs a lazy deployment action", async () => {
+    const [lines, write] = writer()
+
+    await commanderCli(write).parseAsync(["deploy", "api", "--target", "staging", "--dry-run", "--actor", "ci"], {
+      from: "user",
+    })
+
+    expect(read(lines)).toMatchObject({
+      operation: "deploy",
+      actor: "ci",
+      service: "api",
+      target: "staging",
+      dryRun: true,
+    })
+  })
+
+  test("Yargs runs a lazy audit action", async () => {
+    const [lines, write] = writer()
+
+    await yargsCli(write).parseAsync(["audit", "--json", "--actor", "ci"])
+
+    expect(read(lines)).toMatchObject({
+      operation: "audit",
+      actor: "ci",
+      format: "json",
+      risky: 1,
+    })
+  })
+
+  test("CAC runs a lazy deployment action", async () => {
+    const [lines, write] = writer()
+    const cli = cacCli(write)
+
+    cli.parse(["node", "test", "deploy", "worker", "--target", "production"], { run: false })
+    await cli.runMatchedCommand()
+
+    expect(read(lines)).toMatchObject({
+      operation: "deploy",
+      actor: "local",
+      service: "worker",
+      target: "production",
+      next: "4.3.0-rc.1",
+    })
+  })
+})

--- a/examples/lite-cli-practical/tests/commands.test.ts
+++ b/examples/lite-cli-practical/tests/commands.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "vitest"
+import { audit } from "../src/commands/audit"
+import { deploy } from "../src/commands/deploy"
+
+describe("command modules", () => {
+  test("deploy creates one operation scope with logs and observable events", async () => {
+    const result = await deploy({
+      service: "api",
+      target: "production",
+      dryRun: true,
+      actor: "release-bot",
+    })
+
+    expect(result.output).toMatchObject({
+      operation: "deploy",
+      actor: "release-bot",
+      service: "api",
+      target: "production",
+      next: "1.9.0-rc.2",
+      dryRun: true,
+    })
+    expect(result.logs.map((record) => record.message)).toContain("deploy.plan")
+    expect(result.events.map((event) => `${event.phase}:${event.kind}:${event.name}`)).toContain(
+      "success:flow:deployment-plan",
+    )
+  })
+
+  test("audit uses the same public seam and keeps operation telemetry", async () => {
+    const result = await audit({ json: false, actor: "operator" })
+
+    expect(result.output).toMatchObject({
+      operation: "audit",
+      actor: "operator",
+      format: "text",
+      risky: 1,
+    })
+    expect(result.output.services.map((service) => service.service)).toEqual(["api", "worker"])
+    expect(result.logs.map((record) => record.message)).toContain("audit.report")
+    expect(result.events.map((event) => `${event.phase}:${event.kind}:${event.name}`)).toContain(
+      "success:flow:audit-readiness",
+    )
+  })
+})

--- a/examples/lite-cli-practical/tests/lazy-loading.test.ts
+++ b/examples/lite-cli-practical/tests/lazy-loading.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "vitest"
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import ts from "typescript"
+
+const root = process.cwd()
+const routers = ["src/commander-cli.ts", "src/yargs-cli.ts", "src/cac-cli.ts"]
+
+function source(path: string): string {
+  return readFileSync(resolve(root, path), "utf8")
+}
+
+function runtimeImports(path: string): string[] {
+  const file = ts.createSourceFile(path, source(path), ts.ScriptTarget.Latest, true)
+  const imports: string[] = []
+  for (const statement of file.statements) {
+    if (
+      ts.isImportDeclaration(statement) &&
+      ts.isStringLiteral(statement.moduleSpecifier) &&
+      statement.importClause?.isTypeOnly !== true
+    ) {
+      imports.push(statement.moduleSpecifier.text)
+    }
+  }
+  return imports.sort()
+}
+
+function dynamicImports(path: string): string[] {
+  const file = ts.createSourceFile(path, source(path), ts.ScriptTarget.Latest, true)
+  const imports: string[] = []
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments[0] !== undefined &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      imports.push(node.arguments[0].text)
+    }
+    ts.forEachChild(node, visit)
+  }
+
+  visit(file)
+  return imports.sort()
+}
+
+describe("lazy loading", () => {
+  test("parser modules do not import the Lite graph or command implementations at startup", () => {
+    expect(Object.fromEntries(routers.map((path) => [path, runtimeImports(path)]))).toEqual({
+      "src/cac-cli.ts": ["./args", "cac"],
+      "src/commander-cli.ts": ["./args", "commander"],
+      "src/yargs-cli.ts": ["./args", "yargs"],
+    })
+  })
+
+  test("parser actions import only the selected command implementation", () => {
+    expect(Object.fromEntries(routers.map((path) => [path, dynamicImports(path)]))).toEqual({
+      "src/cac-cli.ts": ["./commands/audit", "./commands/deploy"],
+      "src/commander-cli.ts": ["./commands/audit", "./commands/deploy"],
+      "src/yargs-cli.ts": ["./commands/audit", "./commands/deploy"],
+    })
+  })
+})

--- a/examples/lite-cli-practical/tsconfig.json
+++ b/examples/lite-cli-practical/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "paths": {
+      "@pumped-fn/lite": ["../../pkg/core/lite/src/index.ts"],
+      "@pumped-fn/lite-extension-logging": ["../../pkg/ext/logging/src/index.ts"],
+      "@pumped-fn/lite-extension-observable": ["../../pkg/ext/observable/src/index.ts"]
+    }
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/lite-cli-practical/vitest.config.ts
+++ b/examples/lite-cli-practical/vitest.config.ts
@@ -1,0 +1,15 @@
+import { fileURLToPath } from "node:url"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@pumped-fn/lite": fileURLToPath(new URL("../../pkg/core/lite/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite-extension-logging": fileURLToPath(new URL("../../pkg/ext/logging/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite-extension-observable": fileURLToPath(new URL("../../pkg/ext/observable/src/index.ts", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+  },
+})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "verify": "pnpm build && pnpm test && pnpm typecheck",
     "format": "echo 'Formatting disabled'",
     "format:check": "echo 'Format check disabled'",
-    "lint": "pnpm -F @pumped-fn/lite-lint build && node pkg/tool/lint/dist/cli.mjs pkg/core/lite/README.md pkg/core/lite/PATTERNS.md pkg/react/lite-react/README.md pkg/react/lite-react/PATTERNS.md examples/lite-practical examples/lite-react-practical examples/lite-bff-practical examples/lite-hono-todo-practical examples/lite-tanstack-start-todo-practical",
+    "lint": "pnpm -F @pumped-fn/lite-lint build && node pkg/tool/lint/dist/cli.mjs pkg/core/lite/README.md pkg/core/lite/PATTERNS.md pkg/react/lite-react/README.md pkg/react/lite-react/PATTERNS.md examples/lite-practical examples/lite-react-practical examples/lite-bff-practical examples/lite-hono-todo-practical examples/lite-tanstack-start-todo-practical examples/lite-cli-practical",
     "lint:check": "pnpm lint",
     "actionlint": "github-actionlint .github/workflows/*.yml",
     "act": "node scripts/act.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,12 @@ catalogs:
     acorn:
       specifier: 8.16.0
       version: 8.16.0
+    cac:
+      specifier: 7.0.0
+      version: 7.0.0
+    commander:
+      specifier: 15.0.0
+      version: 15.0.0
     estree-walker:
       specifier: 3.0.3
       version: 3.0.3
@@ -102,6 +108,9 @@ catalogs:
     vitest:
       specifier: 4.1.8
       version: 4.1.8
+    yargs:
+      specifier: 18.0.0
+      version: 18.0.0
     zod:
       specifier: 4.3.6
       version: 4.3.6
@@ -232,6 +241,43 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  examples/lite-cli-practical:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+      '@pumped-fn/lite-extension-logging':
+        specifier: workspace:*
+        version: link:../../pkg/ext/logging
+      '@pumped-fn/lite-extension-observable':
+        specifier: workspace:*
+        version: link:../../pkg/ext/observable
+      cac:
+        specifier: 'catalog:'
+        version: 7.0.0
+      commander:
+        specifier: 'catalog:'
+        version: 15.0.0
+      yargs:
+        specifier: 'catalog:'
+        version: 18.0.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -2019,9 +2065,17 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   ansis@4.3.0:
     resolution: {integrity: sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==}
@@ -2135,9 +2189,17 @@ packages:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
+
+  commander@15.0.0:
+    resolution: {integrity: sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==}
+    engines: {node: '>=22.12.0'}
 
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
@@ -2237,6 +2299,9 @@ packages:
 
   electron-to-chromium@1.5.362:
     resolution: {integrity: sha512-PUY2DrLvkjkUuWqq+KPL2iWshrJsZOcIojzRQ7eXFacc9dWga7MGMJAa15VbiejSZB1PAXaRLAiKgruHP8LB1w==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
 
   empathic@2.0.1:
     resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
@@ -2365,6 +2430,14 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
 
   get-tsconfig@5.0.0-beta.5:
     resolution: {integrity: sha512-/6gFNr0N04nob252sTQxyFLi3eKFRqIg1I87YcqAMT1i6SQrSF6KujUEQrtrjMV0H/eejTCltLdDSTEMzHbnsQ==}
@@ -3155,12 +3228,20 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -3497,6 +3578,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -3531,6 +3616,10 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
@@ -3542,6 +3631,14 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.0.0:
+    resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -4740,7 +4837,11 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@5.2.0: {}
+
+  ansi-styles@6.2.3: {}
 
   ansis@4.3.0: {}
 
@@ -4851,11 +4952,19 @@ snapshots:
 
   chownr@3.0.0: {}
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   clone-deep@4.0.1:
     dependencies:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+
+  commander@15.0.0: {}
 
   commander@6.2.1: {}
 
@@ -4929,6 +5038,8 @@ snapshots:
   dts-resolver@3.0.0: {}
 
   electron-to-chromium@1.5.362: {}
+
+  emoji-regex@10.6.0: {}
 
   empathic@2.0.1: {}
 
@@ -5081,6 +5192,10 @@ snapshots:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-tsconfig@5.0.0-beta.5:
     dependencies:
@@ -5820,6 +5935,12 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -5828,6 +5949,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@4.0.0: {}
 
@@ -6111,6 +6236,12 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
   wrappy@1.0.2:
     optional: true
 
@@ -6136,11 +6267,24 @@ snapshots:
   xmlchars@2.2.0:
     optional: true
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
 
   yaml@2.9.0: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.0.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 7.2.0
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   zod@4.3.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -74,6 +74,8 @@ catalog:
   "@vitest/browser-playwright": 4.1.8
   "@vitest/coverage-v8": 4.1.8
   acorn: 8.16.0
+  cac: 7.0.0
+  commander: 15.0.0
   estree-walker: 3.0.3
   github-actionlint: 1.7.12
   hono: 4.12.27
@@ -89,6 +91,7 @@ catalog:
   unrun: 0.3.1
   vite: 8.0.16
   vitest: 4.1.8
+  yargs: 18.0.0
   zod: 4.3.6
 
 minimumReleaseAgeExclude:


### PR DESCRIPTION
## Summary

Adds a practical CLI example package showing how to integrate @pumped-fn/lite with popular Node.js command parsers while keeping startup work lazy and per-command execution scoped.

## Changes

- Adds `examples/lite-cli-practical` with Commander, Yargs, and CAC parser entrypoints.
- Moves Lite work behind dynamically imported command modules with one scope/context per operation.
- Uses the existing logging and observable extension packages through tag-injected runtimes.
- Adds type/runtime tests plus a static guard proving parser modules do not import the Lite graph at startup.
- Adds catalog entries, lockfile updates, example indexes, and root lint coverage for the new example.

## Testing

- `pnpm -F @pumped-fn/lite-cli-practical typecheck`
- `pnpm -F @pumped-fn/lite-cli-practical test`
- `pnpm lint`
- `git diff --check`