### PR TITLE
Add lite sync extension and NATS transport

### DIFF
--- a/.changeset/good-drafts-sync.md
+++ b/.changeset/good-drafts-sync.md
@@ -1,5 +1,6 @@
 ---
 "@pumped-fn/lite-extension-sync": minor
+"@pumped-fn/lite-extension-sync-nats": minor
 ---
 
-Add the first sync extension package with an atom-like `sync(...)` primitive, tag-injected runtime transport, memory transport, runtime JSON validation, codec support, and revision conflict policy.
+Add the first sync extension package with an atom-like `sync(...)` primitive, tag-injected runtime transport, memory transport, runtime JSON validation, codec support, revision conflict policy, and a NATS JetStream KV transport adapter.

--- a/.changeset/good-drafts-sync.md
+++ b/.changeset/good-drafts-sync.md
@@ -1,0 +1,5 @@
+---
+"@pumped-fn/lite-extension-sync": minor
+---
+
+Add the first sync extension package with an atom-like `sync(...)` primitive, tag-injected runtime transport, memory transport, runtime JSON validation, codec support, and revision conflict policy.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Current source packages live under one-word lanes in `pkg/`.
 | `pkg/ext/observable-otel` | `@pumped-fn/lite-extension-observable-otel` | OpenTelemetry sink adapter for observable events |
 | `pkg/ext/logging` | `@pumped-fn/lite-extension-logging` | Execution-scoped logger resource and flow logs with tag-injected sinks |
 | `pkg/ext/logging-pino` | `@pumped-fn/lite-extension-logging-pino` | Pino sink adapter for logging records |
+| `pkg/ext/sync` | `@pumped-fn/lite-extension-sync` | Strict replicated state primitive with tag-injected transports |
 | `pkg/ext/hmr` | `@pumped-fn/lite-hmr` | HMR helpers for preserving atom state during development |
 | `pkg/agent/core` | `@pumped-fn/agent-sdk` | Agent workflows, tools, skills, sessions, evals, HTTP adapters, and run inspection over lite |
 | `pkg/agent/codex` | `@pumped-fn/agent-sdk-codex` | Lazy Codex CLI model provider tag for agent-sdk |

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Current source packages live under one-word lanes in `pkg/`.
 | `pkg/ext/logging` | `@pumped-fn/lite-extension-logging` | Execution-scoped logger resource and flow logs with tag-injected sinks |
 | `pkg/ext/logging-pino` | `@pumped-fn/lite-extension-logging-pino` | Pino sink adapter for logging records |
 | `pkg/ext/sync` | `@pumped-fn/lite-extension-sync` | Strict replicated state primitive with tag-injected transports |
+| `pkg/ext/sync-nats` | `@pumped-fn/lite-extension-sync-nats` | NATS JetStream KV transport adapter for sync |
 | `pkg/ext/hmr` | `@pumped-fn/lite-hmr` | HMR helpers for preserving atom state during development |
 | `pkg/agent/core` | `@pumped-fn/agent-sdk` | Agent workflows, tools, skills, sessions, evals, HTTP adapters, and run inspection over lite |
 | `pkg/agent/codex` | `@pumped-fn/agent-sdk-codex` | Lazy Codex CLI model provider tag for agent-sdk |

--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ The examples are part of the public contract for how code should be shaped:
 | `examples/lite-react-practical` | React observer patterns, provider-owned execution, scoped drafts, json-render, complex Kanban |
 | `examples/lite-bff-practical` | BFF transport/capability/feature layering and HTTP-shaped flow boundaries |
 | `examples/lite-cli-practical` | Commander, Yargs, and CAC parser integrations with per-command Lite scopes |
+| `examples/lite-sync-practical` | Strict replicated state, runtime validation, conflict reporting, and stress metrics |
+| `examples/lite-sync-web-practical` | Frontend/backend sync through a web environment gateway and ordinary React observers |
 | `benchmarks/lite-perf` | Runtime and React observer performance checks |
 
 ## Local Development

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ surfaces for documented patterns, not publishing targets.
 | `lite-tanstack-start-todo-practical/` | `@pumped-fn/lite-tanstack-start-todo-practical` | TanStack Start fullstack integration for todos. |
 | `lite-cli-practical/` | `@pumped-fn/lite-cli-practical` | CLI parser integrations with per-command Lite scopes. |
 | `lite-sync-practical/` | `@pumped-fn/lite-sync-practical` | Replicated draft state with sync stress metrics. |
+| `lite-sync-web-practical/` | `@pumped-fn/lite-sync-web-practical` | Frontend/backend sync through a web environment gateway. |
 | `agent-practical/` | `@pumped-fn/agent-practical` | Agent workflow examples. |
 
 ## Naming

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,6 +15,7 @@ surfaces for documented patterns, not publishing targets.
 | `lite-hono-todo-practical/` | `@pumped-fn/lite-hono-todo-practical` | Hono backend integration for a todo API. |
 | `lite-tanstack-start-todo-practical/` | `@pumped-fn/lite-tanstack-start-todo-practical` | TanStack Start fullstack integration for todos. |
 | `lite-cli-practical/` | `@pumped-fn/lite-cli-practical` | CLI parser integrations with per-command Lite scopes. |
+| `lite-sync-practical/` | `@pumped-fn/lite-sync-practical` | Replicated draft state with sync stress metrics. |
 | `agent-practical/` | `@pumped-fn/agent-practical` | Agent workflow examples. |
 
 ## Naming

--- a/examples/lite-sync-practical/README.md
+++ b/examples/lite-sync-practical/README.md
@@ -1,0 +1,8 @@
+# Lite Sync Practical
+
+Production-shaped replicated draft state over Lite scopes.
+
+The example uses `sync(...)` for editor state, `sync.extension()` at the composition boundary, and a
+tag-injected memory transport for deterministic tests. The stress run records write overhead,
+invalid payload rejection, conflict reporting, and final peer convergence without module mocks or
+hidden globals.

--- a/examples/lite-sync-practical/package.json
+++ b/examples/lite-sync-practical/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pumped-fn/lite-sync-practical",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-extension-sync": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/lite-sync-practical/src/main.ts
+++ b/examples/lite-sync-practical/src/main.ts
@@ -60,6 +60,7 @@ export async function runSyncStress(options: SyncStressOptions = {}): Promise<Sy
   await right.resolve(draft)
 
   const ctrl = left.controller(draft)
+  const mirror = right.controller(draft)
   const start = now()
   for (let i = 1; i <= edits; i++) {
     ctrl.set({
@@ -68,9 +69,10 @@ export async function runSyncStress(options: SyncStressOptions = {}): Promise<Sy
       body: `Body revision ${i}`,
       version: i,
     })
+    await until(() => mirror.get().version === i)
   }
   const localWriteMs = now() - start
-  const beforeInvalid = right.controller(draft).get()
+  const beforeInvalid = mirror.get()
 
   await wire.write({
     key: "document:proposal:draft",
@@ -83,7 +85,7 @@ export async function runSyncStress(options: SyncStressOptions = {}): Promise<Sy
       version: edits + 1,
     },
   })
-  const afterInvalid = right.controller(draft).get()
+  const afterInvalid = mirror.get()
 
   await wire.write({
     key: "document:proposal:draft",
@@ -99,7 +101,7 @@ export async function runSyncStress(options: SyncStressOptions = {}): Promise<Sy
 
   const result = {
     edits,
-    final: right.controller(draft).get(),
+    final: mirror.get(),
     records: wire.size(),
     invalidPayloadRejects: errors.filter((phase) => phase === "decode").length,
     invalidApplyCount: Number(JSON.stringify(beforeInvalid) !== JSON.stringify(afterInvalid)),
@@ -111,4 +113,10 @@ export async function runSyncStress(options: SyncStressOptions = {}): Promise<Sy
   await left.dispose()
   await right.dispose()
   return result
+}
+
+async function until(check: () => boolean): Promise<void> {
+  while (!check()) {
+    await Promise.resolve()
+  }
 }

--- a/examples/lite-sync-practical/src/main.ts
+++ b/examples/lite-sync-practical/src/main.ts
@@ -1,0 +1,114 @@
+import { createScope, type Lite } from "@pumped-fn/lite"
+import { sync, type Sync } from "@pumped-fn/lite-extension-sync"
+
+const draft = sync({
+  id: "draft",
+  factory: () => ({ id: "draft", title: "", body: "", version: 0 }),
+  conflict: sync.revision("version"),
+})
+
+export type Draft = Lite.Utils.AtomValue<typeof draft>
+
+export interface SyncStressOptions {
+  readonly edits?: number
+  readonly now?: () => number
+}
+
+export interface SyncStressResult {
+  readonly edits: number
+  readonly final: Draft
+  readonly records: number
+  readonly invalidPayloadRejects: number
+  readonly invalidApplyCount: number
+  readonly conflictCount: number
+  readonly localWriteMs: number
+  readonly localWriteMsPerOp: number
+}
+
+export async function runSyncStress(options: SyncStressOptions = {}): Promise<SyncStressResult> {
+  const edits = options.edits ?? 250
+  const now = options.now ?? (() => performance.now())
+  const wire = sync.memory()
+  const errors: Sync.ErrorPhase[] = []
+  const conflicts: Sync.Conflict<unknown>[] = []
+  const left = createScope({
+    extensions: [sync.extension()],
+    tags: [
+      sync.runtime({
+        peer: "left",
+        namespace: "document:proposal",
+        transport: wire,
+        onError: (_error, phase) => errors.push(phase),
+        onConflict: (conflict) => conflicts.push(conflict),
+      }),
+    ],
+  })
+  const right = createScope({
+    extensions: [sync.extension()],
+    tags: [
+      sync.runtime({
+        peer: "right",
+        namespace: "document:proposal",
+        transport: wire,
+        onError: (_error, phase) => errors.push(phase),
+        onConflict: (conflict) => conflicts.push(conflict),
+      }),
+    ],
+  })
+
+  await left.resolve(draft)
+  await right.resolve(draft)
+
+  const ctrl = left.controller(draft)
+  const start = now()
+  for (let i = 1; i <= edits; i++) {
+    ctrl.set({
+      id: "draft",
+      title: `Proposal ${i}`,
+      body: `Body revision ${i}`,
+      version: i,
+    })
+  }
+  const localWriteMs = now() - start
+  const beforeInvalid = right.controller(draft).get()
+
+  await wire.write({
+    key: "document:proposal:draft",
+    peer: "corrupt",
+    version: edits + 1,
+    value: {
+      id: "draft",
+      title: "corrupt",
+      body: Number.NaN,
+      version: edits + 1,
+    },
+  })
+  const afterInvalid = right.controller(draft).get()
+
+  await wire.write({
+    key: "document:proposal:draft",
+    peer: "offline",
+    version: edits + 2,
+    value: {
+      id: "draft",
+      title: "offline",
+      body: "same revision conflict",
+      version: edits,
+    },
+  })
+
+  const result = {
+    edits,
+    final: right.controller(draft).get(),
+    records: wire.size(),
+    invalidPayloadRejects: errors.filter((phase) => phase === "decode").length,
+    invalidApplyCount: Number(JSON.stringify(beforeInvalid) !== JSON.stringify(afterInvalid)),
+    conflictCount: conflicts.length,
+    localWriteMs,
+    localWriteMsPerOp: localWriteMs / edits,
+  }
+
+  await left.dispose()
+  await right.dispose()
+  return result
+}

--- a/examples/lite-sync-practical/tests/main.test.ts
+++ b/examples/lite-sync-practical/tests/main.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { runSyncStress } from "../src/main"
+
+describe("lite sync practical", () => {
+  it("proves draft sync stress with invalid payload and conflict evidence", async () => {
+    let tick = 0
+    const result = await runSyncStress({
+      edits: 100,
+      now: () => tick++,
+    })
+
+    expect(result).toMatchObject({
+      edits: 100,
+      final: {
+        id: "draft",
+        title: "Proposal 100",
+        body: "Body revision 100",
+        version: 100,
+      },
+      invalidPayloadRejects: 2,
+      invalidApplyCount: 0,
+      conflictCount: 2,
+      localWriteMs: 1,
+      localWriteMsPerOp: 0.01,
+    })
+    expect(result.records).toBeGreaterThanOrEqual(102)
+  })
+
+  it("runs with default stress settings and real timing", async () => {
+    const result = await runSyncStress()
+
+    expect(result.edits).toBe(250)
+    expect(result.final.version).toBe(250)
+    expect(result.invalidApplyCount).toBe(0)
+    expect(result.localWriteMs).toBeGreaterThanOrEqual(0)
+    expect(result.localWriteMsPerOp).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/examples/lite-sync-practical/tsconfig.json
+++ b/examples/lite-sync-practical/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/lite-sync-practical/vitest.config.ts
+++ b/examples/lite-sync-practical/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.ts"],
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+})

--- a/examples/lite-sync-web-practical/README.md
+++ b/examples/lite-sync-web-practical/README.md
@@ -1,0 +1,53 @@
+# Lite Sync Web Practical
+
+Frontend/backend sync through the same Lite scope seam.
+
+This example keeps the synced value declaration shared:
+
+```ts
+const draft = sync({
+  id: "draft",
+  factory: () => ({ id: "draft", title: "Untitled", body: "", savedBy: "system", version: 0 }),
+  conflict: sync.revision("version"),
+})
+```
+
+The browser composition root injects a web environment runtime:
+
+```ts
+const scope = createScope({
+  extensions: [sync.extension()],
+  tags: [
+    sync.runtime(web.env({
+      gateway: web.client({ url: "/sync", fetch }),
+      token,
+      peer: web.peer(store, () => crypto.randomUUID()),
+      namespace: "workspace:demo",
+    })),
+  ],
+})
+```
+
+The backend owns the gateway and decides which durable transport backs it:
+
+```ts
+const gateway = web.server({
+  namespace: "workspace:demo",
+  transport: nats.kv(kv),
+  authorize: (token) => token === expected,
+})
+
+await gateway.handle(request)
+```
+
+React stays ordinary: `useAtom(draft)` observes, `useFlow(saveDraft)` dispatches, and the sync transport is
+chosen at the scope boundary. Tests prove browser-to-backend replication through fetch plus streamed
+watch updates, namespace/auth enforcement, backend conflict pass-through, peer identity stability, and
+rendered React behavior without module mocks.
+
+## Run
+
+```sh
+pnpm test
+pnpm typecheck
+```

--- a/examples/lite-sync-web-practical/package.json
+++ b/examples/lite-sync-web-practical/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@pumped-fn/lite-sync-web-practical",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run --coverage",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-extension-sync": "workspace:*",
+    "@pumped-fn/lite-react": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "@vitest/browser-playwright": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "playwright": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/lite-sync-web-practical/src/app.tsx
+++ b/examples/lite-sync-web-practical/src/app.tsx
@@ -1,0 +1,54 @@
+import { Suspense } from "react"
+import type { Lite } from "@pumped-fn/lite"
+import { ExecutionContextProvider, ScopeProvider, useAtom, useFlow } from "@pumped-fn/lite-react"
+import { draft, saveDraft } from "./model"
+
+export interface AppProps {
+  readonly scope: Lite.Scope
+  readonly actor: string
+}
+
+export function App({ scope, actor }: AppProps) {
+  return (
+    <ScopeProvider scope={scope}>
+      <ExecutionContextProvider>
+        <Suspense fallback={<section aria-label="sync draft">Loading draft</section>}>
+          <DraftScreen actor={actor} />
+        </Suspense>
+      </ExecutionContextProvider>
+    </ScopeProvider>
+  )
+}
+
+export function DraftScreen({ actor }: { readonly actor: string }) {
+  const current = useAtom(draft)
+  const save = useFlow(saveDraft)
+
+  return (
+    <section aria-label="sync draft">
+      <h1>{current.title}</h1>
+      <p>{current.body || "No body"}</p>
+      <dl>
+        <dt>saved by</dt>
+        <dd>{current.savedBy}</dd>
+        <dt>version</dt>
+        <dd>{current.version}</dd>
+        <dt>status</dt>
+        <dd>{save.status}</dd>
+      </dl>
+      <button
+        type="button"
+        aria-label="save browser edit"
+        onClick={() => {
+          save.execute({
+            title: `${current.title} from ${actor}`,
+            body: `browser revision ${current.version + 1}`,
+            actor,
+          })
+        }}
+      >
+        Save
+      </button>
+    </section>
+  )
+}

--- a/examples/lite-sync-web-practical/src/index.ts
+++ b/examples/lite-sync-web-practical/src/index.ts
@@ -1,0 +1,4 @@
+export { App, DraftScreen } from "./app"
+export { draft, saveDraft, type Draft, type SaveDraftInput } from "./model"
+export { createBrowserScope } from "./runtime"
+export { web, type Web } from "./web"

--- a/examples/lite-sync-web-practical/src/model.ts
+++ b/examples/lite-sync-web-practical/src/model.ts
@@ -1,0 +1,42 @@
+import { controller, flow, typed, type Lite } from "@pumped-fn/lite"
+import { sync } from "@pumped-fn/lite-extension-sync"
+
+export const draft = sync({
+  id: "draft",
+  factory: () => ({
+    id: "draft",
+    title: "Untitled",
+    body: "",
+    savedBy: "system",
+    version: 0,
+  }),
+  conflict: sync.revision("version"),
+})
+
+export type Draft = Lite.Utils.AtomValue<typeof draft>
+
+export interface SaveDraftInput {
+  readonly title: string
+  readonly body: string
+  readonly actor: string
+}
+
+export const saveDraft = flow({
+  name: "syncWeb.saveDraft",
+  parse: typed<SaveDraftInput>(),
+  deps: {
+    draft: controller(draft, { resolve: true }),
+  },
+  factory: (ctx, { draft }) => {
+    const current = draft.get()
+    const next = {
+      ...current,
+      title: ctx.input.title.trim(),
+      body: ctx.input.body,
+      savedBy: ctx.input.actor,
+      version: current.version + 1,
+    }
+    draft.set(next)
+    return next
+  },
+})

--- a/examples/lite-sync-web-practical/src/runtime.ts
+++ b/examples/lite-sync-web-practical/src/runtime.ts
@@ -1,0 +1,10 @@
+import { createScope, type Lite } from "@pumped-fn/lite"
+import { sync } from "@pumped-fn/lite-extension-sync"
+import { web, type Web } from "./web"
+
+export function createBrowserScope(options: Web.EnvOptions): Lite.Scope {
+  return createScope({
+    extensions: [sync.extension()],
+    tags: [sync.runtime(web.env(options))],
+  })
+}

--- a/examples/lite-sync-web-practical/src/web.ts
+++ b/examples/lite-sync-web-practical/src/web.ts
@@ -1,0 +1,285 @@
+import type { Sync } from "@pumped-fn/lite-extension-sync"
+
+type MaybePromise<T> = T | Promise<T>
+
+export namespace Web {
+  export interface Gateway {
+    read(token: string, key: string): MaybePromise<Sync.Message | undefined>
+    write(token: string, message: Sync.Message): MaybePromise<Sync.WriteResult>
+    subscribe(token: string, key: string, listener: (message: Sync.Message) => void): MaybePromise<() => void>
+    close(): MaybePromise<void>
+  }
+
+  export interface Server extends Gateway {
+    handle(request: Request): Promise<Response>
+  }
+
+  export interface ServerOptions {
+    readonly namespace: string
+    readonly transport: Sync.Transport
+    readonly authorize: (token: string) => boolean
+  }
+
+  export interface ClientOptions {
+    readonly url: string
+    readonly fetch: typeof fetch
+    readonly onError?: (error: unknown) => void
+  }
+
+  export interface EnvOptions {
+    readonly gateway: Gateway
+    readonly token: string
+    readonly peer: string
+    readonly namespace: string
+    readonly failure?: Sync.Failure
+    readonly onError?: (error: unknown, phase: Sync.ErrorPhase, message: Sync.Message | undefined) => void
+    readonly onConflict?: (conflict: Sync.Conflict<unknown>, message: Sync.Message) => void
+  }
+
+  export interface PeerStore {
+    read(): string | undefined
+    write(peer: string): void
+  }
+}
+
+function server(options: Web.ServerOptions): Web.Server {
+  let closed = false
+
+  const assertOpen = () => {
+    if (closed) throw new Error("sync gateway closed")
+  }
+  const assertToken = (token: string) => {
+    if (!options.authorize(token)) throw new Error("sync token rejected")
+  }
+  const assertKey = (key: string) => {
+    if (!key.startsWith(`${options.namespace}:`)) throw new Error(`sync key outside namespace ${options.namespace}`)
+  }
+
+  const gateway: Web.Server = {
+    async read(token, key) {
+      assertOpen()
+      assertToken(token)
+      assertKey(key)
+      return options.transport.read(key)
+    },
+    async write(token, message) {
+      assertOpen()
+      assertToken(token)
+      assertKey(message.key)
+      return options.transport.write(message)
+    },
+    async subscribe(token, key, listener) {
+      assertOpen()
+      assertToken(token)
+      assertKey(key)
+      return options.transport.subscribe(key, listener)
+    },
+    async close() {
+      closed = true
+      await options.transport.close?.()
+    },
+    async handle(request) {
+      try {
+        const url = new URL(request.url)
+        const token = bearer(request)
+        if (url.pathname.endsWith("/read")) {
+          return json({ message: await gateway.read(token, required(url, "key")) })
+        }
+        if (url.pathname.endsWith("/write")) {
+          return json(encodeWrite(await gateway.write(token, assertMessage(await request.json()))))
+        }
+        if (url.pathname.endsWith("/watch")) {
+          return watch(gateway, token, required(url, "key"))
+        }
+        return new Response("not found", { status: 404 })
+      } catch (error) {
+        return json({ error: error instanceof Error ? error.message : String(error) }, 400)
+      }
+    },
+  }
+
+  return gateway
+}
+
+function client(options: Web.ClientOptions): Web.Gateway {
+  return {
+    async read(token, key) {
+      const response = await request(options, token, `/read?key=${encodeURIComponent(key)}`)
+      const payload = await response.json() as unknown
+      const message = optionalMessage(assertObject(payload)["message"])
+      return message
+    },
+    async write(token, message) {
+      const response = await request(options, token, "/write", {
+        method: "PUT",
+        body: JSON.stringify(message),
+      })
+      return decodeWrite(await response.json() as unknown)
+    },
+    async subscribe(token, key, listener) {
+      let stopped = false
+      const abort = new AbortController()
+      const response = await request(options, token, `/watch?key=${encodeURIComponent(key)}`, { signal: abort.signal })
+      void pump(response, listener).catch((error) => {
+        if (!stopped) options.onError?.(error)
+      })
+      return () => {
+        stopped = true
+        abort.abort()
+      }
+    },
+    close() {},
+  }
+}
+
+function env(options: Web.EnvOptions): Sync.Runtime {
+  return {
+    peer: options.peer,
+    namespace: options.namespace,
+    failure: options.failure,
+    onError: options.onError,
+    onConflict: options.onConflict,
+    transport: {
+      read: (key) => options.gateway.read(options.token, key),
+      write: (message) => options.gateway.write(options.token, message),
+      subscribe: (key, listener) => options.gateway.subscribe(options.token, key, listener),
+    },
+  }
+}
+
+function peer(store: Web.PeerStore, create: () => string): string {
+  const stored = store.read()
+  if (stored) return stored
+  const next = create()
+  store.write(next)
+  return next
+}
+
+export const web = {
+  client,
+  env,
+  peer,
+  server,
+}
+
+function bearer(request: Request): string {
+  const header = request.headers.get("authorization")
+  if (!header?.startsWith("Bearer ")) throw new Error("sync token missing")
+  return header.slice("Bearer ".length)
+}
+
+function required(url: URL, key: string): string {
+  const value = url.searchParams.get(key)
+  if (!value) throw new Error(`sync parameter ${key} missing`)
+  return value
+}
+
+function json(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+function watch(gateway: Web.Gateway, token: string, key: string): Response {
+  const encoder = new TextEncoder()
+  let off: (() => void) | undefined
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      off = await gateway.subscribe(token, key, (message) => {
+        controller.enqueue(encoder.encode(`${JSON.stringify(message)}\n`))
+      })
+    },
+    cancel() {
+      off?.()
+    },
+  })
+  return new Response(stream, {
+    headers: {
+      "content-type": "application/x-ndjson",
+      "cache-control": "no-cache",
+    },
+  })
+}
+
+async function request(options: Web.ClientOptions, token: string, path: string, init: RequestInit = {}): Promise<Response> {
+  const response = await options.fetch(`${options.url}${path}`, {
+    ...init,
+    headers: {
+      ...init.headers,
+      authorization: `Bearer ${token}`,
+    },
+  })
+  if (!response.ok) throw new Error(await response.text())
+  return response
+}
+
+async function pump(response: Response, listener: (message: Sync.Message) => void): Promise<void> {
+  if (!response.body) throw new Error("sync watch response missing body")
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+  for (;;) {
+    const chunk = await reader.read()
+    if (chunk.done) return
+    buffer += decoder.decode(chunk.value, { stream: true })
+    let newline = buffer.indexOf("\n")
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline)
+      buffer = buffer.slice(newline + 1)
+      if (line) listener(assertMessage(JSON.parse(line) as unknown))
+      newline = buffer.indexOf("\n")
+    }
+  }
+}
+
+function encodeWrite(result: Sync.WriteResult): unknown {
+  if (!result) return { kind: "void" }
+  if ("conflict" in result) return { kind: "conflict", conflict: result.conflict }
+  return { kind: "ack", version: result.version }
+}
+
+function decodeWrite(input: unknown): Sync.WriteResult {
+  const record = assertObject(input)
+  if (record["kind"] === "void") return
+  if (record["kind"] === "ack" && typeof record["version"] === "number") return { version: record["version"] }
+  if (record["kind"] === "conflict") return { conflict: assertMessage(record["conflict"]) }
+  throw new Error("sync write result invalid")
+}
+
+function optionalMessage(input: unknown): Sync.Message | undefined {
+  return input === undefined ? undefined : assertMessage(input)
+}
+
+function assertMessage(input: unknown): Sync.Message {
+  const record = assertObject(input)
+  if (typeof record["key"] !== "string") throw new Error("sync message key invalid")
+  if (typeof record["peer"] !== "string") throw new Error("sync message peer invalid")
+  if (typeof record["version"] !== "number") throw new Error("sync message version invalid")
+  return {
+    key: record["key"],
+    peer: record["peer"],
+    version: record["version"],
+    value: assertValue(record["value"]),
+  }
+}
+
+function assertObject(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) throw new Error("sync payload invalid")
+  return input as Record<string, unknown>
+}
+
+function assertValue(input: unknown): Sync.Value {
+  if (input === null || typeof input === "string" || typeof input === "boolean") return input
+  if (typeof input === "number") {
+    if (!Number.isFinite(input)) throw new Error("sync number is not finite")
+    return input
+  }
+  if (Array.isArray(input)) return input.map(assertValue)
+  if (typeof input === "object") {
+    const out: Record<string, Sync.Value> = {}
+    for (const [key, value] of Object.entries(input)) out[key] = assertValue(value)
+    return out
+  }
+  throw new Error("sync value is not JSON")
+}

--- a/examples/lite-sync-web-practical/tests/setup.browser.ts
+++ b/examples/lite-sync-web-practical/tests/setup.browser.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest"

--- a/examples/lite-sync-web-practical/tests/view.browser.test.tsx
+++ b/examples/lite-sync-web-practical/tests/view.browser.test.tsx
@@ -1,0 +1,66 @@
+import { createScope } from "@pumped-fn/lite"
+import { sync } from "@pumped-fn/lite-extension-sync"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, test } from "vitest"
+import { App } from "../src/app"
+import { draft } from "../src/model"
+import { createBrowserScope } from "../src/runtime"
+import { web } from "../src/web"
+
+const namespace = "workspace:browser"
+const token = "secret"
+
+describe("sync web React boundary", () => {
+  test("renders synced state through normal lite-react observers", async () => {
+    const wire = sync.memory()
+    const gateway = web.server({
+      namespace,
+      transport: wire,
+      authorize: (value) => value === token,
+    })
+    const browser = createBrowserScope({
+      gateway,
+      token,
+      peer: "browser",
+      namespace,
+    })
+    const backend = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "backend",
+          namespace,
+          transport: wire,
+        }),
+      ],
+    })
+    const backendDraft = await backend.controller(draft, { resolve: true })
+
+    const view = render(<App scope={browser} actor="browser" />)
+
+    expect(await screen.findByText("Untitled")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "save browser edit" }))
+
+    expect(await screen.findByText("Untitled from browser")).toBeInTheDocument()
+    await until(() => backendDraft.get().savedBy === "browser")
+    expect(backendDraft.get()).toMatchObject({
+      title: "Untitled from browser",
+      savedBy: "browser",
+      version: 1,
+    })
+
+    view.unmount()
+    await browser.dispose()
+    await backend.dispose()
+    await gateway.close()
+  })
+})
+
+async function until(check: () => boolean): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (check()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error("condition did not settle")
+}

--- a/examples/lite-sync-web-practical/tests/web.test.ts
+++ b/examples/lite-sync-web-practical/tests/web.test.ts
@@ -1,0 +1,487 @@
+import { createServer } from "node:http"
+import type { AddressInfo } from "node:net"
+import type { IncomingHttpHeaders, ServerResponse } from "node:http"
+import { createScope } from "@pumped-fn/lite"
+import { sync, type Sync } from "@pumped-fn/lite-extension-sync"
+import { describe, expect, test } from "vitest"
+import { draft } from "../src/model"
+import { createBrowserScope } from "../src/runtime"
+import { web, type Web } from "../src/web"
+
+const namespace = "workspace:demo"
+const key = `${namespace}:draft`
+const token = "secret"
+
+describe("sync web practical environment", () => {
+  test("replicates browser and backend scopes through the gateway", async () => {
+    const wire = sync.memory()
+    const gateway = web.server({
+      namespace,
+      transport: wire,
+      authorize: (value) => value === token,
+    })
+    const browser = createBrowserScope({
+      gateway,
+      token,
+      peer: "browser",
+      namespace,
+    })
+    const backend = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "backend",
+          namespace,
+          transport: wire,
+        }),
+      ],
+    })
+
+    const browserDraft = await browser.controller(draft, { resolve: true })
+    const backendDraft = await backend.controller(draft, { resolve: true })
+
+    browserDraft.set({
+      id: "draft",
+      title: "Browser edit",
+      body: "edited through web env",
+      savedBy: "browser",
+      version: 1,
+    })
+    await until(() => backendDraft.get().savedBy === "browser")
+
+    backendDraft.set({
+      id: "draft",
+      title: "Backend edit",
+      body: "accepted by durable side",
+      savedBy: "backend",
+      version: 2,
+    })
+    await until(() => browserDraft.get().savedBy === "backend")
+
+    expect(browserDraft.get()).toEqual(backendDraft.get())
+
+    await browser.dispose()
+    await backend.dispose()
+    await gateway.close()
+  })
+
+  test("replicates through the fetch protocol and streamed watches", async () => {
+    const wire = sync.memory()
+    const gateway = web.server({
+      namespace,
+      transport: wire,
+      authorize: (value) => value === token,
+    })
+    const live = await serve(gateway)
+    const browser = createBrowserScope({
+      gateway: web.client({ url: live.url, fetch }),
+      token,
+      peer: "browser",
+      namespace,
+    })
+    const backend = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "backend",
+          namespace,
+          transport: wire,
+        }),
+      ],
+    })
+
+    const browserDraft = await browser.controller(draft, { resolve: true })
+    const backendDraft = await backend.controller(draft, { resolve: true })
+
+    backendDraft.set({
+      id: "draft",
+      title: "Backend streamed",
+      body: "delivered by fetch watch",
+      savedBy: "backend",
+      version: 1,
+    })
+    await until(() => browserDraft.get().savedBy === "backend")
+
+    browserDraft.set({
+      id: "draft",
+      title: "Browser fetched",
+      body: "written through fetch",
+      savedBy: "browser",
+      version: 2,
+    })
+    await until(() => backendDraft.get().savedBy === "browser")
+
+    expect(browserDraft.get()).toEqual(backendDraft.get())
+
+    await browser.dispose()
+    await backend.dispose()
+    await live.close()
+    await gateway.close()
+  })
+
+  test("enforces token, namespace, and close boundaries", async () => {
+    const gateway = web.server({
+      namespace,
+      transport: sync.memory(),
+      authorize: (value) => value === token,
+    })
+
+    await expect(gateway.read("bad", key)).rejects.toThrow("sync token rejected")
+    await expect(gateway.read(token, "workspace:other:draft")).rejects.toThrow("sync key outside namespace workspace:demo")
+
+    await gateway.close()
+    await expect(gateway.read(token, key)).rejects.toThrow("sync gateway closed")
+  })
+
+  test("handles protocol errors and write result variants", async () => {
+    const transport: Sync.Transport = {
+      read: () => undefined,
+      write: (message) => {
+        if (message.peer === "ack") return { version: 7 }
+        if (message.peer === "conflict") return { conflict: { ...message, peer: "server", version: 8 } }
+      },
+      subscribe: () => () => {},
+    }
+    const gateway = web.server({
+      namespace,
+      transport,
+      authorize: (value) => value === token,
+    })
+    const http = web.client({ url: "http://example.test/sync", fetch: (request, init) => gateway.handle(new Request(request, init)) })
+    const message: Sync.Message = {
+      key,
+      peer: "ack",
+      version: 1,
+      value: {
+        ok: true,
+        list: [1, "two", null],
+      },
+    }
+
+    expect(await http.read(token, key)).toBeUndefined()
+    await expect(http.read("bad", key)).rejects.toThrow("sync token rejected")
+    expect(await http.write(token, message)).toEqual({ version: 7 })
+    expect(await http.write(token, { ...message, peer: "conflict" })).toEqual({
+      conflict: {
+        ...message,
+        peer: "server",
+        version: 8,
+      },
+    })
+
+    const missingToken = await gateway.handle(new Request(`http://example.test/sync/read?key=${encodeURIComponent(key)}`))
+    const missingKey = await gateway.handle(new Request("http://example.test/sync/read", {
+      headers: { authorization: `Bearer ${token}` },
+    }))
+    const invalid = await gateway.handle(new Request("http://example.test/sync/write", {
+      method: "PUT",
+      headers: { authorization: `Bearer ${token}` },
+      body: JSON.stringify({ peer: "bad", version: 1, value: 1 }),
+    }))
+    const notFound = await gateway.handle(new Request("http://example.test/sync/nope", {
+      headers: { authorization: `Bearer ${token}` },
+    }))
+
+    expect(missingToken.status).toBe(400)
+    expect(await missingToken.json()).toEqual({ error: "sync token missing" })
+    expect(missingKey.status).toBe(400)
+    expect(await missingKey.json()).toEqual({ error: "sync parameter key missing" })
+    expect(invalid.status).toBe(400)
+    expect(await invalid.json()).toEqual({ error: "sync message key invalid" })
+    expect(notFound.status).toBe(404)
+  })
+
+  test("rejects malformed protocol payloads", async () => {
+    const message: Sync.Message = {
+      key,
+      peer: "ack",
+      version: 1,
+      value: {
+        ok: true,
+      },
+    }
+    const invalidWrite = web.client({
+      url: "http://example.test/sync",
+      fetch: async () => json({ kind: "bad" }),
+    })
+    const invalidMessage = web.client({
+      url: "http://example.test/sync",
+      fetch: async () => json({ message: [] }),
+    })
+    const invalidPeer = web.client({
+      url: "http://example.test/sync",
+      fetch: async () => json({ message: { key, version: 1, value: null } }),
+    })
+    const invalidVersion = web.client({
+      url: "http://example.test/sync",
+      fetch: async () => json({ message: { key, peer: "bad", value: null } }),
+    })
+    const invalidNumber = web.client({
+      url: "http://example.test/sync",
+      fetch: async () => json({ message: { key, peer: "bad", version: 1, value: Number.NaN } }),
+    })
+    const invalidValue = web.client({
+      url: "http://example.test/sync",
+      fetch: async () => json({ message: { key, peer: "bad", version: 1, value: () => undefined } }),
+    })
+    const streamErrors: unknown[] = []
+    const missingBody = web.client({
+      url: "http://example.test/sync",
+      fetch: async () => new Response(null),
+      onError: (error) => {
+        streamErrors.push(error)
+      },
+    })
+    const streamed: Sync.Message[] = []
+    const stream = web.client({
+      url: "http://example.test/sync",
+      fetch: async () => new Response(`\n${JSON.stringify(message)}\n`),
+    })
+
+    await expect(invalidWrite.write(token, message)).rejects.toThrow("sync write result invalid")
+    await expect(invalidMessage.read(token, key)).rejects.toThrow("sync payload invalid")
+    await expect(invalidPeer.read(token, key)).rejects.toThrow("sync message peer invalid")
+    await expect(invalidVersion.read(token, key)).rejects.toThrow("sync message version invalid")
+    await expect(invalidNumber.read(token, key)).rejects.toThrow("sync number is not finite")
+    await expect(invalidValue.read(token, key)).rejects.toThrow("sync value is not JSON")
+
+    const off = await missingBody.subscribe(token, key, () => {})
+    await until(() => streamErrors.length === 1)
+    off()
+    missingBody.close()
+
+    const streamOff = await stream.subscribe(token, key, (value) => {
+      streamed.push(value)
+    })
+    await until(() => streamed.length === 1)
+    streamOff()
+    stream.close()
+  })
+
+  test("closes server watch streams through cancellation", async () => {
+    let listeners = 0
+    const gateway = web.server({
+      namespace,
+      transport: {
+        read: () => undefined,
+        write: () => undefined,
+        subscribe: () => {
+          listeners += 1
+          return () => {
+            listeners -= 1
+          }
+        },
+      },
+      authorize: (value) => value === token,
+    })
+
+    const response = await gateway.handle(new Request(`http://example.test/sync/watch?key=${encodeURIComponent(key)}`, {
+      headers: { authorization: `Bearer ${token}` },
+    }))
+    await until(() => listeners === 1)
+    const body = response.body
+    if (!body) throw new Error("expected watch body")
+    await body.cancel()
+
+    expect(listeners).toBe(0)
+  })
+
+  test("serializes non-error boundary failures", async () => {
+    const gateway = web.server({
+      namespace,
+      transport: {
+        read: () => {
+          throw "plain failure"
+        },
+        write: () => undefined,
+        subscribe: () => () => {},
+      },
+      authorize: (value) => value === token,
+    })
+
+    const response = await gateway.handle(new Request(`http://example.test/sync/read?key=${encodeURIComponent(key)}`, {
+      headers: { authorization: `Bearer ${token}` },
+    }))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: "plain failure" })
+  })
+
+  test("preserves backend write conflicts as sync conflicts", async () => {
+    const initial: Sync.Message = {
+      key,
+      peer: "backend",
+      version: 3,
+      value: {
+        id: "draft",
+        title: "Backend base",
+        body: "accepted",
+        savedBy: "backend",
+        version: 3,
+      },
+    }
+    const incoming: Sync.Message = {
+      key,
+      peer: "backend",
+      version: 4,
+      value: {
+        id: "draft",
+        title: "Backend concurrent",
+        body: "same revision",
+        savedBy: "backend",
+        version: 4,
+      },
+    }
+    let writes = 0
+    const transport: Sync.Transport = {
+      read: () => initial,
+      write: () => {
+        writes += 1
+        return { conflict: incoming }
+      },
+      subscribe: () => () => {},
+    }
+    const gateway = web.server({
+      namespace,
+      transport,
+      authorize: (value) => value === token,
+    })
+    const conflicts: Sync.Conflict<unknown>[] = []
+    const browser = createBrowserScope({
+      gateway,
+      token,
+      peer: "browser",
+      namespace,
+      onConflict: (conflict) => {
+        conflicts.push(conflict)
+      },
+    })
+
+    const current = await browser.controller(draft, { resolve: true })
+    current.set({
+      id: "draft",
+      title: "Browser concurrent",
+      body: "same revision",
+      savedBy: "browser",
+      version: 4,
+    })
+
+    await until(() => conflicts.length === 1)
+
+    expect(writes).toBe(1)
+    expect(conflicts[0]).toEqual({
+      current: {
+        id: "draft",
+        title: "Browser concurrent",
+        body: "same revision",
+        savedBy: "browser",
+        version: 4,
+      },
+      incoming: incoming.value,
+    })
+
+    await browser.dispose()
+    await gateway.close()
+  })
+
+  test("keeps browser peer identity stable through the environment store", () => {
+    const writes: string[] = []
+    let saved: string | undefined
+    const store: Web.PeerStore = {
+      read: () => saved,
+      write: (value) => {
+        saved = value
+        writes.push(value)
+      },
+    }
+
+    expect(web.peer(store, () => "peer-a")).toBe("peer-a")
+    expect(web.peer(store, () => "peer-b")).toBe("peer-a")
+    expect(writes).toEqual(["peer-a"])
+  })
+})
+
+async function until(check: () => boolean): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (check()) return
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+  throw new Error("condition did not settle")
+}
+
+function json(value: unknown): Response {
+  return {
+    ok: true,
+    body: null,
+    json: async () => value,
+    text: async () => JSON.stringify(value),
+  } as Response
+}
+
+async function serve(gateway: Web.Server): Promise<{ readonly url: string; close(): Promise<void> }> {
+  const node = createServer(async (req, res) => {
+    const body = await read(req)
+    const address = node.address() as AddressInfo
+    const response = await gateway.handle(new Request(`http://127.0.0.1:${address.port}${req.url ?? "/"}`, {
+      method: req.method,
+      headers: headers(req.headers),
+      body: requestBody(req.method ?? "GET", body),
+    }))
+    await send(res, response)
+  })
+
+  await new Promise<void>((resolve) => {
+    node.listen(0, "127.0.0.1", resolve)
+  })
+  const address = node.address() as AddressInfo
+
+  return {
+    url: `http://127.0.0.1:${address.port}/sync`,
+    close: () => new Promise<void>((resolve, reject) => {
+      node.close((error) => {
+        if (error) reject(error)
+        else resolve()
+      })
+    }),
+  }
+}
+
+async function read(req: AsyncIterable<unknown>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = []
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk as Uint8Array)
+  }
+  return Buffer.concat(chunks)
+}
+
+function requestBody(method: string, body: Uint8Array): BodyInit | undefined {
+  return method === "GET" || method === "HEAD" || body.byteLength === 0 ? undefined : Buffer.from(body).toString("utf8")
+}
+
+function headers(input: IncomingHttpHeaders): Headers {
+  const out = new Headers()
+  for (const [key, value] of Object.entries(input)) {
+    if (Array.isArray(value)) out.set(key, value.join(", "))
+    else if (value) out.set(key, value)
+  }
+  return out
+}
+
+async function send(res: ServerResponse, response: Response): Promise<void> {
+  res.statusCode = response.status
+  response.headers.forEach((value, key) => res.setHeader(key, value))
+  if (!response.body) {
+    res.end()
+    return
+  }
+  res.flushHeaders()
+  const reader = response.body.getReader()
+  for (;;) {
+    const chunk = await reader.read()
+    if (chunk.done) {
+      res.end()
+      return
+    }
+    res.write(chunk.value)
+  }
+}

--- a/examples/lite-sync-web-practical/tsconfig.json
+++ b/examples/lite-sync-web-practical/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/lite-sync-web-practical/vitest.config.ts
+++ b/examples/lite-sync-web-practical/vitest.config.ts
@@ -1,0 +1,52 @@
+import { playwright } from "@vitest/browser-playwright"
+import { configDefaults, defineConfig } from "vitest/config"
+
+export default defineConfig({
+  optimizeDeps: {
+    include: [
+      "@testing-library/jest-dom/vitest",
+      "@testing-library/react",
+      "react",
+      "react-dom/client",
+      "react/jsx-dev-runtime",
+      "react/jsx-runtime",
+    ],
+  },
+  test: {
+    projects: [
+      {
+        test: {
+          name: "node",
+          include: ["**/*.test.ts", "**/*.test.tsx"],
+          exclude: [...configDefaults.exclude, "**/*.browser.test.tsx"],
+          environment: "node",
+          globals: true,
+        },
+      },
+      {
+        test: {
+          name: "browser",
+          include: ["**/*.browser.test.tsx"],
+          globals: true,
+          setupFiles: ["./tests/setup.browser.ts"],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+          },
+        },
+      },
+    ],
+    coverage: {
+      provider: "v8",
+      include: ["src/app.tsx", "src/model.ts", "src/runtime.ts", "src/web.ts"],
+      thresholds: {
+        statements: 100,
+        branches: 100,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+})

--- a/pkg/ext/README.md
+++ b/pkg/ext/README.md
@@ -14,6 +14,7 @@ runtime.
 | `observable-otel/` | `@pumped-fn/lite-extension-observable-otel` | OpenTelemetry sink adapter for observable events. |
 | `logging/` | `@pumped-fn/lite-extension-logging` | Execution-scoped logger resource and flow logs with tag-injected sinks. |
 | `logging-pino/` | `@pumped-fn/lite-extension-logging-pino` | Pino sink adapter for logging records. |
+| `sync/` | `@pumped-fn/lite-extension-sync` | Strict replicated state primitive with tag-injected transports. |
 | `hmr/` | `@pumped-fn/lite-hmr` | Development-time HMR state preservation helpers. |
 
 ## Naming

--- a/pkg/ext/README.md
+++ b/pkg/ext/README.md
@@ -15,6 +15,7 @@ runtime.
 | `logging/` | `@pumped-fn/lite-extension-logging` | Execution-scoped logger resource and flow logs with tag-injected sinks. |
 | `logging-pino/` | `@pumped-fn/lite-extension-logging-pino` | Pino sink adapter for logging records. |
 | `sync/` | `@pumped-fn/lite-extension-sync` | Strict replicated state primitive with tag-injected transports. |
+| `sync-nats/` | `@pumped-fn/lite-extension-sync-nats` | NATS JetStream KV transport adapter for sync. |
 | `hmr/` | `@pumped-fn/lite-hmr` | Development-time HMR state preservation helpers. |
 
 ## Naming

--- a/pkg/ext/sync-nats/README.md
+++ b/pkg/ext/sync-nats/README.md
@@ -1,0 +1,29 @@
+# @pumped-fn/lite-extension-sync-nats
+
+NATS JetStream KV transport for `@pumped-fn/lite-extension-sync`.
+
+```ts
+import { Kvm } from "@nats-io/kv"
+import { connect } from "@nats-io/transport-node"
+import { createScope } from "@pumped-fn/lite"
+import { sync } from "@pumped-fn/lite-extension-sync"
+import { nats } from "@pumped-fn/lite-extension-sync-nats"
+
+const nc = await connect({ servers: "127.0.0.1:4222" })
+const kv = await new Kvm(nc).create("drafts", { history: 5 })
+
+const scope = createScope({
+  extensions: [sync.extension()],
+  tags: [
+    sync.runtime({
+      peer: "worker-1",
+      transport: nats.kv(kv),
+    }),
+  ],
+})
+```
+
+The adapter stores strict sync messages as UTF-8 JSON bytes in JetStream KV, uses watch updates for
+live delivery, and returns the backend KV revision as the sync write acknowledgement.
+Use `nats.kv(kv, { prefix, onError })` to customize the KV subject prefix or receive watch-loop
+failures from the adapter boundary.

--- a/pkg/ext/sync-nats/README.md
+++ b/pkg/ext/sync-nats/README.md
@@ -25,5 +25,7 @@ const scope = createScope({
 
 The adapter stores strict sync messages as UTF-8 JSON bytes in JetStream KV, uses watch updates for
 live delivery, and returns the backend KV revision as the sync write acknowledgement.
+JetStream stale-revision responses return sync write conflicts, so backend CAS conflicts flow through
+the same sync conflict path as watched remote records.
 Use `nats.kv(kv, { prefix, onError })` to customize the KV subject prefix or receive watch-loop
 failures from the adapter boundary.

--- a/pkg/ext/sync-nats/README.md
+++ b/pkg/ext/sync-nats/README.md
@@ -27,5 +27,7 @@ The adapter stores strict sync messages as UTF-8 JSON bytes in JetStream KV, use
 live delivery, and returns the backend KV revision as the sync write acknowledgement.
 JetStream stale-revision responses return sync write conflicts, so backend CAS conflicts flow through
 the same sync conflict path as watched remote records.
-Use `nats.kv(kv, { prefix, onError })` to customize the KV subject prefix or receive watch-loop
-failures from the adapter boundary.
+Watch failures resubscribe from the last delivered KV revision by default. Use
+`nats.kv(kv, { prefix, onError, retry })` to customize the KV subject prefix, receive watch-loop
+failures from the adapter boundary with retry metadata, or disable adapter-level retry with
+`retry: false`.

--- a/pkg/ext/sync-nats/package.json
+++ b/pkg/ext/sync-nats/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@pumped-fn/lite-extension-sync-nats",
+  "version": "0.1.0",
+  "private": false,
+  "description": "NATS JetStream KV transport for @pumped-fn/lite-extension-sync",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@nats-io/kv": "^3.4.0",
+    "@pumped-fn/lite-extension-sync": "^0.1.0"
+  },
+  "devDependencies": {
+    "@nats-io/kv": "catalog:",
+    "@nats-io/transport-node": "catalog:",
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-extension-sync": "workspace:*",
+    "@types/node": "catalog:",
+    "@vitest/coverage-v8": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "keywords": [
+    "pumped-fn",
+    "sync",
+    "nats",
+    "jetstream",
+    "kv"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "directory": "pkg/ext/sync-nats",
+    "url": "git+https://github.com/pumped-fn/pumped-fn.git"
+  }
+}

--- a/pkg/ext/sync-nats/src/index.ts
+++ b/pkg/ext/sync-nats/src/index.ts
@@ -23,6 +23,7 @@ export namespace Nats {
 
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
+const stale = new Set([10071, 10164])
 
 function kv(store: Nats.Store, options?: Nats.Options): Sync.Transport {
   const prefix = options?.prefix ?? "sync"
@@ -36,11 +37,18 @@ function kv(store: Nats.Store, options?: Nats.Options): Sync.Transport {
     async write(message) {
       const key = entryKey(prefix, message.key)
       const payload = encode(message)
-      const current = await store.get(key)
-      const version = current && current.operation === "PUT"
-        ? await store.update(key, payload, current.revision)
-        : await store.create(key, payload)
-      return { version }
+      try {
+        const current = await store.get(key)
+        const version = current && current.operation === "PUT"
+          ? await store.update(key, payload, current.revision)
+          : await store.create(key, payload)
+        return { version }
+      } catch (error) {
+        if (!isStale(error)) throw error
+        const conflict = await store.get(key)
+        if (!conflict || conflict.operation !== "PUT") throw error
+        return { conflict: decode(message.key, conflict) }
+      }
     },
     async subscribe(key, listener) {
       const watch = await store.watch({ key: entryKey(prefix, key) })
@@ -106,6 +114,14 @@ function readEntry(
     onError?.(error)
     return undefined
   }
+}
+
+function isStale(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && typeof error.code === "number"
+    && stale.has(error.code)
 }
 
 function base64(value: string): string {

--- a/pkg/ext/sync-nats/src/index.ts
+++ b/pkg/ext/sync-nats/src/index.ts
@@ -62,7 +62,8 @@ async function pump(
   try {
     for await (const entry of watch) {
       if (entry.operation !== "PUT") continue
-      listener(decode(key, entry))
+      const message = readEntry(key, entry, onError)
+      if (message) listener(message)
     }
   } catch (error) {
     onError?.(error)
@@ -91,6 +92,19 @@ function decode(key: string, entry: KvEntry): Sync.Message {
     peer: wire.peer,
     version: entry.revision,
     value: wire.value,
+  }
+}
+
+function readEntry(
+  key: string,
+  entry: KvEntry,
+  onError: ((error: unknown) => void) | undefined
+): Sync.Message | undefined {
+  try {
+    return decode(key, entry)
+  } catch (error) {
+    onError?.(error)
+    return undefined
   }
 }
 

--- a/pkg/ext/sync-nats/src/index.ts
+++ b/pkg/ext/sync-nats/src/index.ts
@@ -5,14 +5,27 @@ import { type Sync } from "@pumped-fn/lite-extension-sync"
 export namespace Nats {
   export interface Options {
     readonly prefix?: string
-    readonly onError?: (error: unknown) => void
+    readonly onError?: (error: unknown, event: WatchError) => void
+    readonly retry?: false | Retry
   }
+
+  export interface WatchError {
+    readonly attempts: number
+    readonly terminal: boolean
+  }
+
+  export interface Retry {
+    readonly attempts?: number
+    readonly delayMs?: number
+  }
+
+  export type Watch = AsyncIterable<KvEntry> & { stop(): void }
 
   export interface Store {
     get(key: string): Promise<KvEntry | null>
     create(key: string, data: Uint8Array): Promise<number>
     update(key: string, data: Uint8Array, version: number): Promise<number>
-    watch(options?: KvWatchOptions): Promise<AsyncIterable<KvEntry> & { stop(): void }>
+    watch(options?: KvWatchOptions): Promise<Watch>
   }
 
   export interface Wire {
@@ -24,6 +37,15 @@ export namespace Nats {
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 const stale = new Set([10071, 10164])
+const closed = new Error("NATS KV watch closed")
+
+interface WatchState {
+  closed: boolean
+  revision: number
+  watch: Nats.Watch | undefined
+  timer: ReturnType<typeof setTimeout> | undefined
+  wake: (() => void) | undefined
+}
 
 function kv(store: Nats.Store, options?: Nats.Options): Sync.Transport {
   const prefix = options?.prefix ?? "sync"
@@ -51,30 +73,66 @@ function kv(store: Nats.Store, options?: Nats.Options): Sync.Transport {
       }
     },
     async subscribe(key, listener) {
-      const watch = await store.watch({ key: entryKey(prefix, key) })
-      void pump(key, watch, listener, options?.onError)
+      const subject = entryKey(prefix, key)
+      const state: WatchState = {
+        closed: false,
+        revision: 0,
+        watch: undefined,
+        timer: undefined,
+        wake: undefined,
+      }
+      void pump(store, subject, key, state, listener, options?.onError, retry(options?.retry))
 
       return () => {
-        watch.stop()
+        state.closed = true
+        state.watch?.stop()
+        if (state.timer) clearTimeout(state.timer)
+        state.wake?.()
       }
     },
   }
 }
 
 async function pump(
+  store: Nats.Store,
+  subject: string,
   key: string,
-  watch: AsyncIterable<KvEntry>,
+  state: WatchState,
   listener: (message: Sync.Message) => void,
-  onError: ((error: unknown) => void) | undefined
+  onError: ((error: unknown, event: Nats.WatchError) => void) | undefined,
+  retry: RetryState | undefined
 ): Promise<void> {
-  try {
-    for await (const entry of watch) {
-      if (entry.operation !== "PUT") continue
-      const message = readEntry(key, entry, onError)
-      if (message) listener(message)
+  let attempts = 0
+  while (!state.closed) {
+    try {
+      const watch = state.watch ?? await store.watch(watchOptions(subject, state.revision))
+      if (state.closed) {
+        watch.stop()
+        return
+      }
+      state.watch = watch
+      for await (const entry of watch) {
+        if (entry.operation !== "PUT") continue
+        const message = readEntry(key, entry, onError)
+        if (!message) continue
+        state.revision = message.version
+        attempts = 0
+        listener(message)
+      }
+      if (state.closed) return
+      throw closed
+    } catch (error) {
+      if (state.closed) return
+      state.watch?.stop()
+      state.watch = undefined
+      attempts += 1
+      if (!retry || attempts > retry.attempts) {
+        onError?.(error, { attempts, terminal: true })
+        return
+      }
+      onError?.(error, { attempts, terminal: false })
+      await delay(retry.delayMs, state)
     }
-  } catch (error) {
-    onError?.(error)
   }
 }
 
@@ -106,12 +164,12 @@ function decode(key: string, entry: KvEntry): Sync.Message {
 function readEntry(
   key: string,
   entry: KvEntry,
-  onError: ((error: unknown) => void) | undefined
+  onError: ((error: unknown, event: Nats.WatchError) => void) | undefined
 ): Sync.Message | undefined {
   try {
     return decode(key, entry)
   } catch (error) {
-    onError?.(error)
+    onError?.(error, { attempts: 0, terminal: false })
     return undefined
   }
 }
@@ -122,6 +180,33 @@ function isStale(error: unknown): boolean {
     && "code" in error
     && typeof error.code === "number"
     && stale.has(error.code)
+}
+
+interface RetryState {
+  readonly attempts: number
+  readonly delayMs: number
+}
+
+function retry(value: Nats.Options["retry"]): RetryState | undefined {
+  if (value === false) return undefined
+  return {
+    attempts: value?.attempts ?? Number.POSITIVE_INFINITY,
+    delayMs: value?.delayMs ?? 100,
+  }
+}
+
+function watchOptions(key: string, revision: number): KvWatchOptions {
+  return revision > 0 ? { key, resumeFromRevision: revision + 1 } : { key }
+}
+
+async function delay(ms: number, state: WatchState): Promise<void> {
+  if (ms <= 0) return
+  await new Promise<void>((resolve) => {
+    state.wake = resolve
+    state.timer = setTimeout(resolve, ms)
+  })
+  state.timer = undefined
+  state.wake = undefined
 }
 
 function base64(value: string): string {

--- a/pkg/ext/sync-nats/src/index.ts
+++ b/pkg/ext/sync-nats/src/index.ts
@@ -1,0 +1,99 @@
+import { Buffer } from "node:buffer"
+import { type KvEntry, type KvWatchOptions } from "@nats-io/kv"
+import { type Sync } from "@pumped-fn/lite-extension-sync"
+
+export namespace Nats {
+  export interface Options {
+    readonly prefix?: string
+    readonly onError?: (error: unknown) => void
+  }
+
+  export interface Store {
+    get(key: string): Promise<KvEntry | null>
+    create(key: string, data: Uint8Array): Promise<number>
+    update(key: string, data: Uint8Array, version: number): Promise<number>
+    watch(options?: KvWatchOptions): Promise<AsyncIterable<KvEntry> & { stop(): void }>
+  }
+
+  export interface Wire {
+    readonly peer: string
+    readonly value: Sync.Value
+  }
+}
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+function kv(store: Nats.Store, options?: Nats.Options): Sync.Transport {
+  const prefix = options?.prefix ?? "sync"
+
+  return {
+    async read(key) {
+      const entry = await store.get(entryKey(prefix, key))
+      if (!entry || entry.operation !== "PUT") return undefined
+      return decode(key, entry)
+    },
+    async write(message) {
+      const key = entryKey(prefix, message.key)
+      const payload = encode(message)
+      const current = await store.get(key)
+      const version = current && current.operation === "PUT"
+        ? await store.update(key, payload, current.revision)
+        : await store.create(key, payload)
+      return { version }
+    },
+    async subscribe(key, listener) {
+      const watch = await store.watch({ key: entryKey(prefix, key) })
+      void pump(key, watch, listener, options?.onError)
+
+      return () => {
+        watch.stop()
+      }
+    },
+  }
+}
+
+async function pump(
+  key: string,
+  watch: AsyncIterable<KvEntry>,
+  listener: (message: Sync.Message) => void,
+  onError: ((error: unknown) => void) | undefined
+): Promise<void> {
+  try {
+    for await (const entry of watch) {
+      if (entry.operation !== "PUT") continue
+      listener(decode(key, entry))
+    }
+  } catch (error) {
+    onError?.(error)
+  }
+}
+
+export const nats = {
+  kv,
+}
+
+function entryKey(prefix: string, key: string): string {
+  return `${prefix}.${base64(key)}`
+}
+
+function encode(message: Sync.Message): Uint8Array {
+  return encoder.encode(JSON.stringify({
+    peer: message.peer,
+    value: message.value,
+  } satisfies Nats.Wire))
+}
+
+function decode(key: string, entry: KvEntry): Sync.Message {
+  const wire = JSON.parse(decoder.decode(entry.value)) as Nats.Wire
+  return {
+    key,
+    peer: wire.peer,
+    version: entry.revision,
+    value: wire.value,
+  }
+}
+
+function base64(value: string): string {
+  return Buffer.from(value, "utf8").toString("base64url")
+}

--- a/pkg/ext/sync-nats/tests/nats.integration.test.ts
+++ b/pkg/ext/sync-nats/tests/nats.integration.test.ts
@@ -5,7 +5,9 @@ import { connect, type NatsConnection } from "@nats-io/transport-node"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { createScope } from "@pumped-fn/lite"
 import { sync } from "@pumped-fn/lite-extension-sync"
-import { nats } from "../src"
+import { nats, type Nats } from "../src"
+
+const encoder = new TextEncoder()
 
 const canRun = docker()
 const run = canRun ? describe : describe.skip
@@ -110,6 +112,44 @@ run("nats sync transport integration", () => {
     })
   })
 
+  it("maps real JetStream stale revision failures to sync write conflicts", async () => {
+    let raced = false
+    const store = {
+      get: kv.get.bind(kv),
+      create: kv.create.bind(kv),
+      async update(key: string, data: Uint8Array, version: number) {
+        if (!raced) {
+          raced = true
+          await kv.update(key, encode({ peer: "right", value: { ok: "right" } }), version)
+        }
+        return kv.update(key, data, version)
+      },
+      watch: kv.watch.bind(kv),
+    } satisfies Nats.Store
+    const transport = nats.kv(store, { prefix: "race" })
+
+    await transport.write({
+      key: "manual",
+      peer: "left",
+      version: 1,
+      value: { ok: "left" },
+    })
+
+    expect(await transport.write({
+      key: "manual",
+      peer: "left",
+      version: 2,
+      value: { ok: "stale" },
+    })).toEqual({
+      conflict: {
+        key: "manual",
+        peer: "right",
+        version: expect.any(Number),
+        value: { ok: "right" },
+      },
+    })
+  })
+
   it("sustains one thousand backend writes with revision and overhead evidence", async () => {
     const edits = 1000
     const transport = nats.kv(kv, { prefix: "stress" })
@@ -176,4 +216,8 @@ async function until(check: () => boolean): Promise<void> {
 
 function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function encode(wire: Nats.Wire): Uint8Array {
+  return encoder.encode(JSON.stringify(wire))
 }

--- a/pkg/ext/sync-nats/tests/nats.integration.test.ts
+++ b/pkg/ext/sync-nats/tests/nats.integration.test.ts
@@ -109,6 +109,35 @@ run("nats sync transport integration", () => {
       value: { ok: 2 },
     })
   })
+
+  it("sustains one thousand backend writes with revision and overhead evidence", async () => {
+    const edits = 1000
+    const transport = nats.kv(kv, { prefix: "stress" })
+    const start = performance.now()
+    let version = 0
+
+    for (let i = 1; i <= edits; i++) {
+      const ack = await transport.write({
+        key: "draft",
+        peer: "left",
+        version: i,
+        value: { edit: i },
+      })
+      version = ack?.version ?? version
+    }
+
+    const elapsed = performance.now() - start
+    const perOp = elapsed / edits
+
+    expect(version).toBeGreaterThanOrEqual(edits)
+    expect(perOp).toBeGreaterThanOrEqual(0)
+    expect(await transport.read("draft")).toEqual({
+      key: "draft",
+      peer: "left",
+      version,
+      value: { edit: edits },
+    })
+  })
 })
 
 function docker(): boolean {

--- a/pkg/ext/sync-nats/tests/nats.integration.test.ts
+++ b/pkg/ext/sync-nats/tests/nats.integration.test.ts
@@ -1,0 +1,150 @@
+import { execFileSync, spawnSync } from "node:child_process"
+import { createServer } from "node:net"
+import { Kvm, type KV } from "@nats-io/kv"
+import { connect, type NatsConnection } from "@nats-io/transport-node"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { createScope } from "@pumped-fn/lite"
+import { sync } from "@pumped-fn/lite-extension-sync"
+import { nats } from "../src"
+
+const canRun = docker()
+const run = canRun ? describe : describe.skip
+
+if (!canRun && process.env.CI) {
+  throw new Error("Docker is required for NATS integration tests in CI")
+}
+
+run("nats sync transport integration", () => {
+  let container = ""
+  let nc: NatsConnection
+  let kv: KV
+
+  beforeAll(async () => {
+    const port = await freePort()
+    container = `pumped-sync-nats-${process.pid}-${port}`
+    execFileSync("docker", [
+      "run",
+      "--rm",
+      "-d",
+      "--name",
+      container,
+      "-p",
+      `${port}:4222`,
+      "nats:2.12-alpine",
+      "-js",
+    ], { stdio: "pipe" })
+    nc = await connectServer(port)
+    kv = await new Kvm(nc).create(`PFSYNC${process.pid}${port}`, { history: 10 })
+  })
+
+  afterAll(async () => {
+    await nc?.close()
+    if (container) {
+      spawnSync("docker", ["rm", "-f", container], { stdio: "ignore" })
+    }
+  })
+
+  it("replicates sync atoms through real JetStream KV watches", async () => {
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", version: 0 }),
+      conflict: sync.revision("version"),
+    })
+    const left = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "left",
+          namespace: "proposal",
+          transport: nats.kv(kv, { prefix: "sync" }),
+        }),
+      ],
+    })
+    const right = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "right",
+          namespace: "proposal",
+          transport: nats.kv(kv, { prefix: "sync" }),
+        }),
+      ],
+    })
+
+    await left.resolve(draft)
+    await right.resolve(draft)
+    left.controller(draft).set({ title: "NATS", version: 1 })
+
+    await until(() => right.controller(draft).get().title === "NATS")
+    const stored = await kv.get("sync.cHJvcG9zYWw6ZHJhZnQ")
+
+    expect(stored?.revision).toBeGreaterThan(0)
+    expect(right.controller(draft).get()).toEqual({ title: "NATS", version: 1 })
+    await left.dispose()
+    await right.dispose()
+  })
+
+  it("surfaces backend revisions on direct transport writes and reads", async () => {
+    const transport = nats.kv(kv, { prefix: "direct" })
+    const first = await transport.write({
+      key: "manual",
+      peer: "left",
+      version: 1,
+      value: { ok: 1 },
+    })
+    const second = await transport.write({
+      key: "manual",
+      peer: "left",
+      version: 2,
+      value: { ok: 2 },
+    })
+
+    expect(first).toEqual({ version: expect.any(Number) })
+    expect(second).toEqual({ version: expect.any(Number) })
+    expect(second && first && second.version > first.version).toBe(true)
+    expect(await transport.read("manual")).toEqual({
+      key: "manual",
+      peer: "left",
+      version: second?.version,
+      value: { ok: 2 },
+    })
+  })
+})
+
+function docker(): boolean {
+  return spawnSync("docker", ["info"], { stdio: "ignore" }).status === 0
+}
+
+async function freePort(): Promise<number> {
+  const server = createServer()
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve))
+  const address = server.address()
+  await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  if (!address || typeof address === "string") throw new Error("Port allocation failed")
+  return address.port
+}
+
+async function connectServer(port: number): Promise<NatsConnection> {
+  let last: unknown
+  for (let i = 0; i < 60; i++) {
+    try {
+      return await connect({ servers: `127.0.0.1:${port}`, timeout: 1000 })
+    } catch (error) {
+      last = error
+      await delay(500)
+    }
+  }
+  throw last
+}
+
+async function until(check: () => boolean): Promise<void> {
+  for (let i = 0; i < 100; i++) {
+    if (check()) return
+    await delay(20)
+  }
+  throw new Error("Condition was not reached")
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/pkg/ext/sync-nats/tests/nats.integration.test.ts
+++ b/pkg/ext/sync-nats/tests/nats.integration.test.ts
@@ -1,10 +1,10 @@
 import { execFileSync, spawnSync } from "node:child_process"
 import { createServer } from "node:net"
-import { Kvm, type KV } from "@nats-io/kv"
+import { Kvm, type KV, type KvWatchOptions } from "@nats-io/kv"
 import { connect, type NatsConnection } from "@nats-io/transport-node"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { createScope } from "@pumped-fn/lite"
-import { sync } from "@pumped-fn/lite-extension-sync"
+import { sync, type Sync } from "@pumped-fn/lite-extension-sync"
 import { nats, type Nats } from "../src"
 
 const encoder = new TextEncoder()
@@ -150,6 +150,54 @@ run("nats sync transport integration", () => {
     })
   })
 
+  it("resumes real JetStream KV watches from the last delivered revision", async () => {
+    const watches: KvWatchOptions[] = []
+    const errors: unknown[] = []
+    const messages: Sync.Message[] = []
+    let failed = false
+    const store = {
+      get: kv.get.bind(kv),
+      create: kv.create.bind(kv),
+      update: kv.update.bind(kv),
+      async watch(options?: KvWatchOptions) {
+        if (options) watches.push(options)
+        const watch = await kv.watch(options)
+        if (failed) return watch
+        failed = true
+        return failAfterFirst(watch, new Error("watch reset"))
+      },
+    } satisfies Nats.Store
+    const transport = nats.kv(store, {
+      prefix: "resume",
+      retry: { delayMs: 0 },
+      onError: (error) => errors.push(error),
+    })
+    const off = await transport.subscribe("manual", (message) => messages.push(message))
+
+    await transport.write({
+      key: "manual",
+      peer: "left",
+      version: 1,
+      value: { ok: 1 },
+    })
+    await until(() => messages.length === 1)
+    await until(() => errors.length === 1 && watches.length === 2)
+    await transport.write({
+      key: "manual",
+      peer: "left",
+      version: 2,
+      value: { ok: 2 },
+    })
+    await until(() => messages.length === 2)
+    off()
+
+    expect(watches[1]).toEqual({
+      key: "resume.bWFudWFs",
+      resumeFromRevision: messages[0]!.version + 1,
+    })
+    expect(messages.map((message) => message.value)).toEqual([{ ok: 1 }, { ok: 2 }])
+  })
+
   it("sustains one thousand backend writes with revision and overhead evidence", async () => {
     const edits = 1000
     const transport = nats.kv(kv, { prefix: "stress" })
@@ -220,4 +268,18 @@ function delay(ms: number): Promise<void> {
 
 function encode(wire: Nats.Wire): Uint8Array {
   return encoder.encode(JSON.stringify(wire))
+}
+
+function failAfterFirst(watch: Nats.Watch, error: unknown): Nats.Watch {
+  return {
+    stop() {
+      watch.stop()
+    },
+    async *[Symbol.asyncIterator]() {
+      for await (const entry of watch) {
+        yield entry
+        throw error
+      }
+    },
+  }
 }

--- a/pkg/ext/sync-nats/tests/nats.test.ts
+++ b/pkg/ext/sync-nats/tests/nats.test.ts
@@ -195,7 +195,7 @@ describe("nats sync transport", () => {
   it("reports watch iterator failures through adapter options", async () => {
     const store = fake()
     const errors: unknown[] = []
-    const transport = nats.kv(store, { prefix: "p", onError: (error) => errors.push(error) })
+    const transport = nats.kv(store, { prefix: "p", retry: false, onError: (error) => errors.push(error) })
     const off = await transport.subscribe("draft", () => {})
     const error = new Error("watch failed")
 
@@ -204,6 +204,211 @@ describe("nats sync transport", () => {
     off()
 
     expect(errors).toEqual([error])
+  })
+
+  it("resubscribes watched keys from the last delivered revision after iterator failures", async () => {
+    const store = fake()
+    const errors: unknown[] = []
+    const messages: unknown[] = []
+    const transport = nats.kv(store, { prefix: "p", retry: { attempts: 1, delayMs: 1 }, onError: (error) => errors.push(error) })
+    const off = await transport.subscribe("draft", (message) => messages.push(message))
+
+    store.push("p.ZHJhZnQ", "PUT", {
+      peer: "remote",
+      value: { title: "first" },
+    })
+    await until(() => messages.length === 1)
+    store.fail(new Error("watch failed"))
+    await until(() => errors.length === 1 && store.watches.length === 2)
+    store.push("p.ZHJhZnQ", "PUT", {
+      peer: "remote",
+      value: { title: "second" },
+    })
+    await until(() => messages.length === 2)
+    off()
+
+    expect(store.watches).toEqual([
+      { key: "p.ZHJhZnQ" },
+      { key: "p.ZHJhZnQ", resumeFromRevision: 2 },
+    ])
+    expect(messages).toEqual([
+      {
+        key: "draft",
+        peer: "remote",
+        version: 1,
+        value: { title: "first" },
+      },
+      {
+        key: "draft",
+        peer: "remote",
+        version: 2,
+        value: { title: "second" },
+      },
+    ])
+  })
+
+  it("reports natural watch closure and stops when retry attempts are exhausted", async () => {
+    const store = fake()
+    const errors: unknown[] = []
+    const events: Nats.WatchError[] = []
+    const transport = nats.kv(store, {
+      prefix: "p",
+      retry: { attempts: 0 },
+      onError(error, event) {
+        errors.push(error)
+        events.push(event)
+      },
+    })
+    const off = await transport.subscribe("draft", () => {})
+
+    store.end()
+    await until(() => errors.length === 1)
+    off()
+
+    expect(errors).toEqual([new Error("NATS KV watch closed")])
+    expect(events).toEqual([{ attempts: 1, terminal: true }])
+    expect(store.watches).toEqual([{ key: "p.ZHJhZnQ" }])
+  })
+
+  it("retries watches without resume when no revision was delivered", async () => {
+    const store = fake()
+    const errors: unknown[] = []
+    const transport = nats.kv(store, { prefix: "p", retry: { attempts: 1, delayMs: 0 }, onError: (error) => errors.push(error) })
+    const off = await transport.subscribe("draft", () => {})
+
+    store.fail(new Error("watch failed"))
+    await until(() => errors.length === 1 && store.watches.length === 2)
+    off()
+
+    expect(store.watches).toEqual([{ key: "p.ZHJhZnQ" }, { key: "p.ZHJhZnQ" }])
+  })
+
+  it("retries initial watch failures before any subscription is open", async () => {
+    const stream = queue<KvEntry>()
+    const error = new Error("initial watch failed")
+    const errors: unknown[] = []
+    const events: Nats.WatchError[] = []
+    let watches = 0
+    const store = {
+      get: async () => null,
+      create: async () => 0,
+      update: async () => 0,
+      async watch() {
+        watches += 1
+        if (watches === 1) throw error
+        return stream
+      },
+    } satisfies Nats.Store
+    const transport = nats.kv(store, {
+      retry: { attempts: 1, delayMs: 0 },
+      onError(found, event) {
+        errors.push(found)
+        events.push(event)
+      },
+    })
+    const off = await transport.subscribe("draft", () => {})
+
+    await until(() => watches === 2)
+    off()
+
+    expect(errors).toEqual([error])
+    expect(events).toEqual([{ attempts: 1, terminal: false }])
+  })
+
+  it("resets retry attempts after a successful resumed delivery", async () => {
+    const store = fake()
+    const errors: unknown[] = []
+    const messages: unknown[] = []
+    const transport = nats.kv(store, { prefix: "p", retry: { attempts: 1, delayMs: 0 }, onError: (error) => errors.push(error) })
+    const off = await transport.subscribe("draft", (message) => messages.push(message))
+
+    store.push("p.ZHJhZnQ", "PUT", {
+      peer: "remote",
+      value: { title: "first" },
+    })
+    await until(() => messages.length === 1)
+    store.fail(new Error("first watch failed"))
+    await until(() => errors.length === 1 && store.watches.length === 2)
+    store.push("p.ZHJhZnQ", "PUT", {
+      peer: "remote",
+      value: { title: "second" },
+    })
+    await until(() => messages.length === 2)
+    store.fail(new Error("second watch failed"))
+    await until(() => errors.length === 2 && store.watches.length === 3)
+    off()
+
+    expect(store.watches).toEqual([
+      { key: "p.ZHJhZnQ" },
+      { key: "p.ZHJhZnQ", resumeFromRevision: 2 },
+      { key: "p.ZHJhZnQ", resumeFromRevision: 3 },
+    ])
+  })
+
+  it("cleans pending retry timers when subscriptions are disposed", async () => {
+    const store = fake()
+    const errors: unknown[] = []
+    const transport = nats.kv(store, { prefix: "p", retry: { attempts: 1, delayMs: 50 }, onError: (error) => errors.push(error) })
+    const off = await transport.subscribe("draft", () => {})
+
+    store.fail(new Error("watch failed"))
+    await until(() => errors.length === 1)
+    off()
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    expect(store.watches).toEqual([{ key: "p.ZHJhZnQ" }])
+  })
+
+  it("ignores iterator failures after subscription cleanup", async () => {
+    const errors: unknown[] = []
+    const error = new Error("late failure")
+    const watch = {
+      stop() {},
+      async *[Symbol.asyncIterator]() {
+        await new Promise((resolve) => setTimeout(resolve, 1))
+        throw error
+      },
+    } satisfies Nats.Watch
+    const store = {
+      get: async () => null,
+      create: async () => 0,
+      update: async () => 0,
+      watch: async () => watch,
+    } satisfies Nats.Store
+    const transport = nats.kv(store, { onError: (found) => errors.push(found) })
+    const off = await transport.subscribe("draft", () => {})
+
+    off()
+    await new Promise((resolve) => setTimeout(resolve, 5))
+
+    expect(errors).toEqual([])
+  })
+
+  it("stops watches that open after subscription cleanup", async () => {
+    let stopped = false
+    let open: ((watch: Nats.Watch) => void) | undefined
+    const watch = {
+      stop() {
+        stopped = true
+      },
+      async *[Symbol.asyncIterator]() {},
+    } satisfies Nats.Watch
+    const store = {
+      get: async () => null,
+      create: async () => 0,
+      update: async () => 0,
+      watch: () => new Promise<Nats.Watch>((resolve) => {
+        open = resolve
+      }),
+    } satisfies Nats.Store
+    const transport = nats.kv(store)
+    const off = await transport.subscribe("draft", () => {})
+
+    off()
+    open!(watch)
+    await Promise.resolve()
+
+    expect(stopped).toBe(true)
   })
 })
 
@@ -216,6 +421,7 @@ function fake(): Nats.Store & {
   push(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
   pushRaw(key: string, operation: KvEntry["operation"], value: Uint8Array): void
   race(key: string, wire: Nats.Wire): void
+  end(): void
   fail(error: unknown): void
 } {
   let revision = 0
@@ -282,6 +488,9 @@ function fake(): Nats.Store & {
     race(key: string, wire: Nats.Wire) {
       races.set(key, wire)
     },
+    end() {
+      for (const stream of queues) stream.stop()
+    },
     fail(error: unknown) {
       for (const stream of queues) stream.fail(error)
     },
@@ -294,6 +503,7 @@ function fake(): Nats.Store & {
     push(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
     pushRaw(key: string, operation: KvEntry["operation"], value: Uint8Array): void
     race(key: string, wire: Nats.Wire): void
+    end(): void
     fail(error: unknown): void
   }
 
@@ -373,7 +583,7 @@ function queue<T>(): AsyncIterable<T> & { push(value: T): void; fail(error: unkn
 async function until(check: () => boolean): Promise<void> {
   for (let i = 0; i < 20; i++) {
     if (check()) return
-    await Promise.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 1))
   }
   throw new Error("Condition was not reached")
 }

--- a/pkg/ext/sync-nats/tests/nats.test.ts
+++ b/pkg/ext/sync-nats/tests/nats.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest"
+import { type KvEntry, type KvWatchOptions } from "@nats-io/kv"
+import { nats, type Nats } from "../src"
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+describe("nats sync transport", () => {
+  it("stores sync messages as NATS KV entries with backend revision acks", async () => {
+    const store = fake()
+    const transport = nats.kv(store, { prefix: "p" })
+
+    expect(await transport.read("draft")).toBeUndefined()
+    expect(await transport.write({
+      key: "draft",
+      peer: "left",
+      version: 1,
+      value: { title: "One" },
+    })).toEqual({ version: 1 })
+    expect(await transport.read("draft")).toEqual({
+      key: "draft",
+      peer: "left",
+      version: 1,
+      value: { title: "One" },
+    })
+    expect(await transport.write({
+      key: "draft",
+      peer: "left",
+      version: 2,
+      value: { title: "Two" },
+    })).toEqual({ version: 2 })
+
+    expect(store.keys).toEqual(["p.ZHJhZnQ", "p.ZHJhZnQ", "p.ZHJhZnQ", "p.ZHJhZnQ"])
+    expect(store.updates).toEqual([{ key: "p.ZHJhZnQ", version: 1 }])
+    expect(await transport.read("draft")).toMatchObject({
+      key: "draft",
+      version: 2,
+      value: { title: "Two" },
+    })
+  })
+
+  it("creates over deleted entries and keeps default key prefix subject-safe", async () => {
+    const store = fake()
+    const transport = nats.kv(store)
+
+    store.set("sync.ZHJhZnQ6MS93aXRoIHNwYWNl", "DEL", {
+      peer: "remote",
+      value: { deleted: true },
+    })
+
+    expect(await transport.read("draft:1/with space")).toBeUndefined()
+    expect(await transport.write({
+      key: "draft:1/with space",
+      peer: "local",
+      version: 1,
+      value: { ok: true },
+    })).toEqual({ version: 2 })
+    expect(store.creates).toEqual(["sync.ZHJhZnQ6MS93aXRoIHNwYWNl"])
+  })
+
+  it("watches update-only NATS entries and stops delivery through the cleanup", async () => {
+    const store = fake()
+    const transport = nats.kv(store, { prefix: "p" })
+    const messages: unknown[] = []
+    const off = await transport.subscribe("draft", (message) => messages.push(message))
+
+    store.push("p.ZHJhZnQ", "DEL", {
+      peer: "remote",
+      value: { title: "deleted" },
+    })
+    store.push("p.ZHJhZnQ", "PUT", {
+      peer: "remote",
+      value: { title: "live" },
+    })
+    await until(() => messages.length === 1)
+    off()
+    store.push("p.ZHJhZnQ", "PUT", {
+      peer: "remote",
+      value: { title: "ignored" },
+    })
+    await Promise.resolve()
+
+    expect(store.watches).toEqual([{ key: "p.ZHJhZnQ" }])
+    expect(messages).toEqual([
+      {
+        key: "draft",
+        peer: "remote",
+        version: 2,
+        value: { title: "live" },
+      },
+    ])
+  })
+
+  it("reports watch iterator failures through adapter options", async () => {
+    const store = fake()
+    const errors: unknown[] = []
+    const transport = nats.kv(store, { prefix: "p", onError: (error) => errors.push(error) })
+    const off = await transport.subscribe("draft", () => {})
+    const error = new Error("watch failed")
+
+    store.fail(error)
+    await until(() => errors.length === 1)
+    off()
+
+    expect(errors).toEqual([error])
+  })
+})
+
+function fake(): Nats.Store & {
+  readonly keys: string[]
+  readonly creates: string[]
+  readonly updates: { readonly key: string; readonly version: number }[]
+  readonly watches: KvWatchOptions[]
+  set(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
+  push(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
+  fail(error: unknown): void
+} {
+  let revision = 0
+  const values = new Map<string, KvEntry>()
+  const keys: string[] = []
+  const creates: string[] = []
+  const updates: { readonly key: string; readonly version: number }[] = []
+  const watches: KvWatchOptions[] = []
+  const queues: Array<ReturnType<typeof queue<KvEntry>>> = []
+
+  const store = {
+    keys,
+    creates,
+    updates,
+    watches,
+    async get(key: string) {
+      keys.push(key)
+      return values.get(key) ?? null
+    },
+    async create(key: string, data: Uint8Array) {
+      creates.push(key)
+      revision += 1
+      values.set(key, entry(key, "PUT", revision, data))
+      return revision
+    },
+    async update(key: string, data: Uint8Array, version: number) {
+      updates.push({ key, version })
+      revision += 1
+      values.set(key, entry(key, "PUT", revision, data))
+      return revision
+    },
+    async watch(options?: KvWatchOptions) {
+      if (options) watches.push(options)
+      const stream = queue<KvEntry>()
+      queues.push(stream)
+      return stream
+    },
+    set(key: string, operation: KvEntry["operation"], wire: Nats.Wire) {
+      revision += 1
+      values.set(key, entry(key, operation, revision, encode(wire)))
+    },
+    push(key: string, operation: KvEntry["operation"], wire: Nats.Wire) {
+      revision += 1
+      const next = entry(key, operation, revision, encode(wire))
+      values.set(key, next)
+      for (const stream of queues) stream.push(next)
+    },
+    fail(error: unknown) {
+      for (const stream of queues) stream.fail(error)
+    },
+  } satisfies Nats.Store & {
+    readonly keys: string[]
+    readonly creates: string[]
+    readonly updates: { readonly key: string; readonly version: number }[]
+    readonly watches: KvWatchOptions[]
+    set(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
+    push(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
+    fail(error: unknown): void
+  }
+
+  return store
+}
+
+function entry(key: string, operation: KvEntry["operation"], revision: number, value: Uint8Array): KvEntry {
+  return {
+    bucket: "sync",
+    key,
+    rawKey: key,
+    value,
+    created: new Date(0),
+    revision,
+    operation,
+    length: value.byteLength,
+    string() {
+      return decoder.decode(value)
+    },
+    json<T>() {
+      return JSON.parse(decoder.decode(value)) as T
+    },
+  }
+}
+
+function encode(wire: Nats.Wire): Uint8Array {
+  return encoder.encode(JSON.stringify(wire))
+}
+
+function queue<T>(): AsyncIterable<T> & { push(value: T): void; fail(error: unknown): void; stop(): void } {
+  const values: T[] = []
+  let stopped = false
+  let failed = false
+  let failure: unknown
+  let resume: (() => void) | undefined
+
+  return {
+    push(value) {
+      if (stopped) return
+      values.push(value)
+      resume?.()
+      resume = undefined
+    },
+    fail(error) {
+      failed = true
+      failure = error
+      resume?.()
+      resume = undefined
+    },
+    stop() {
+      stopped = true
+      resume?.()
+      resume = undefined
+    },
+    async *[Symbol.asyncIterator]() {
+      while (!stopped) {
+        if (failed) throw failure
+        const value = values.shift()
+        if (value !== undefined) {
+          yield value
+          continue
+        }
+        await new Promise<void>((resolve) => {
+          resume = resolve
+        })
+      }
+    },
+  }
+}
+
+async function until(check: () => boolean): Promise<void> {
+  for (let i = 0; i < 20; i++) {
+    if (check()) return
+    await Promise.resolve()
+  }
+  throw new Error("Condition was not reached")
+}

--- a/pkg/ext/sync-nats/tests/nats.test.ts
+++ b/pkg/ext/sync-nats/tests/nats.test.ts
@@ -91,6 +91,61 @@ describe("nats sync transport", () => {
     ])
   })
 
+  it("reports corrupt watched entries and keeps delivering later records", async () => {
+    const store = fake()
+    const errors: unknown[] = []
+    const messages: unknown[] = []
+    const transport = nats.kv(store, { prefix: "p", onError: (error) => errors.push(error) })
+    const off = await transport.subscribe("draft", (message) => messages.push(message))
+
+    store.pushRaw("p.ZHJhZnQ", "PUT", encoder.encode("{"))
+    store.push("p.ZHJhZnQ", "PUT", {
+      peer: "remote",
+      value: { title: "after" },
+    })
+    await until(() => errors.length === 1 && messages.length === 1)
+    off()
+
+    expect(errors[0]).toBeInstanceOf(SyntaxError)
+    expect(messages).toEqual([
+      {
+        key: "draft",
+        peer: "remote",
+        version: 2,
+        value: { title: "after" },
+      },
+    ])
+  })
+
+  it("surfaces stale revision writes as backend CAS failures", async () => {
+    const store = fake()
+    const transport = nats.kv(store, { prefix: "p" })
+
+    await transport.write({
+      key: "draft",
+      peer: "left",
+      version: 1,
+      value: { title: "left" },
+    })
+    store.race("p.ZHJhZnQ", {
+      peer: "right",
+      value: { title: "right" },
+    })
+
+    await expect(transport.write({
+      key: "draft",
+      peer: "left",
+      version: 2,
+      value: { title: "stale" },
+    })).rejects.toThrow("NATS KV revision mismatch")
+    expect(await transport.read("draft")).toEqual({
+      key: "draft",
+      peer: "right",
+      version: 2,
+      value: { title: "right" },
+    })
+  })
+
   it("reports watch iterator failures through adapter options", async () => {
     const store = fake()
     const errors: unknown[] = []
@@ -113,6 +168,8 @@ function fake(): Nats.Store & {
   readonly watches: KvWatchOptions[]
   set(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
   push(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
+  pushRaw(key: string, operation: KvEntry["operation"], value: Uint8Array): void
+  race(key: string, wire: Nats.Wire): void
   fail(error: unknown): void
 } {
   let revision = 0
@@ -122,6 +179,7 @@ function fake(): Nats.Store & {
   const updates: { readonly key: string; readonly version: number }[] = []
   const watches: KvWatchOptions[] = []
   const queues: Array<ReturnType<typeof queue<KvEntry>>> = []
+  const races = new Map<string, Nats.Wire>()
 
   const store = {
     keys,
@@ -140,6 +198,15 @@ function fake(): Nats.Store & {
     },
     async update(key: string, data: Uint8Array, version: number) {
       updates.push({ key, version })
+      const race = races.get(key)
+      if (race) {
+        races.delete(key)
+        revision += 1
+        const next = entry(key, "PUT", revision, encode(race))
+        values.set(key, next)
+        for (const stream of queues) stream.push(next)
+      }
+      if (values.get(key)?.revision !== version) throw new Error("NATS KV revision mismatch")
       revision += 1
       values.set(key, entry(key, "PUT", revision, data))
       return revision
@@ -160,6 +227,15 @@ function fake(): Nats.Store & {
       values.set(key, next)
       for (const stream of queues) stream.push(next)
     },
+    pushRaw(key: string, operation: KvEntry["operation"], value: Uint8Array) {
+      revision += 1
+      const next = entry(key, operation, revision, value)
+      values.set(key, next)
+      for (const stream of queues) stream.push(next)
+    },
+    race(key: string, wire: Nats.Wire) {
+      races.set(key, wire)
+    },
     fail(error: unknown) {
       for (const stream of queues) stream.fail(error)
     },
@@ -170,6 +246,8 @@ function fake(): Nats.Store & {
     readonly watches: KvWatchOptions[]
     set(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
     push(key: string, operation: KvEntry["operation"], wire: Nats.Wire): void
+    pushRaw(key: string, operation: KvEntry["operation"], value: Uint8Array): void
+    race(key: string, wire: Nats.Wire): void
     fail(error: unknown): void
   }
 

--- a/pkg/ext/sync-nats/tests/nats.test.ts
+++ b/pkg/ext/sync-nats/tests/nats.test.ts
@@ -117,7 +117,7 @@ describe("nats sync transport", () => {
     ])
   })
 
-  it("surfaces stale revision writes as backend CAS failures", async () => {
+  it("surfaces stale revision writes as sync write conflicts", async () => {
     const store = fake()
     const transport = nats.kv(store, { prefix: "p" })
 
@@ -137,13 +137,59 @@ describe("nats sync transport", () => {
       peer: "left",
       version: 2,
       value: { title: "stale" },
-    })).rejects.toThrow("NATS KV revision mismatch")
+    })).resolves.toEqual({
+      conflict: {
+        key: "draft",
+        peer: "right",
+        version: 2,
+        value: { title: "right" },
+      },
+    })
     expect(await transport.read("draft")).toEqual({
       key: "draft",
       peer: "right",
       version: 2,
       value: { title: "right" },
     })
+  })
+
+  it("keeps non-stale write failures as backend errors", async () => {
+    const error = new Error("backend offline")
+    const store = {
+      get: async () => null,
+      create: async () => {
+        throw error
+      },
+      update: async () => 0,
+      watch: async () => queue<KvEntry>(),
+    } satisfies Nats.Store
+    const transport = nats.kv(store)
+
+    await expect(transport.write({
+      key: "draft",
+      peer: "left",
+      version: 1,
+      value: { title: "left" },
+    })).rejects.toBe(error)
+  })
+
+  it("keeps stale write failures as errors when no conflict record exists", async () => {
+    const store = {
+      get: async () => null,
+      create: async () => {
+        throw staleError()
+      },
+      update: async () => 0,
+      watch: async () => queue<KvEntry>(),
+    } satisfies Nats.Store
+    const transport = nats.kv(store)
+
+    await expect(transport.write({
+      key: "draft",
+      peer: "left",
+      version: 1,
+      value: { title: "left" },
+    })).rejects.toThrow("NATS KV revision mismatch")
   })
 
   it("reports watch iterator failures through adapter options", async () => {
@@ -206,7 +252,7 @@ function fake(): Nats.Store & {
         values.set(key, next)
         for (const stream of queues) stream.push(next)
       }
-      if (values.get(key)?.revision !== version) throw new Error("NATS KV revision mismatch")
+      if (values.get(key)?.revision !== version) throw staleError()
       revision += 1
       values.set(key, entry(key, "PUT", revision, data))
       return revision
@@ -275,6 +321,12 @@ function entry(key: string, operation: KvEntry["operation"], revision: number, v
 
 function encode(wire: Nats.Wire): Uint8Array {
   return encoder.encode(JSON.stringify(wire))
+}
+
+function staleError(): Error & { code: number } {
+  const error = new Error("NATS KV revision mismatch") as Error & { code: number }
+  error.code = 10071
+  return error
 }
 
 function queue<T>(): AsyncIterable<T> & { push(value: T): void; fail(error: unknown): void; stop(): void } {

--- a/pkg/ext/sync-nats/tsconfig.json
+++ b/pkg/ext/sync-nats/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "../..",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "types": ["node"],
+    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
+    "paths": {
+      "@pumped-fn/lite-extension-sync": ["../sync/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pkg/ext/sync-nats/tsconfig.test.json
+++ b/pkg/ext/sync-nats/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pkg/ext/sync-nats/tsdown.config.ts
+++ b/pkg/ext/sync-nats/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+})

--- a/pkg/ext/sync-nats/vitest.config.ts
+++ b/pkg/ext/sync-nats/vitest.config.ts
@@ -1,0 +1,26 @@
+import { resolve } from "node:path"
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    hookTimeout: 120000,
+    testTimeout: 120000,
+    coverage: {
+      provider: "v8",
+      reporter: ["text"],
+      include: ["src/**/*.ts"],
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        statements: 100,
+        branches: 100,
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      "@pumped-fn/lite-extension-sync": resolve(__dirname, "../sync/src/index.ts"),
+    },
+  },
+})

--- a/pkg/ext/sync/README.md
+++ b/pkg/ext/sync/README.md
@@ -1,0 +1,28 @@
+# @pumped-fn/lite-extension-sync
+
+Strict replicated state for Lite scopes.
+
+```ts
+import { createScope } from "@pumped-fn/lite"
+import { sync } from "@pumped-fn/lite-extension-sync"
+
+const draft = sync({
+  id: "draft",
+  factory: () => ({ title: "", body: "" }),
+})
+
+const wire = sync.memory()
+
+const left = createScope({
+  extensions: [sync.extension()],
+  tags: [sync.runtime({ peer: "left", transport: wire })],
+})
+
+const right = createScope({
+  extensions: [sync.extension()],
+  tags: [sync.runtime({ peer: "right", transport: wire })],
+})
+```
+
+`sync(...)` returns an atom-like value. Plain JSON-safe state is inferred. Non-JSON state must use a
+codec, and every inbound value is decoded before it can be applied.

--- a/pkg/ext/sync/package.json
+++ b/pkg/ext/sync/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@pumped-fn/lite-extension-sync",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Strict replicated state primitive and sync extension for @pumped-fn/lite",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest run --coverage",
+    "test:watch": "vitest"
+  },
+  "peerDependencies": {
+    "@pumped-fn/lite": "^3.2.0"
+  },
+  "devDependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "keywords": [
+    "pumped-fn",
+    "sync",
+    "replication",
+    "extension"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "directory": "pkg/ext/sync",
+    "url": "git+https://github.com/pumped-fn/pumped-fn.git"
+  }
+}

--- a/pkg/ext/sync/src/index.ts
+++ b/pkg/ext/sync/src/index.ts
@@ -32,9 +32,15 @@ export namespace Sync {
     readonly version: number
   }
 
+  export interface WriteConflict {
+    readonly conflict: Message
+  }
+
+  export type WriteResult = WriteAck | WriteConflict | void
+
   export interface Transport {
     read(key: string): MaybePromise<Message | undefined>
-    write(message: Message): MaybePromise<WriteAck | void>
+    write(message: Message): MaybePromise<WriteResult>
     subscribe(key: string, listener: (message: Message) => void): MaybePromise<() => void>
     close?(): MaybePromise<void>
   }
@@ -315,7 +321,7 @@ async function bind<T>(
     if (encoded === undefined) return
     if (!state.writing && state.desired === undefined && sameValue(encoded, state.last)) return
     state.desired = encoded
-    void flush(current, state, key)
+    void flush(current, spec, ctrl, state, key)
   })
 
   const close = () => {
@@ -326,7 +332,13 @@ async function bind<T>(
   ctx.data.set(bound, state)
 }
 
-async function flush<T>(current: Active, state: Bound<T>, key: string): Promise<void> {
+async function flush<T>(
+  current: Active,
+  spec: Spec<T, Sync.Value>,
+  ctrl: Lite.Controller<T>,
+  state: Bound<T>,
+  key: string
+): Promise<void> {
   if (state.writing) return
   state.writing = true
   while (state.desired !== undefined) {
@@ -345,6 +357,10 @@ async function flush<T>(current: Active, state: Bound<T>, key: string): Promise<
       version,
       value: encoded,
     })
+    if (ack && isWriteConflict(ack)) {
+      apply(current, spec, ctrl, state, ack.conflict)
+      continue
+    }
     if (!ack || state.version !== version) continue
     state.last = encoded
     state.version = Math.max(version, ack === true ? version : ack.version)
@@ -352,7 +368,7 @@ async function flush<T>(current: Active, state: Bound<T>, key: string): Promise<
   state.writing = false
 }
 
-async function write(current: Active, message: Sync.Message): Promise<Sync.WriteAck | true | undefined> {
+async function write(current: Active, message: Sync.Message): Promise<Sync.WriteAck | Sync.WriteConflict | true | undefined> {
   try {
     return await current.transport.write(message) ?? true
   } catch (error) {
@@ -490,6 +506,10 @@ function isConflict<T>(value: T | Sync.Conflict<T>): value is Sync.Conflict<T> {
     && value !== null
     && "current" in value
     && "incoming" in value
+}
+
+function isWriteConflict(value: Sync.WriteAck | Sync.WriteConflict | true): value is Sync.WriteConflict {
+  return typeof value === "object" && "conflict" in value
 }
 
 function scopedKey(current: Active, id: string): string {

--- a/pkg/ext/sync/src/index.ts
+++ b/pkg/ext/sync/src/index.ts
@@ -28,10 +28,14 @@ export namespace Sync {
     readonly value: Value
   }
 
+  export interface WriteAck {
+    readonly version: number
+  }
+
   export interface Transport {
     read(key: string): MaybePromise<Message | undefined>
-    write(message: Message): MaybePromise<void>
-    subscribe(key: string, listener: (message: Message) => void): () => void
+    write(message: Message): MaybePromise<WriteAck | void>
+    subscribe(key: string, listener: (message: Message) => void): MaybePromise<() => void>
     close?(): MaybePromise<void>
   }
 
@@ -92,8 +96,10 @@ interface Spec<T, Wire extends Sync.Value> {
 }
 
 interface Bound<T> {
-  last: Sync.Value | undefined
+  last: Sync.Value
+  desired: Sync.Value | undefined
   version: number
+  writing: boolean
   applying: boolean
 }
 
@@ -157,7 +163,8 @@ function extension(options?: Sync.Options): Lite.Extension {
       const key = scopedKey(current, spec.id)
       const remote = await read(current, key)
       const value = remote ? decode(current, spec, remote, local) : local
-      bind(event.scope, event.target, event.ctx, current, spec, key, remote?.value)
+      const last = encode(current, spec, value, false)
+      if (last !== undefined) await bind(event.scope, event.target, event.ctx, current, spec, key, last)
       return value
     },
   }
@@ -252,7 +259,7 @@ export const sync = Object.assign(create, {
 })
 
 function validate<T>(value: T, spec: Spec<T, Sync.Value>): T {
-  spec.codec.encode(value)
+  assertValue(spec.codec.encode(value))
   return value
 }
 
@@ -278,40 +285,37 @@ async function read(current: Active, key: string): Promise<Sync.Message | undefi
   }
 }
 
-function bind<T>(
+async function bind<T>(
   scope: Lite.Scope,
   target: Lite.Atom<unknown>,
   ctx: Lite.ResolveContext,
   current: Active,
   spec: Spec<T, Sync.Value>,
   key: string,
-  last: Sync.Value | undefined
-): void {
+  last: Sync.Value
+): Promise<void> {
   const ctrl = scope.controller(target as Lite.Atom<T>)
   const state: Bound<T> = {
     last,
+    desired: undefined,
     version: 0,
+    writing: false,
     applying: false,
   }
+
+  const offRemote = await subscribe(current, key, (message) => {
+    if (message.peer === current.peer) return
+    apply(current, spec, ctrl, state, message)
+  })
 
   const offChange = ctrl.on("resolved", () => {
     if (state.applying) return
     const value = ctrl.get()
     const encoded = encode(current, spec, value)
-    if (encoded === undefined || sameValue(encoded, state.last)) return
-    state.version += 1
-    state.last = encoded
-    void write(current, {
-      key,
-      peer: current.peer,
-      version: state.version,
-      value: encoded,
-    })
-  })
-
-  const offRemote = subscribe(current, key, (message) => {
-    if (message.peer === current.peer) return
-    apply(current, spec, ctrl, state, message)
+    if (encoded === undefined) return
+    if (!state.writing && state.desired === undefined && sameValue(encoded, state.last)) return
+    state.desired = encoded
+    void flush(current, state, key)
   })
 
   const close = () => {
@@ -322,17 +326,44 @@ function bind<T>(
   ctx.data.set(bound, state)
 }
 
-async function write(current: Active, message: Sync.Message): Promise<void> {
+async function flush<T>(current: Active, state: Bound<T>, key: string): Promise<void> {
+  if (state.writing) return
+  state.writing = true
+  while (state.desired !== undefined) {
+    const encoded = state.desired
+    if (sameValue(encoded, state.last)) {
+      state.desired = undefined
+      continue
+    }
+
+    state.desired = undefined
+    state.version += 1
+    const version = state.version
+    const ack = await write(current, {
+      key,
+      peer: current.peer,
+      version,
+      value: encoded,
+    })
+    if (!ack || state.version !== version) continue
+    state.last = encoded
+    state.version = Math.max(version, ack === true ? version : ack.version)
+  }
+  state.writing = false
+}
+
+async function write(current: Active, message: Sync.Message): Promise<Sync.WriteAck | true | undefined> {
   try {
-    await current.transport.write(message)
+    return await current.transport.write(message) ?? true
   } catch (error) {
-    handleError(current, error, "write", message)
+    handleError(current, error, "write", message, false)
+    return undefined
   }
 }
 
-function subscribe(current: Active, key: string, listener: (message: Sync.Message) => void): () => void {
+async function subscribe(current: Active, key: string, listener: (message: Sync.Message) => void): Promise<() => void> {
   try {
-    return current.transport.subscribe(key, (message) => {
+    return await current.transport.subscribe(key, (message) => {
       try {
         listener(message)
       } catch (error) {
@@ -374,7 +405,7 @@ function apply<T>(
 
 function encode<T>(current: Active, spec: Spec<T, Sync.Value>, value: T, throwOnFailure = true): Sync.Value | undefined {
   try {
-    return spec.codec.encode(value)
+    return assertValue(spec.codec.encode(value))
   } catch (error) {
     handleError(current, error, "encode", undefined, throwOnFailure)
     return undefined
@@ -496,8 +527,7 @@ function assertRecord(value: Record<string, unknown>): Sync.Value {
   return result
 }
 
-function sameValue(left: Sync.Value | undefined, right: Sync.Value | undefined): boolean {
-  if (left === undefined || right === undefined) return left === right
+function sameValue(left: Sync.Value, right: Sync.Value): boolean {
   if (Object.is(left, right)) return true
   if (typeof left !== "object" || typeof right !== "object" || left === null || right === null) return false
   if (Array.isArray(left) || Array.isArray(right)) return sameArray(left, right)
@@ -509,7 +539,7 @@ function sameValue(left: Sync.Value | undefined, right: Sync.Value | undefined):
   const rightRecord = right as { readonly [key: string]: Sync.Value }
   for (const key of leftKeys) {
     if (!Object.hasOwn(rightRecord, key)) return false
-    if (!sameValue(leftRecord[key], rightRecord[key])) return false
+    if (!sameValue(leftRecord[key]!, rightRecord[key]!)) return false
   }
   return true
 }
@@ -518,7 +548,7 @@ function sameArray(left: Sync.Value, right: Sync.Value): boolean {
   if (!Array.isArray(left) || !Array.isArray(right)) return false
   if (left.length !== right.length) return false
   for (let i = 0; i < left.length; i++) {
-    if (!sameValue(left[i], right[i])) return false
+    if (!sameValue(left[i]!, right[i]!)) return false
   }
   return true
 }

--- a/pkg/ext/sync/src/index.ts
+++ b/pkg/ext/sync/src/index.ts
@@ -1,0 +1,524 @@
+import { atom, tag, type Lite } from "@pumped-fn/lite"
+
+type MaybePromise<T> = T | Promise<T>
+
+export namespace Sync {
+  export type Value = Lite.JsonValue
+  export type Failure = "isolate" | "throw"
+  export type ErrorPhase = "read" | "write" | "subscribe" | "decode" | "encode" | "conflict"
+
+  export interface Codec<T, Wire extends Value> {
+    encode(value: T): Wire
+    decode(raw: Wire): T
+  }
+
+  export interface Conflict<T> {
+    readonly current: T
+    readonly incoming: T
+  }
+
+  export interface Policy<T> {
+    resolve(current: T, incoming: T): T | Conflict<T>
+  }
+
+  export interface Message {
+    readonly key: string
+    readonly peer: string
+    readonly version: number
+    readonly value: Value
+  }
+
+  export interface Transport {
+    read(key: string): MaybePromise<Message | undefined>
+    write(message: Message): MaybePromise<void>
+    subscribe(key: string, listener: (message: Message) => void): () => void
+    close?(): MaybePromise<void>
+  }
+
+  export interface Runtime {
+    readonly peer: string
+    readonly transport: Transport
+    readonly namespace?: string
+    readonly failure?: Failure
+    readonly onError?: (error: unknown, phase: ErrorPhase, message: Message | undefined) => void
+    readonly onConflict?: (conflict: Conflict<unknown>, message: Message) => void
+  }
+
+  export interface Options {
+    readonly name?: string
+  }
+
+  export interface Base<T, D extends Record<string, Lite.AtomDependency> | undefined> {
+    readonly id: string
+    readonly deps?: D
+    readonly factory: D extends Record<string, Lite.AtomDependency>
+      ? (ctx: Lite.ResolveContext, deps: Lite.InferDeps<D>) => MaybePromise<T>
+      : (ctx: Lite.ResolveContext) => MaybePromise<T>
+    readonly tags?: Lite.Tagged<any>[]
+    readonly keepAlive?: boolean
+    readonly conflict?: Policy<NoInfer<T>>
+  }
+
+  export type Json<T extends Value, D extends Record<string, Lite.AtomDependency> | undefined> = Base<T, D>
+
+  export type Encoded<
+    T,
+    Wire extends Value,
+    D extends Record<string, Lite.AtomDependency> | undefined,
+  > = Base<T, D> & {
+    readonly codec: Codec<T, Wire>
+  }
+
+  export interface Memory extends Transport {
+    records(): readonly Message[]
+    clear(): void
+    size(): number
+  }
+}
+
+interface Active {
+  readonly peer: string
+  readonly transport: Sync.Transport
+  readonly namespace: string | undefined
+  readonly failure: Sync.Failure
+  readonly onError: ((error: unknown, phase: Sync.ErrorPhase, message: Sync.Message | undefined) => void) | undefined
+  readonly onConflict: ((conflict: Sync.Conflict<unknown>, message: Sync.Message) => void) | undefined
+}
+
+interface Spec<T, Wire extends Sync.Value> {
+  readonly id: string
+  readonly codec: Sync.Codec<T, Wire>
+  readonly conflict: Sync.Policy<T> | undefined
+}
+
+interface Bound<T> {
+  last: Sync.Value | undefined
+  version: number
+  applying: boolean
+}
+
+const meta = tag<Spec<any, Sync.Value>>({ label: "sync.meta" })
+const runtime = tag<Sync.Runtime>({ label: "sync.runtime" })
+const bound = Symbol("@pumped-fn/lite-extension-sync/bound")
+
+const json: Sync.Codec<Sync.Value, Sync.Value> = {
+  encode: assertValue,
+  decode: assertValue,
+}
+
+function create<T extends Sync.Value>(config: Sync.Json<T, undefined>): Lite.Atom<T>
+function create<T extends Sync.Value, const D extends Record<string, Lite.AtomDependency>>(config: Sync.Json<T, D>): Lite.Atom<T>
+function create<T, const Wire extends Sync.Value>(config: Sync.Encoded<T, Wire, undefined>): Lite.Atom<T>
+function create<T, const Wire extends Sync.Value, const D extends Record<string, Lite.AtomDependency>>(config: Sync.Encoded<T, Wire, D>): Lite.Atom<T>
+function create(config: Sync.Base<unknown, Record<string, Lite.AtomDependency> | undefined> & { readonly codec?: Sync.Codec<unknown, Sync.Value> }): Lite.Atom<unknown> {
+  const spec = {
+    id: config.id,
+    codec: config.codec ?? json,
+    conflict: config.conflict,
+  }
+
+  if (config.deps) {
+    return atom({
+      deps: config.deps,
+      factory: (ctx: Lite.ResolveContext, deps: Lite.InferDeps<Record<string, Lite.AtomDependency>>) => {
+        const value = config.factory(ctx, deps)
+        if (isPromise(value)) return value.then((resolved) => validate(resolved, spec))
+        return validate(value, spec)
+      },
+      tags: [meta(spec), ...(config.tags ?? [])],
+      keepAlive: config.keepAlive ?? true,
+    })
+  }
+
+  return atom({
+    factory: (ctx: Lite.ResolveContext) => {
+      const value = (config.factory as (ctx: Lite.ResolveContext) => MaybePromise<unknown>)(ctx)
+      if (isPromise(value)) return value.then((resolved) => validate(resolved, spec))
+      return validate(value, spec)
+    },
+    tags: [meta(spec), ...(config.tags ?? [])],
+    keepAlive: config.keepAlive ?? true,
+  })
+}
+
+function extension(options?: Sync.Options): Lite.Extension {
+  return {
+    name: options?.name ?? "sync",
+    async wrapResolve(run, event) {
+      if (event.kind !== "atom") return run()
+      const spec = meta.find(event.target)
+      if (!spec) return run()
+
+      const local = await run()
+      const current = active(event.scope)
+      if (!current) return local
+      if (event.ctx.data.get(bound)) return local
+
+      const key = scopedKey(current, spec.id)
+      const remote = await read(current, key)
+      const value = remote ? decode(current, spec, remote, local) : local
+      bind(event.scope, event.target, event.ctx, current, spec, key, remote?.value)
+      return value
+    },
+  }
+}
+
+function memory(): Sync.Memory {
+  const values = new Map<string, Sync.Message>()
+  const messages: Sync.Message[] = []
+  const listeners = new Map<string, Set<(message: Sync.Message) => void>>()
+
+  return {
+    read(key) {
+      return values.get(key)
+    },
+    write(message) {
+      values.set(message.key, message)
+      messages.push(message)
+      const found = listeners.get(message.key)
+      if (found) {
+        for (const listener of found) listener(message)
+      }
+    },
+    subscribe(key, listener) {
+      let found = listeners.get(key)
+      if (!found) {
+        found = new Set()
+        listeners.set(key, found)
+      }
+      found.add(listener)
+      return () => {
+        found.delete(listener)
+        if (found.size === 0) listeners.delete(key)
+      }
+    },
+    records() {
+      return messages.slice()
+    },
+    clear() {
+      values.clear()
+      messages.length = 0
+    },
+    size() {
+      return messages.length
+    },
+    close() {
+      listeners.clear()
+    },
+  }
+}
+
+function codec<T, const Wire extends Sync.Value>(value: Sync.Codec<T, Wire>): Sync.Codec<T, Wire> {
+  return value
+}
+
+function revision<const K extends string>(read: K): {
+  resolve<T extends Record<K, number>>(current: T, incoming: T): T | Sync.Conflict<T>
+}
+function revision<T>(read: (value: T) => number): Sync.Policy<T>
+function revision(read: string | ((value: never) => number)) {
+  const readVersion = versionReader(read)
+  return {
+    resolve(current: unknown, incoming: unknown) {
+      const currentVersion = readVersion(current)
+      const incomingVersion = readVersion(incoming)
+      if (incomingVersion > currentVersion) return incoming
+      if (incomingVersion < currentVersion || Object.is(current, incoming)) return current
+      return { current, incoming }
+    },
+  }
+}
+
+function lww<const K extends string>(read: K): {
+  resolve<T extends Record<K, number>>(current: T, incoming: T): T | Sync.Conflict<T>
+}
+function lww<T>(read: (value: T) => number): Sync.Policy<T>
+function lww(read: string | ((value: never) => number)) {
+  const readVersion = versionReader(read)
+  return {
+    resolve(current: unknown, incoming: unknown) {
+      return readVersion(incoming) >= readVersion(current) ? incoming : current
+    },
+  }
+}
+
+export const sync = Object.assign(create, {
+  runtime,
+  extension,
+  memory,
+  codec,
+  revision,
+  lww,
+})
+
+function validate<T>(value: T, spec: Spec<T, Sync.Value>): T {
+  spec.codec.encode(value)
+  return value
+}
+
+function active(scope: Lite.Scope): Active | undefined {
+  const value = runtime.find(scope as unknown as Lite.TagSource)
+  if (!value) return undefined
+  return {
+    peer: value.peer,
+    transport: value.transport,
+    namespace: value.namespace,
+    failure: value.failure ?? "isolate",
+    onError: value.onError,
+    onConflict: value.onConflict,
+  }
+}
+
+async function read(current: Active, key: string): Promise<Sync.Message | undefined> {
+  try {
+    return await current.transport.read(key)
+  } catch (error) {
+    handleError(current, error, "read", undefined)
+    return undefined
+  }
+}
+
+function bind<T>(
+  scope: Lite.Scope,
+  target: Lite.Atom<unknown>,
+  ctx: Lite.ResolveContext,
+  current: Active,
+  spec: Spec<T, Sync.Value>,
+  key: string,
+  last: Sync.Value | undefined
+): void {
+  const ctrl = scope.controller(target as Lite.Atom<T>)
+  const state: Bound<T> = {
+    last,
+    version: 0,
+    applying: false,
+  }
+
+  const offChange = ctrl.on("resolved", () => {
+    if (state.applying) return
+    const value = ctrl.get()
+    const encoded = encode(current, spec, value)
+    if (encoded === undefined || sameValue(encoded, state.last)) return
+    state.version += 1
+    state.last = encoded
+    void write(current, {
+      key,
+      peer: current.peer,
+      version: state.version,
+      value: encoded,
+    })
+  })
+
+  const offRemote = subscribe(current, key, (message) => {
+    if (message.peer === current.peer) return
+    apply(current, spec, ctrl, state, message)
+  })
+
+  const close = () => {
+    offRemote()
+    offChange()
+  }
+  ctx.cleanup(close)
+  ctx.data.set(bound, state)
+}
+
+async function write(current: Active, message: Sync.Message): Promise<void> {
+  try {
+    await current.transport.write(message)
+  } catch (error) {
+    handleError(current, error, "write", message)
+  }
+}
+
+function subscribe(current: Active, key: string, listener: (message: Sync.Message) => void): () => void {
+  try {
+    return current.transport.subscribe(key, (message) => {
+      try {
+        listener(message)
+      } catch (error) {
+        handleError(current, error, "subscribe", undefined, false)
+      }
+    })
+  } catch (error) {
+    handleError(current, error, "subscribe", undefined)
+    return () => {}
+  }
+}
+
+function apply<T>(
+  current: Active,
+  spec: Spec<T, Sync.Value>,
+  ctrl: Lite.Controller<T>,
+  state: Bound<T>,
+  message: Sync.Message
+): void {
+  const incoming = decode(current, spec, message, undefined, false)
+  if (incoming === undefined) return
+
+  const next = resolveConflict(current, spec, ctrl.get(), incoming, message, false)
+  if (next === undefined) return
+  if (isConflict(next)) {
+    current.onConflict?.(next, message)
+    return
+  }
+
+  const encoded = encode(current, spec, next, false)
+  if (encoded === undefined || sameValue(encoded, state.last)) return
+
+  state.applying = true
+  state.last = encoded
+  state.version = Math.max(state.version, message.version)
+  ctrl.set(next)
+  state.applying = false
+}
+
+function encode<T>(current: Active, spec: Spec<T, Sync.Value>, value: T, throwOnFailure = true): Sync.Value | undefined {
+  try {
+    return spec.codec.encode(value)
+  } catch (error) {
+    handleError(current, error, "encode", undefined, throwOnFailure)
+    return undefined
+  }
+}
+
+function decode<T>(current: Active, spec: Spec<T, Sync.Value>, message: Sync.Message, fallback: T): T
+function decode<T>(current: Active, spec: Spec<T, Sync.Value>, message: Sync.Message, fallback: undefined): T | undefined
+function decode<T>(current: Active, spec: Spec<T, Sync.Value>, message: Sync.Message, fallback: T, throwOnFailure: boolean): T
+function decode<T>(
+  current: Active,
+  spec: Spec<T, Sync.Value>,
+  message: Sync.Message,
+  fallback: undefined,
+  throwOnFailure: boolean
+): T | undefined
+function decode<T>(
+  current: Active,
+  spec: Spec<T, Sync.Value>,
+  message: Sync.Message,
+  fallback: T | undefined,
+  throwOnFailure = true
+): T | undefined {
+  try {
+    const wire = assertValue(message.value)
+    return spec.codec.decode(wire)
+  } catch (error) {
+    handleError(current, error, "decode", message, throwOnFailure)
+    return fallback
+  }
+}
+
+function resolveConflict<T>(
+  current: Active,
+  spec: Spec<T, Sync.Value>,
+  local: T,
+  incoming: T,
+  message: Sync.Message,
+  throwOnFailure = true
+): T | Sync.Conflict<T> | undefined {
+  if (!spec.conflict) return incoming
+  try {
+    return spec.conflict.resolve(local, incoming)
+  } catch (error) {
+    handleError(current, error, "conflict", message, throwOnFailure)
+    return undefined
+  }
+}
+
+function handleError(
+  current: Active,
+  error: unknown,
+  phase: Sync.ErrorPhase,
+  message: Sync.Message | undefined,
+  throwOnFailure = true
+): void {
+  current.onError?.(error, phase, message)
+  if (throwOnFailure && current.failure === "throw") throw error
+}
+
+function versionReader(read: string | ((value: never) => number)): (value: unknown) => number {
+  if (typeof read === "function") {
+    const readVersion = read as (value: unknown) => number
+    return (value) => assertVersion(readVersion(value))
+  }
+
+  return (value) => {
+    if (value === null || typeof value !== "object") throw new Error("Sync revision value must be an object")
+    const version = (value as Record<string, unknown>)[read]
+    if (typeof version !== "number") throw new Error("Sync revision field must be a number")
+    return assertVersion(version)
+  }
+}
+
+function assertVersion(value: number): number {
+  if (Number.isFinite(value)) return value
+  throw new Error("Sync revision field must be finite")
+}
+
+function isConflict<T>(value: T | Sync.Conflict<T>): value is Sync.Conflict<T> {
+  return typeof value === "object"
+    && value !== null
+    && "current" in value
+    && "incoming" in value
+}
+
+function scopedKey(current: Active, id: string): string {
+  return current.namespace ? `${current.namespace}:${id}` : id
+}
+
+function isPromise<T>(value: MaybePromise<T>): value is Promise<T> {
+  return value != null && typeof (value as Promise<T>).then === "function"
+}
+
+function assertValue(value: unknown): Sync.Value {
+  if (value === null) return null
+
+  switch (typeof value) {
+    case "string":
+    case "boolean":
+      return value
+    case "number":
+      if (Number.isFinite(value)) return value
+      throw new Error("Sync value number must be finite")
+    case "object":
+      if (Array.isArray(value)) return value.map(assertValue)
+      if (Object.getPrototypeOf(value) !== Object.prototype) throw new Error("Sync value must be plain JSON")
+      return assertRecord(value as Record<string, unknown>)
+    default:
+      throw new Error("Sync value must be plain JSON")
+  }
+}
+
+function assertRecord(value: Record<string, unknown>): Sync.Value {
+  const result: Record<string, Sync.Value> = {}
+  for (const key of Object.keys(value)) {
+    result[key] = assertValue(value[key])
+  }
+  return result
+}
+
+function sameValue(left: Sync.Value | undefined, right: Sync.Value | undefined): boolean {
+  if (left === undefined || right === undefined) return left === right
+  if (Object.is(left, right)) return true
+  if (typeof left !== "object" || typeof right !== "object" || left === null || right === null) return false
+  if (Array.isArray(left) || Array.isArray(right)) return sameArray(left, right)
+
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  if (leftKeys.length !== rightKeys.length) return false
+  const leftRecord = left as { readonly [key: string]: Sync.Value }
+  const rightRecord = right as { readonly [key: string]: Sync.Value }
+  for (const key of leftKeys) {
+    if (!Object.hasOwn(rightRecord, key)) return false
+    if (!sameValue(leftRecord[key], rightRecord[key])) return false
+  }
+  return true
+}
+
+function sameArray(left: Sync.Value, right: Sync.Value): boolean {
+  if (!Array.isArray(left) || !Array.isArray(right)) return false
+  if (left.length !== right.length) return false
+  for (let i = 0; i < left.length; i++) {
+    if (!sameValue(left[i], right[i])) return false
+  }
+  return true
+}

--- a/pkg/ext/sync/tests/sync.test.ts
+++ b/pkg/ext/sync/tests/sync.test.ts
@@ -23,7 +23,7 @@ describe("sync extension", () => {
     left.controller(draft).set({ title: "Plan", body: "sync" })
 
     expect(right.controller(draft).get()).toEqual({ title: "Plan", body: "sync" })
-    expect(wire.records()).toHaveLength(2)
+    expect(wire.records()).toHaveLength(1)
     await left.dispose()
     await right.dispose()
   })
@@ -428,9 +428,142 @@ describe("sync extension", () => {
     await Promise.resolve()
 
     expect(listeners.size).toBe(1)
-    expect(errors).toEqual(["read", "write", "write"])
+    expect(errors).toEqual(["read", "write"])
     await scope.dispose()
     expect(listeners.size).toBe(0)
+  })
+
+  it("keeps local payload unsynced until the transport write succeeds", async () => {
+    const errors: Sync.ErrorPhase[] = []
+    let writes = 0
+    let failedChanged = false
+    const versions: number[] = []
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire: Sync.Transport = {
+      read: () => undefined,
+      write(message) {
+        writes += 1
+        versions.push(message.version)
+        if (!failedChanged && (message.value as { readonly title?: string }).title === "Changed") {
+          failedChanged = true
+          throw new Error("write failed")
+        }
+        return { version: message.version + 10 }
+      },
+      subscribe() {
+        return () => {}
+      },
+    }
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onError: (_error, phase) => errors.push(phase),
+        }),
+      ],
+    })
+
+    await scope.resolve(draft)
+    scope.controller(draft).set({ title: "Changed", body: "" })
+    await Promise.resolve()
+    await Promise.resolve()
+    scope.controller(draft).set({ title: "Changed", body: "" })
+    await Promise.resolve()
+    await Promise.resolve()
+    scope.controller(draft).set({ title: "Next", body: "" })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(errors).toEqual(["write"])
+    expect(writes).toBe(3)
+    expect(versions).toEqual([1, 2, 13])
+    await scope.dispose()
+  })
+
+  it("flushes a revert that happens while a write is in flight", async () => {
+    const writes: Sync.Message[] = []
+    const acks: Array<(ack: Sync.WriteAck) => void> = []
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire: Sync.Transport = {
+      read: () => undefined,
+      write(message) {
+        writes.push(message)
+        return new Promise<Sync.WriteAck>((resolve) => {
+          acks.push(resolve)
+        })
+      },
+      subscribe() {
+        return () => {}
+      },
+    }
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "local", transport: wire })],
+    })
+    const ctrl = scope.controller(draft)
+
+    await scope.resolve(draft)
+    ctrl.set({ title: "Working", body: "" })
+    ctrl.set({ title: "", body: "" })
+
+    expect(writes.map((message) => message.value)).toEqual([{ title: "Working", body: "" }])
+    acks[0]!({ version: 1 })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(writes.map((message) => message.value)).toEqual([
+      { title: "Working", body: "" },
+      { title: "", body: "" },
+    ])
+    acks[1]!({ version: 2 })
+    await Promise.resolve()
+
+    expect(writes.map((message) => message.version)).toEqual([1, 2])
+    await scope.dispose()
+  })
+
+  it("coalesces repeated values while a write is in flight", async () => {
+    const writes: Sync.Message[] = []
+    const acks: Array<(ack: Sync.WriteAck) => void> = []
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire: Sync.Transport = {
+      read: () => undefined,
+      write(message) {
+        writes.push(message)
+        return new Promise<Sync.WriteAck>((resolve) => {
+          acks.push(resolve)
+        })
+      },
+      subscribe() {
+        return () => {}
+      },
+    }
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "local", transport: wire })],
+    })
+    const ctrl = scope.controller(draft)
+
+    await scope.resolve(draft)
+    ctrl.set({ title: "Working", body: "" })
+    ctrl.set({ title: "Working", body: "" })
+    acks[0]!({ version: 1 })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(writes.map((message) => message.value)).toEqual([{ title: "Working", body: "" }])
+    await scope.dispose()
   })
 
   it("leaves non-atom resolution untouched", async () => {
@@ -479,7 +612,7 @@ describe("sync extension", () => {
     scope.controller(entry).set({ value: "bad" })
 
     expect(errors).toEqual(["encode"])
-    expect(wire.records()).toHaveLength(1)
+    expect(wire.records()).toHaveLength(0)
     await scope.dispose()
   })
 
@@ -602,7 +735,7 @@ describe("sync extension", () => {
     })
 
     expect(scope.controller(list).get()).toEqual(["a", "b"])
-    expect(wire.records()).toHaveLength(3)
+    expect(wire.records()).toHaveLength(2)
     await scope.dispose()
     wire.clear()
     wire.close?.()

--- a/pkg/ext/sync/tests/sync.test.ts
+++ b/pkg/ext/sync/tests/sync.test.ts
@@ -566,6 +566,53 @@ describe("sync extension", () => {
     await scope.dispose()
   })
 
+  it("routes backend write conflicts through sync conflict policy", async () => {
+    const conflicts: Sync.Conflict<unknown>[] = []
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", version: 0 }),
+      conflict: sync.revision("version"),
+    })
+    const wire: Sync.Transport = {
+      read: () => undefined,
+      write: () => ({
+        conflict: {
+          key: "draft",
+          peer: "remote",
+          version: 2,
+          value: { title: "remote", version: 1 },
+        },
+      }),
+      subscribe() {
+        return () => {}
+      },
+    }
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onConflict: (conflict) => conflicts.push(conflict),
+        }),
+      ],
+    })
+
+    await scope.resolve(draft)
+    scope.controller(draft).set({ title: "local", version: 1 })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(scope.controller(draft).get()).toEqual({ title: "local", version: 1 })
+    expect(conflicts).toEqual([
+      {
+        current: { title: "local", version: 1 },
+        incoming: { title: "remote", version: 1 },
+      },
+    ])
+    await scope.dispose()
+  })
+
   it("leaves non-atom resolution untouched", async () => {
     const tx = resource({
       name: "tx",

--- a/pkg/ext/sync/tests/sync.test.ts
+++ b/pkg/ext/sync/tests/sync.test.ts
@@ -1,0 +1,653 @@
+import { describe, expect, it } from "vitest"
+import { atom, controller, createScope, resource, type Lite } from "@pumped-fn/lite"
+import { sync, type Sync } from "../src"
+
+describe("sync extension", () => {
+  it("replicates plain state through scope tags and public controllers", async () => {
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire = sync.memory()
+    const left = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "left", transport: wire })],
+    })
+    const right = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "right", transport: wire })],
+    })
+
+    await left.resolve(draft)
+    await right.resolve(draft)
+    left.controller(draft).set({ title: "Plan", body: "sync" })
+
+    expect(right.controller(draft).get()).toEqual({ title: "Plan", body: "sync" })
+    expect(wire.records()).toHaveLength(2)
+    await left.dispose()
+    await right.dispose()
+  })
+
+  it("hydrates later scopes from the transport record", async () => {
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire = sync.memory()
+    const left = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "left", transport: wire, namespace: "team" })],
+    })
+
+    await left.resolve(draft)
+    left.controller(draft).set({ title: "Saved", body: "later" })
+
+    const right = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "right", transport: wire, namespace: "team" })],
+    })
+
+    expect(await right.resolve(draft)).toEqual({ title: "Saved", body: "later" })
+    expect(right.controller(draft).get()).toEqual({ title: "Saved", body: "later" })
+    await left.dispose()
+    await right.dispose()
+  })
+
+  it("does not close a shared transport when one scope is disposed", async () => {
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire = sync.memory()
+    const left = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "left", transport: wire })],
+    })
+    const right = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "right", transport: wire })],
+    })
+
+    await left.resolve(draft)
+    await right.resolve(draft)
+    await left.dispose()
+    await wire.write({
+      key: "draft",
+      peer: "remote",
+      version: 1,
+      value: { title: "Remote", body: "still live" },
+    })
+
+    expect(right.controller(draft).get()).toEqual({ title: "Remote", body: "still live" })
+    await right.dispose()
+  })
+
+  it("rejects invalid remote payloads before apply", async () => {
+    const errors: Array<[unknown, Sync.ErrorPhase]> = []
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onError: (error, phase) => errors.push([error, phase]),
+        }),
+      ],
+    })
+
+    await scope.resolve(draft)
+    await wire.write({
+      key: "draft",
+      peer: "remote",
+      version: 1,
+      value: { title: "bad", body: Number.NaN },
+    })
+
+    expect(scope.controller(draft).get()).toEqual({ title: "", body: "" })
+    expect(errors.map((entry) => entry[1])).toEqual(["decode"])
+    await scope.dispose()
+  })
+
+  it("isolates remote delivery failures from synchronous transport writes", async () => {
+    const errors: Sync.ErrorPhase[] = []
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          failure: "throw",
+          onError: (_error, phase) => errors.push(phase),
+        }),
+      ],
+    })
+
+    await scope.resolve(draft)
+    await wire.write({
+      key: "draft",
+      peer: "remote",
+      version: 1,
+      value: { title: "bad", body: Number.NaN },
+    })
+
+    expect(scope.controller(draft).get()).toEqual({ title: "", body: "" })
+    expect(errors).toEqual(["decode"])
+    await scope.dispose()
+  })
+
+  it("uses codecs for non-json local state", async () => {
+    const session = sync({
+      id: "session",
+      factory: () => ({ expiresAt: new Date(0) }),
+      codec: sync.codec({
+        encode: (value: { expiresAt: Date }) => ({ expiresAt: value.expiresAt.toISOString() }),
+        decode: (raw: { expiresAt: string }) => ({ expiresAt: new Date(raw.expiresAt) }),
+      }),
+    })
+    const wire = sync.memory()
+    const left = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "left", transport: wire })],
+    })
+    const right = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "right", transport: wire })],
+    })
+
+    await left.resolve(session)
+    await right.resolve(session)
+    left.controller(session).set({ expiresAt: new Date(1000) })
+
+    expect(right.controller(session).get().expiresAt.getTime()).toBe(1000)
+    await left.dispose()
+    await right.dispose()
+  })
+
+  it("surfaces equal-revision conflicts without applying the remote value", async () => {
+    const conflicts: Sync.Conflict<unknown>[] = []
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", version: 0 }),
+      conflict: sync.revision("version"),
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onConflict: (conflict) => conflicts.push(conflict),
+        }),
+      ],
+    })
+
+    await scope.resolve(draft)
+    scope.controller(draft).set({ title: "local", version: 1 })
+    await wire.write({
+      key: "draft",
+      peer: "remote",
+      version: 1,
+      value: { title: "remote", version: 1 },
+    })
+
+    expect(scope.controller(draft).get()).toEqual({ title: "local", version: 1 })
+    expect(conflicts).toHaveLength(1)
+
+    await wire.write({
+      key: "draft",
+      peer: "remote",
+      version: 2,
+      value: { title: "old", version: 0 },
+    })
+    expect(scope.controller(draft).get()).toEqual({ title: "local", version: 1 })
+
+    await wire.write({
+      key: "draft",
+      peer: "remote",
+      version: 3,
+      value: { title: "new", version: 2 },
+    })
+    expect(scope.controller(draft).get()).toEqual({ title: "new", version: 2 })
+    await scope.dispose()
+  })
+
+  it("can throw runtime failures when configured", async () => {
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire: Sync.Transport = {
+      read: () => undefined,
+      write: () => {},
+      subscribe() {
+        throw new Error("subscribe failed")
+      },
+    }
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "local", transport: wire, failure: "throw" })],
+    })
+
+    await expect(scope.resolve(draft)).rejects.toThrow("subscribe failed")
+  })
+
+  it("isolates subscribe failures while keeping local state writable", async () => {
+    const errors: Sync.ErrorPhase[] = []
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire: Sync.Transport = {
+      read: () => undefined,
+      write: () => {},
+      subscribe() {
+        throw new Error("subscribe failed")
+      },
+    }
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onError: (_error, phase) => errors.push(phase),
+        }),
+      ],
+    })
+
+    await scope.resolve(draft)
+    scope.controller(draft).set({ title: "Changed", body: "" })
+
+    expect(scope.controller(draft).get()).toEqual({ title: "Changed", body: "" })
+    expect(errors).toEqual(["subscribe"])
+    await scope.dispose()
+  })
+
+  it("isolates unexpected listener failures from transport dispatch", async () => {
+    const errors: Sync.ErrorPhase[] = []
+    let listener: (message: Sync.Message) => void = () => {
+      throw new Error("listener missing")
+    }
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const broken = {
+      key: "draft",
+      get peer() {
+        throw new Error("listener failed")
+      },
+      version: 1,
+      value: { title: "Remote", body: "" },
+    } satisfies Sync.Message
+    const wire: Sync.Transport = {
+      read: () => undefined,
+      write: () => {},
+      subscribe(_key, next) {
+        listener = next
+        return () => {}
+      },
+    }
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          failure: "throw",
+          onError: (_error, phase) => errors.push(phase),
+        }),
+      ],
+    })
+
+    await scope.resolve(draft)
+    listener(broken)
+
+    expect(errors).toEqual(["subscribe"])
+    await scope.dispose()
+  })
+
+  it("can throw read failures when configured", async () => {
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const wire: Sync.Transport = {
+      read: () => {
+        throw new Error("read failed")
+      },
+      write: () => {},
+      subscribe() {
+        return () => {}
+      },
+    }
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "local", transport: wire, failure: "throw" })],
+    })
+
+    await expect(scope.resolve(draft)).rejects.toThrow("read failed")
+  })
+
+  it("keeps sync atoms local when no runtime tag is installed", async () => {
+    const draft = sync({
+      id: "draft",
+      factory: async () => ({ title: "Local", body: "" }),
+    })
+    const scope = createScope({
+      extensions: [sync.extension()],
+    })
+
+    expect(await scope.resolve(draft)).toEqual({ title: "Local", body: "" })
+    scope.controller(draft).set({ title: "Changed", body: "" })
+    expect(scope.controller(draft).get()).toEqual({ title: "Changed", body: "" })
+    await scope.dispose()
+  })
+
+  it("supports dependencies without rehydrating stale transport state on rerun", async () => {
+    const source = atom({
+      factory: () => ({ title: "First" }),
+    })
+    const draft = sync({
+      id: "draft",
+      deps: { source: controller(source, { resolve: true, watch: true }) },
+      factory: async (_ctx, deps) => ({ title: deps.source.get().title, body: "" }),
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "local", transport: wire })],
+    })
+
+    expect(await scope.resolve(draft)).toEqual({ title: "First", body: "" })
+    scope.controller(source).set({ title: "Second" })
+    await scope.flush()
+
+    expect(scope.controller(draft).get()).toEqual({ title: "Second", body: "" })
+    await scope.dispose()
+  })
+
+  it("validates synchronous dependency factories", async () => {
+    const source = atom({
+      factory: () => ({ title: "Source" }),
+    })
+    const draft = sync({
+      id: "draft",
+      deps: { source },
+      factory: (_ctx, deps) => ({ title: deps.source.title, body: "" }),
+    })
+    const scope = createScope()
+
+    expect(await scope.resolve(draft)).toEqual({ title: "Source", body: "" })
+    await scope.dispose()
+  })
+
+  it("reports read and write transport failures without applying remote trust", async () => {
+    const errors: Sync.ErrorPhase[] = []
+    const draft = sync({
+      id: "draft",
+      factory: () => ({ title: "", body: "" }),
+    })
+    const listeners = new Set<(message: Sync.Message) => void>()
+    const wire: Sync.Transport = {
+      read: () => {
+        throw new Error("read failed")
+      },
+      write: () => {
+        throw new Error("write failed")
+      },
+      subscribe(_key, listener) {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      },
+    }
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onError: (_error, phase) => errors.push(phase),
+        }),
+      ],
+    })
+
+    await scope.resolve(draft)
+    scope.controller(draft).set({ title: "Changed", body: "" })
+    await Promise.resolve()
+
+    expect(listeners.size).toBe(1)
+    expect(errors).toEqual(["read", "write", "write"])
+    await scope.dispose()
+    expect(listeners.size).toBe(0)
+  })
+
+  it("leaves non-atom resolution untouched", async () => {
+    const tx = resource({
+      name: "tx",
+      factory: () => "ready",
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension({ name: "custom-sync" })],
+      tags: [sync.runtime({ peer: "local", transport: wire })],
+    })
+    const ctx = scope.createContext()
+
+    expect(await ctx.resolve(tx)).toBe("ready")
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("rejects local writes that no longer satisfy the codec", async () => {
+    const errors: Sync.ErrorPhase[] = []
+    const entry = sync({
+      id: "entry",
+      factory: () => ({ value: "ok" }),
+      codec: sync.codec({
+        encode(value: { value: string }) {
+          if (value.value === "bad") throw new Error("bad value")
+          return value
+        },
+        decode: (raw: { value: string }) => raw,
+      }),
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onError: (_error, phase) => errors.push(phase),
+        }),
+      ],
+    })
+
+    await scope.resolve(entry)
+    scope.controller(entry).set({ value: "bad" })
+
+    expect(errors).toEqual(["encode"])
+    expect(wire.records()).toHaveLength(1)
+    await scope.dispose()
+  })
+
+  it("rejects non-json local writes on the default codec", async () => {
+    const errors: Sync.ErrorPhase[] = []
+    const entry = sync({
+      id: "entry",
+      factory: () => ({ value: "ok" }),
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onError: (_error, phase) => errors.push(phase),
+        }),
+      ],
+    })
+
+    await scope.resolve(entry)
+    const ctrl = scope.controller(entry) as Lite.Controller<unknown>
+    ctrl.set(Symbol("bad"))
+
+    expect(errors).toEqual(["encode"])
+    await scope.dispose()
+  })
+
+  it("applies lww updates and ignores older revision updates", async () => {
+    const entry = sync({
+      id: "entry",
+      factory: () => ({ title: "local", updatedAt: 1 }),
+      conflict: sync.lww((value) => value.updatedAt),
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "local", transport: wire })],
+    })
+
+    await scope.resolve(entry)
+    await wire.write({
+      key: "entry",
+      peer: "remote",
+      version: 1,
+      value: { title: "old", updatedAt: 0 },
+    })
+    expect(scope.controller(entry).get()).toEqual({ title: "local", updatedAt: 1 })
+
+    await wire.write({
+      key: "entry",
+      peer: "remote",
+      version: 2,
+      value: { title: "new", updatedAt: 2 },
+    })
+    expect(scope.controller(entry).get()).toEqual({ title: "new", updatedAt: 2 })
+    await scope.dispose()
+  })
+
+  it("reports revision declaration failures without applying remote values", async () => {
+    const errors: Sync.ErrorPhase[] = []
+    const entry = sync({
+      id: "entry",
+      factory: () => ({ title: "local", version: 1 }),
+      conflict: sync.revision("version"),
+    })
+    const callback = sync({
+      id: "callback",
+      factory: () => ({ title: "local", version: 1 }),
+      conflict: sync.revision(() => Number.NaN),
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onError: (_error, phase) => errors.push(phase),
+        }),
+      ],
+    })
+
+    await scope.resolve(entry)
+    await wire.write({ key: "entry", peer: "remote", version: 1, value: { title: "missing" } })
+    await wire.write({ key: "entry", peer: "remote", version: 2, value: null })
+    await scope.resolve(callback)
+    await wire.write({ key: "callback", peer: "remote", version: 1, value: { title: "remote", version: 2 } })
+
+    expect(scope.controller(entry).get()).toEqual({ title: "local", version: 1 })
+    expect(scope.controller(callback).get()).toEqual({ title: "local", version: 1 })
+    expect(errors).toEqual(["conflict", "conflict", "conflict"])
+    await scope.dispose()
+  })
+
+  it("compares array payloads without echoing identical remote records", async () => {
+    const list = sync({
+      id: "list",
+      factory: () => ["a"],
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [sync.runtime({ peer: "local", transport: wire })],
+    })
+
+    await scope.resolve(list)
+    await wire.write({
+      key: "list",
+      peer: "remote",
+      version: 1,
+      value: ["a"],
+    })
+    await wire.write({
+      key: "list",
+      peer: "remote",
+      version: 2,
+      value: ["a", "b"],
+    })
+
+    expect(scope.controller(list).get()).toEqual(["a", "b"])
+    expect(wire.records()).toHaveLength(3)
+    await scope.dispose()
+    wire.clear()
+    wire.close?.()
+    expect(wire.records()).toEqual([])
+    expect(wire.size()).toBe(0)
+  })
+
+  it("covers json comparison and decoder edge cases through remote records", async () => {
+    const errors: Sync.ErrorPhase[] = []
+    const value = sync({
+      id: "value",
+      factory: (): Sync.Value => ({ title: "a" }),
+    })
+    const empty = sync({
+      id: "empty",
+      factory: () => null,
+    })
+    const wire = sync.memory()
+    const scope = createScope({
+      extensions: [sync.extension()],
+      tags: [
+        sync.runtime({
+          peer: "local",
+          transport: wire,
+          onError: (_error, phase) => errors.push(phase),
+        }),
+      ],
+    })
+
+    expect(await scope.resolve(empty)).toBeNull()
+    await scope.resolve(value)
+    await wire.write({ key: "value", peer: "remote", version: 1, value: { other: "text" } })
+    await wire.write({ key: "value", peer: "remote", version: 2, value: "text" })
+    await wire.write({ key: "value", peer: "remote", version: 3, value: { other: "next", extra: true } })
+    await wire.write({ key: "value", peer: "remote", version: 4, value: { other: "final" } })
+    await wire.write({ key: "value", peer: "remote", version: 5, value: ["x"] })
+    await wire.write({ key: "value", peer: "remote", version: 6, value: ["y"] })
+    await wire.write({ key: "value", peer: "remote", version: 7, value: new Date() as unknown as Sync.Value })
+
+    expect(scope.controller(value).get()).toEqual(["y"])
+    expect(errors).toEqual(["decode"])
+    await scope.dispose()
+
+    const alone = sync.memory()
+    await alone.write({ key: "none", peer: "nobody", version: 1, value: null })
+    expect(alone.records()).toHaveLength(1)
+  })
+})

--- a/pkg/ext/sync/tests/type-contracts.ts
+++ b/pkg/ext/sync/tests/type-contracts.ts
@@ -1,0 +1,48 @@
+import { type Lite } from "@pumped-fn/lite"
+import { sync } from "../src"
+
+const draft = sync({
+  id: "draft",
+  factory: () => ({ title: "", body: "" }),
+})
+
+const value: Lite.Utils.AtomValue<typeof draft> = { title: "Title", body: "Body" }
+
+const versioned = sync({
+  id: "versioned",
+  factory: () => ({ title: "", version: 0 }),
+  conflict: sync.revision("version"),
+})
+
+const versionedValue: Lite.Utils.AtomValue<typeof versioned> = { title: "Title", version: 1 }
+
+sync({
+  id: "bad-revision",
+  factory: () => ({ title: "" }),
+  // @ts-expect-error revision key must exist as a number
+  conflict: sync.revision("version"),
+})
+
+sync({
+  id: "session",
+  factory: () => ({ expiresAt: new Date(0) }),
+  codec: sync.codec({
+    encode: (input: { expiresAt: Date }) => ({ expiresAt: input.expiresAt.toISOString() }),
+    decode: (raw: { expiresAt: string }) => ({ expiresAt: new Date(raw.expiresAt) }),
+  }),
+})
+
+sync({
+  id: "derived",
+  deps: { draft },
+  factory: (_ctx, deps) => ({ title: deps.draft.title, body: deps.draft.body }),
+})
+
+// @ts-expect-error non-json values need a codec
+sync({
+  id: "bad",
+  factory: () => ({ expiresAt: new Date(0) }),
+})
+
+// @ts-expect-error dependency values stay inferred
+value.extra = "nope"

--- a/pkg/ext/sync/tsconfig.json
+++ b/pkg/ext/sync/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "../..",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
+    "paths": {
+      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pkg/ext/sync/tsconfig.test.json
+++ b/pkg/ext/sync/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/pkg/ext/sync/tsdown.config.ts
+++ b/pkg/ext/sync/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  dts: true,
+  format: ["cjs", "esm"],
+  clean: true,
+})

--- a/pkg/ext/sync/vitest.config.ts
+++ b/pkg/ext/sync/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config"
+import { resolve } from "node:path"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    coverage: {
+      provider: "v8",
+      reporter: ["text"],
+      include: ["src/**/*.ts"],
+      thresholds: {
+        lines: 100,
+        functions: 100,
+        statements: 100,
+        branches: 100
+      }
+    }
+  },
+  resolve: {
+    alias: {
+      "@pumped-fn/lite": resolve(__dirname, "../../core/lite/src/index.ts")
+    }
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,6 +442,58 @@ importers:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  examples/lite-sync-web-practical:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+      '@pumped-fn/lite-extension-sync':
+        specifier: workspace:*
+        version: link:../../pkg/ext/sync
+      '@pumped-fn/lite-react':
+        specifier: workspace:*
+        version: link:../../pkg/react/lite-react
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      playwright:
+        specifier: 'catalog:'
+        version: 1.61.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
   examples/lite-tanstack-start-todo-practical:
     dependencies:
       '@pumped-fn/lite':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,12 @@ catalogs:
     '@json-render/react':
       specifier: 0.19.0
       version: 0.19.0
+    '@nats-io/kv':
+      specifier: 3.4.0
+      version: 3.4.0
+    '@nats-io/transport-node':
+      specifier: 3.4.0
+      version: 3.4.0
     '@opentelemetry/api':
       specifier: 1.9.1
       version: 1.9.1
@@ -803,6 +809,39 @@ importers:
       '@pumped-fn/lite':
         specifier: workspace:*
         version: link:../../core/lite
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  pkg/ext/sync-nats:
+    devDependencies:
+      '@nats-io/kv':
+        specifier: 'catalog:'
+        version: 3.4.0
+      '@nats-io/transport-node':
+        specifier: 'catalog:'
+        version: 3.4.0
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../core/lite
+      '@pumped-fn/lite-extension-sync':
+        specifier: workspace:*
+        version: link:../sync
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
@@ -1648,6 +1687,27 @@ packages:
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
+
+  '@nats-io/jetstream@3.4.0':
+    resolution: {integrity: sha512-GzHQodNJ942+R5LRb8PuZ5ugVWVWMRiufxUYLLVWkXKfwDXYN+Owo0d7L/b9O7BPyrbYD7jQWAC6+ZVuXa9Gyw==}
+
+  '@nats-io/kv@3.4.0':
+    resolution: {integrity: sha512-168pcRJxWcIRHwdyczI3DaGk5r3CAj3CyKXuk4Nmx5KKj7N1znQOJPIxCoV0TPlAvoTidVb7eBv41J9imapMeQ==}
+
+  '@nats-io/nats-core@3.4.0':
+    resolution: {integrity: sha512-QMDM86EUNm+wudlKC67HLar/KHHQUvJGLfb4jbahje3pUk3K9afeck9fwsxBZF0eUFox6T/TA6m/t+lQqf+QsQ==}
+
+  '@nats-io/nkeys@2.0.3':
+    resolution: {integrity: sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A==}
+    engines: {node: '>=18.0.0'}
+
+  '@nats-io/nuid@3.0.0':
+    resolution: {integrity: sha512-QbXZDrxmYlrn5AD06gYcUTmEHwxn96HBQMIk7XTjDlEcx6FPzVBBPjp4AMRh1lEv6B4iJ6Xb/Uz61JugPXFRQg==}
+    engines: {node: '>= 22.x'}
+
+  '@nats-io/transport-node@3.4.0':
+    resolution: {integrity: sha512-hH7u7ejIBTFEJIZ8rIcMrHJI6wl+HhpO5sVFs1+ppmXa8RuB2+Lh1+UwTzZ5xTNNm1TKcRkYy+2qCV56qp8RxA==}
+    engines: {node: '>= 18.0.0'}
 
   '@nodable/entities@2.2.0':
     resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
@@ -3442,6 +3502,9 @@ packages:
     resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
     engines: {node: '>=18', npm: '>=9'}
 
+  tweetnacl@1.0.3:
+    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -4388,6 +4451,32 @@ snapshots:
       '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.2
     optional: true
+
+  '@nats-io/jetstream@3.4.0':
+    dependencies:
+      '@nats-io/nats-core': 3.4.0
+
+  '@nats-io/kv@3.4.0':
+    dependencies:
+      '@nats-io/jetstream': 3.4.0
+      '@nats-io/nats-core': 3.4.0
+
+  '@nats-io/nats-core@3.4.0':
+    dependencies:
+      '@nats-io/nkeys': 2.0.3
+      '@nats-io/nuid': 3.0.0
+
+  '@nats-io/nkeys@2.0.3':
+    dependencies:
+      tweetnacl: 1.0.3
+
+  '@nats-io/nuid@3.0.0': {}
+
+  '@nats-io/transport-node@3.4.0':
+    dependencies:
+      '@nats-io/nats-core': 3.4.0
+      '@nats-io/nkeys': 2.0.3
+      '@nats-io/nuid': 3.0.0
 
   '@nodable/entities@2.2.0': {}
 
@@ -6151,6 +6240,8 @@ snapshots:
   turndown@7.2.4:
     dependencies:
       '@mixmark-io/domino': 2.2.0
+
+  tweetnacl@1.0.3: {}
 
   typescript@6.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -408,6 +408,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  examples/lite-sync-practical:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+      '@pumped-fn/lite-extension-sync':
+        specifier: workspace:*
+        version: link:../../pkg/ext/sync
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
   examples/lite-tanstack-start-todo-practical:
     dependencies:
       '@pumped-fn/lite':
@@ -757,6 +785,27 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260526.1
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  pkg/ext/sync:
+    devDependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../core/lite
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
       tsdown:
         specifier: 'catalog:'
         version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,8 @@ catalog:
   "@changesets/cli": 2.31.0
   "@json-render/core": 0.19.0
   "@json-render/react": 0.19.0
+  "@nats-io/kv": 3.4.0
+  "@nats-io/transport-node": 3.4.0
   "@tanstack/react-router": 1.170.16
   "@tanstack/react-start": 1.168.26
   "@opentelemetry/api": 1.9.1

--- a/research/learnings/sync-backend-discovery.md
+++ b/research/learnings/sync-backend-discovery.md
@@ -35,23 +35,23 @@ The current `sync(...)` package is a strict value-sync primitive:
 - non-JSON values need a codec;
 - inbound wire values are decoded before apply;
 - runtime selection is tag-injected through `sync.runtime(...)`;
-- transport shape is `read`, `write`, `subscribe`, optional `close`, with backend write acknowledgements.
+- transport shape is `read`, `write`, `subscribe`, optional `close`, with backend write acknowledgements
+  and write conflicts.
 
-That is enough for memory, simple replicated state, and backend revision evidence. It is not yet a full
-compare-and-set conflict contract.
+That is enough for memory, simple replicated state, backend revision evidence, and backend CAS conflict
+handoff into the same sync conflict path.
 
 Implementation checkpoint:
 
-- `Sync.Transport.write` now accepts a backend revision acknowledgement.
+- `Sync.Transport.write` now accepts backend revision acknowledgements and write conflicts.
 - `@pumped-fn/lite-extension-sync-nats` maps sync messages onto NATS JetStream KV keys, stores JSON
   payload bytes, watches key updates, and returns KV revisions as write acknowledgements.
 - The adapter test suite covers deterministic store behavior and a real Docker-backed `nats:2.12-alpine`
   JetStream KV integration through `createScope`, `sync.extension`, and `sync.runtime`.
-- The NATS adapter proof now covers stale revision racing, corrupt persisted watch payload isolation,
-  backend revision mapping, and a 1,000-write JetStream KV stress run with per-operation overhead
-  measurement.
-- Remaining production proof is reconnect behavior and a first-class CAS conflict result if callers need
-  retry/accountability beyond the current write-error boundary.
+- The NATS adapter proof now covers stale revision racing as first-class sync write conflicts, corrupt
+  persisted watch payload isolation, backend revision mapping, and a 1,000-write JetStream KV stress run
+  with per-operation overhead measurement.
+- Remaining production proof is reconnect behavior.
 
 ## Backend Findings
 
@@ -73,20 +73,18 @@ Decision impact:
 
 - Build `@pumped-fn/lite-extension-sync-nats` first.
 - The adapter should not merely wrap `put`; it should prove revision behavior with `update`.
-- The base `Sync.Transport` likely needs an ack shape before this becomes production-grade:
+- The base `Sync.Transport` now has an ack/conflict result shape:
 
 ```ts
 interface WriteAck {
   readonly version: number
 }
-```
 
-or a CAS-aware write result:
+interface WriteConflict {
+  readonly conflict: Sync.Message
+}
 
-```ts
-type WriteResult =
-  | { readonly ok: true; readonly version: number }
-  | { readonly ok: false; readonly conflict: Sync.Message }
+type WriteResult = WriteAck | WriteConflict | void
 ```
 
 Open risk:

--- a/research/learnings/sync-backend-discovery.md
+++ b/research/learnings/sync-backend-discovery.md
@@ -2,7 +2,8 @@
 
 Date: 2026-07-01
 
-Status: candidate learning checkpoint. This is not a package contract yet.
+Status: implementation checkpoint. The value-sync NATS adapter exists in this PR; CRDT and database
+sync lanes remain discovery.
 
 Decision target: choose the next sync implementation lane after `@pumped-fn/lite-extension-sync`.
 
@@ -34,10 +35,20 @@ The current `sync(...)` package is a strict value-sync primitive:
 - non-JSON values need a codec;
 - inbound wire values are decoded before apply;
 - runtime selection is tag-injected through `sync.runtime(...)`;
-- transport shape is `read`, `write`, `subscribe`, optional `close`.
+- transport shape is `read`, `write`, `subscribe`, optional `close`, with backend write acknowledgements.
 
-That is enough for memory and simple replicated state. It is not yet enough for a serious backend
-contract because `write` has no durable ack, backend revision, or compare-and-set result.
+That is enough for memory, simple replicated state, and backend revision evidence. It is not yet a full
+compare-and-set conflict contract.
+
+Implementation checkpoint:
+
+- `Sync.Transport.write` now accepts a backend revision acknowledgement.
+- `@pumped-fn/lite-extension-sync-nats` maps sync messages onto NATS JetStream KV keys, stores JSON
+  payload bytes, watches key updates, and returns KV revisions as write acknowledgements.
+- The adapter test suite covers deterministic store behavior and a real Docker-backed `nats:2.12-alpine`
+  JetStream KV integration through `createScope`, `sync.extension`, and `sync.runtime`.
+- Remaining production proof is reconnect behavior, explicit stale-revision racing, invalid persisted
+  payload handling at the adapter boundary, and larger sustained update stress.
 
 ## Backend Findings
 

--- a/research/learnings/sync-backend-discovery.md
+++ b/research/learnings/sync-backend-discovery.md
@@ -51,7 +51,8 @@ Implementation checkpoint:
 - The NATS adapter proof now covers stale revision racing as first-class sync write conflicts, corrupt
   persisted watch payload isolation, backend revision mapping, and a 1,000-write JetStream KV stress run
   with per-operation overhead measurement.
-- Remaining production proof is reconnect behavior.
+- The NATS adapter proof covers watch resubscribe behavior with `resumeFromRevision`, including cleanup
+  during pending retry and a real JetStream KV resume path.
 
 ## Backend Findings
 
@@ -231,7 +232,7 @@ Evidence required:
   transport lifetime;
 - stress proof that writes at least 1,000 updates and measures per-op overhead;
 - proof that backend revision is surfaced or intentionally mapped;
-- reconnect behavior remains the next adapter-hardening proof.
+- watch reconnect/resume behavior is proven with deterministic and real JetStream KV tests.
 
 Likely package shape:
 

--- a/research/learnings/sync-backend-discovery.md
+++ b/research/learnings/sync-backend-discovery.md
@@ -1,0 +1,268 @@
+# Sync Backend Discovery
+
+Date: 2026-07-01
+
+Status: candidate learning checkpoint. This is not a package contract yet.
+
+Decision target: choose the next sync implementation lane after `@pumped-fn/lite-extension-sync`.
+
+## Objective Frame
+
+Candidate objective: reduce backend uncertainty enough to select one production adapter PR and one
+CRDT discovery PR.
+
+Candidate success metric:
+
+- one value-sync backend can be implemented against a real service with durable reads, watched
+  updates, revision evidence, and failure tests;
+- one CRDT lane is separated from value-sync with its own update semantics and stress proof;
+- database-shaped sync products are classified as integration targets, not forced through the atom
+  value transport.
+
+Candidate anti-goals:
+
+- do not make one generic sync API pretend to cover snapshots, CRDT documents, and database shapes;
+- do not accept fake backend tests as production proof;
+- do not weaken the strict JSON/runtime validation story for value sync;
+- do not hide conflict/accountability behind a best-effort `write(): void` transport.
+
+## Current Primitive Boundary
+
+The current `sync(...)` package is a strict value-sync primitive:
+
+- state is atom-like and JSON-safe by default;
+- non-JSON values need a codec;
+- inbound wire values are decoded before apply;
+- runtime selection is tag-injected through `sync.runtime(...)`;
+- transport shape is `read`, `write`, `subscribe`, optional `close`.
+
+That is enough for memory and simple replicated state. It is not yet enough for a serious backend
+contract because `write` has no durable ack, backend revision, or compare-and-set result.
+
+## Backend Findings
+
+### NATS JetStream KV
+
+NATS is the best first production backend for the existing value-sync package.
+
+Evidence:
+
+- NATS JetStream KV has `put`, `get`, `delete`, `purge`, `keys`, `create`, `update`, `watch`, `watch
+  all`, and `history`.
+- NATS documents `create` and `update` as atomic compare-and-set operations.
+- NATS KV watches push changes in real time.
+- Values are byte arrays, so JSON wire messages can be encoded explicitly.
+- The JavaScript `@nats-io/kv` package implements KV over JetStream and is distributed for npm and
+  JSR runtimes.
+
+Decision impact:
+
+- Build `@pumped-fn/lite-extension-sync-nats` first.
+- The adapter should not merely wrap `put`; it should prove revision behavior with `update`.
+- The base `Sync.Transport` likely needs an ack shape before this becomes production-grade:
+
+```ts
+interface WriteAck {
+  readonly version: number
+}
+```
+
+or a CAS-aware write result:
+
+```ts
+type WriteResult =
+  | { readonly ok: true; readonly version: number }
+  | { readonly ok: false; readonly conflict: Sync.Message }
+```
+
+Open risk:
+
+- NATS KV documents monotonic reads/writes but warns that direct gets may not guarantee
+  read-your-writes unless reading from the stream leader. The adapter tests need to define the
+  consistency policy instead of assuming local echo equals durability.
+
+Sources:
+
+- https://docs.nats.io/nats-concepts/jetstream/key-value-store
+- https://github.com/nats-io/nats.js/blob/main/kv/README.md
+- https://jsr.io/@nats-io/kv
+
+### Yjs
+
+Yjs should be a CRDT lane, not a codec bolted onto `sync(...)`.
+
+Evidence:
+
+- Yjs document updates are binary, compressed, commutative, associative, and idempotent.
+- A Yjs update can be applied in any order and multiple times.
+- Yjs provides `applyUpdate`, `encodeStateAsUpdate`, `encodeStateVector`, and update event hooks.
+- Yjs is explicitly network agnostic and provider-oriented.
+- y-websocket and y-partykit already show provider and persistence patterns.
+
+Decision impact:
+
+- Build a separate `@pumped-fn/lite-extension-sync-yjs` discovery instead of changing
+  `sync(...)` into a CRDT API.
+- The primitive should expose document/update semantics, not snapshot overwrite semantics.
+- NATS can still be useful as a carrier for Yjs updates, but the merge logic belongs to Yjs.
+
+Open risk:
+
+- Initial value seeding is a real footgun in CRDT systems. Two clients independently creating the
+  same initial content can produce duplicate operations. The primitive must define who initializes
+  a document and how that initialization is idempotent.
+
+Sources:
+
+- https://docs.yjs.dev/
+- https://docs.yjs.dev/api/document-updates
+- https://docs.yjs.dev/ecosystem/connection-provider/y-websocket
+- https://docs.partykit.io/reference/y-partykit-api/
+
+### Automerge
+
+Automerge is a second CRDT candidate, especially for structured JSON-like documents.
+
+Evidence:
+
+- Automerge separates the CRDT implementation from `automerge-repo`, which provides networking and
+  storage plumbing.
+- Repositories manage remote peers and local storage and expose document handles.
+- The sync protocol is transport agnostic and per-document.
+- Automerge has a compressed binary storage format for document history.
+
+Decision impact:
+
+- Treat Automerge as a structured document lane after Yjs, not as the first backend adapter.
+- The likely primitive is document-handle/ref based. It should not share the value-sync transport
+  unless the only behavior needed is snapshot export/import.
+
+Open risk:
+
+- The repo/document-handle model may overlap with Lite scope lifetime. The discovery needs to prove
+  whether repository lifetime belongs in a tag, atom, or external composition root.
+
+Source:
+
+- https://automerge.org/docs/reference/concepts/
+
+### Electric and PowerSync
+
+Electric and PowerSync are database-shape sync systems, not atom-value backends.
+
+Evidence:
+
+- Electric uses shape subscriptions that stream data from its sync engine into memory or a local
+  normalized store/database.
+- Electric shapes are single-table, with multiple shapes required for related data.
+- PowerSync Sync Streams define SQL-like streams that determine which data is replicated from the
+  source database to clients.
+- PowerSync persists bucket metadata and operation history to support efficient delta sync.
+
+Decision impact:
+
+- These should integrate through Lite atoms/resources/flows that expose local collections or query
+  results.
+- They should not be forced through `Sync.Transport<Message>` because the unit of sync is a shape,
+  stream, collection, row set, or local database, not one atom value.
+
+Open risk:
+
+- If pumped-fn later wants database sync, the API surface probably belongs closer to render/query
+  integration than to `sync(...)`.
+
+Sources:
+
+- https://electric.ax/docs/sync/guides/shapes
+- https://docs.powersync.com/sync/overview
+
+### Replicache and WatermelonDB
+
+Replicache and WatermelonDB are useful protocol references, not immediate package targets.
+
+Evidence:
+
+- Replicache uses speculative local mutators, server-authoritative push, pull patches, cookies, and
+  rebasing of pending mutations.
+- Replicache server push has strict last-mutation-id handling so invalid mutations do not block a
+  client forever.
+- WatermelonDB gives local database sync primitives and requires backend pull/push endpoints that
+  conform to its protocol.
+
+Decision impact:
+
+- These are good stress references for mutation acknowledgement, replay, and anti-stall behavior.
+- They should inform the NATS/value-sync ack design, but should not be copied into the atom-sync API.
+
+Sources:
+
+- https://doc.replicache.dev/concepts/how-it-works
+- https://doc.replicache.dev/reference/server-push
+- https://watermelondb.dev/docs/Sync/Intro
+- https://watermelondb.dev/docs/Sync/Frontend
+- https://watermelondb.dev/docs/Sync/Backend
+
+## Candidate Next DKRs
+
+### DKR 1: NATS Value Sync Adapter
+
+Decision unlocked: whether `sync(...)` can become production-capable with a NATS adapter and a small
+transport ack/CAS refinement.
+
+Budget: one implementation spike.
+
+Evidence required:
+
+- real `nats-server -js`, not mocked transport;
+- adapter package under `pkg/ext/sync-nats`;
+- conformance tests for read, write, watch, reconnect, stale revision, CAS conflict, invalid payload,
+  and shared transport lifetime;
+- stress example that writes at least 1,000 updates and reports per-op overhead;
+- proof that backend revision is surfaced or intentionally mapped.
+
+Likely package shape:
+
+- package: `@pumped-fn/lite-extension-sync-nats`;
+- export: contextual namespace `nats`;
+- runtime injection stays at `createScope({ tags: [sync.runtime({ transport: nats.kv(...) })] })`.
+
+### DKR 2: Yjs CRDT Primitive
+
+Decision unlocked: whether pumped-fn should provide a first-class CRDT primitive beside value sync.
+
+Budget: one discovery package or research example, not a release package yet.
+
+Evidence required:
+
+- two Y docs converge after offline concurrent edits;
+- duplicate and out-of-order updates are idempotent;
+- initialization is idempotent and cannot duplicate default content;
+- provider lifetime is testable through scope/tags only;
+- one carrier is proven, preferably memory first and then NATS or WebSocket.
+
+Likely package shape:
+
+- package: `@pumped-fn/lite-extension-sync-yjs`;
+- export: contextual namespace `yjs`;
+- expose document/update semantics, not `Sync.Transport<Message>`.
+
+### DKR 3: Database Shape Boundary
+
+Decision unlocked: whether database sync belongs under `sync`, render/query packages, or examples
+only.
+
+Budget: source-only architecture checkpoint.
+
+Evidence required:
+
+- one Electric or PowerSync example mapped to Lite atoms/resources;
+- no new generic sync abstraction unless the use case repeats across at least two systems;
+- clear rule for where local database lifetime lives.
+
+## Accepted For Now
+
+- NATS is the next backend adapter to implement for the existing value-sync primitive.
+- Yjs is the next CRDT discovery, but it should be a sibling lane, not a transport implementation.
+- Automerge is worth a later structured-document discovery.
+- Electric, PowerSync, Replicache, and WatermelonDB are integration/protocol references unless a
+  concrete product use case needs database-shaped sync.

--- a/research/learnings/sync-backend-discovery.md
+++ b/research/learnings/sync-backend-discovery.md
@@ -47,8 +47,11 @@ Implementation checkpoint:
   payload bytes, watches key updates, and returns KV revisions as write acknowledgements.
 - The adapter test suite covers deterministic store behavior and a real Docker-backed `nats:2.12-alpine`
   JetStream KV integration through `createScope`, `sync.extension`, and `sync.runtime`.
-- Remaining production proof is reconnect behavior, explicit stale-revision racing, invalid persisted
-  payload handling at the adapter boundary, and larger sustained update stress.
+- The NATS adapter proof now covers stale revision racing, corrupt persisted watch payload isolation,
+  backend revision mapping, and a 1,000-write JetStream KV stress run with per-operation overhead
+  measurement.
+- Remaining production proof is reconnect behavior and a first-class CAS conflict result if callers need
+  retry/accountability beyond the current write-error boundary.
 
 ## Backend Findings
 
@@ -226,10 +229,11 @@ Evidence required:
 
 - real `nats-server -js`, not mocked transport;
 - adapter package under `pkg/ext/sync-nats`;
-- conformance tests for read, write, watch, reconnect, stale revision, CAS conflict, invalid payload,
-  and shared transport lifetime;
-- stress example that writes at least 1,000 updates and reports per-op overhead;
-- proof that backend revision is surfaced or intentionally mapped.
+- conformance tests for read, write, watch, stale revision, CAS conflict, invalid payload, and shared
+  transport lifetime;
+- stress proof that writes at least 1,000 updates and measures per-op overhead;
+- proof that backend revision is surfaced or intentionally mapped;
+- reconnect behavior remains the next adapter-hardening proof.
 
 Likely package shape:
 


### PR DESCRIPTION
## Summary

Adds `@pumped-fn/lite-extension-sync`, a strict atom-like sync primitive for Lite scopes, plus production-shaped practical examples that stress-test replication, runtime validation, conflict handling, write overhead, and frontend/backend web-environment sync. Adds `@pumped-fn/lite-extension-sync-nats` as the first real backend adapter over NATS JetStream KV, with backend revision acknowledgements, first-class write conflicts, watch resume/retry, and Docker-backed integration proof.

## Changes

- Add `sync(...)` with JSON-safe inference, codec support for non-JSON state, tag-injected runtime transport, memory transport, revision/LWW conflict policies, backend write acknowledgements, and first-class `Sync.WriteConflict` results.
- Serialize and coalesce local writes per bound sync atom so failed writes stay unsynced, in-flight reverts flush correctly, backend ack revisions become the confirmed version boundary, and backend write conflicts flow through the same sync conflict path as watched remote records.
- Add `@pumped-fn/lite-extension-sync-nats` with KV key encoding, JSON byte payloads, CAS-style create/update writes, watch-based delivery, adapter watch error reporting, corrupt watched-entry isolation, revision ack mapping, stale-revision conflict mapping, and adapter-level watch retry using `resumeFromRevision`.
- Add deterministic NATS conformance coverage for stale revision races as `Sync.WriteConflict`, ordinary backend write errors, stale errors without current records, corrupt persisted watch payloads, watch iterator failures, retry exhaustion, delayed retry cleanup, initial watch retry, resume without/with prior revision, cleanup races, safe key encoding, deleted-entry recreation, and backend revision reads/writes.
- Add real Docker-backed NATS JetStream KV integration coverage for scope-level replication, direct revision mapping, real wrong-last-sequence mapping to `Sync.WriteConflict`, real watch resume from the last delivered revision, and 1,000 sustained backend writes with per-operation overhead measurement.
- Add `examples/lite-sync-practical` to exercise two-peer draft replication with stress metrics, invalid payload rejection, conflict reporting, and convergence through the public scope/controller seam.
- Add `examples/lite-sync-web-practical` to prove the frontend shape: shared `sync(...)` atom declarations, `web.env(...)` at the browser scope boundary, `web.server(...)` at the backend boundary, fetch-backed read/write, streamed watch updates, namespace/auth enforcement, peer identity, backend conflict pass-through, and ordinary React `useAtom`/`useFlow` observers.
- Add `research/learnings/sync-backend-discovery.md` to record the backend split: NATS for value sync first, Yjs/Automerge as CRDT lanes, and database-shaped sync outside the atom-value transport.

## Independent Review

Claude reviewed the staged sync/NATS patch and raised two concrete findings: an in-flight local revert could be dropped, and the NATS watch loop could leave a detached unhandled rejection. Both were fixed with public-seam regression tests and adapter watch-error coverage. Claude also reviewed the watch retry patch and raised finite-attempt reset plus terminal-signal concerns; both were fixed with retry metadata and per-incident attempt reset tests.

## Testing

- `pnpm install`
- `pnpm -F @pumped-fn/lite-extension-sync typecheck`
- `pnpm -F @pumped-fn/lite-extension-sync test` - 26 tests, 100% coverage
- `pnpm -F @pumped-fn/lite-extension-sync-nats typecheck`
- `pnpm -F @pumped-fn/lite-extension-sync-nats test` - 21 tests, 100% coverage, includes Docker `nats:2.12-alpine` JetStream KV integration, real stale-revision conflict mapping, real watch resume, and 1,000 backend writes
- `pnpm -F @pumped-fn/lite-extension-sync build`
- `pnpm -F @pumped-fn/lite-extension-sync-nats build`
- `pnpm -F @pumped-fn/lite-sync-practical typecheck`
- `pnpm -F @pumped-fn/lite-sync-practical test` - 2 tests, 100% coverage
- `pnpm -F @pumped-fn/lite-sync-web-practical typecheck`
- `pnpm -F @pumped-fn/lite-sync-web-practical test` - 10 tests, 100% coverage, includes browser React render and fetch/stream gateway proof
- `pnpm -F @pumped-fn/lite-extension-sync-nats pack --dry-run`
- `pnpm ci:changed-packages`
- `git diff --check`
