### PR TITLE
Add parking lot management app examples

### DIFF
--- a/.changeset/steady-flow-controllers.md
+++ b/.changeset/steady-flow-controllers.md
@@ -1,0 +1,5 @@
+---
+"@pumped-fn/lite-lint": patch
+---
+
+Add a `pumped/no-direct-flow-composition` rule that requires flow-to-flow composition to use explicit `controller(childFlow)` dependencies instead of hidden direct flow execution.

--- a/README.md
+++ b/README.md
@@ -311,6 +311,11 @@ The examples are part of the public contract for how code should be shaped:
 | `examples/lite-react-practical` | React observer patterns, provider-owned execution, scoped drafts, json-render, complex Kanban |
 | `examples/lite-bff-practical` | BFF transport/capability/feature layering and HTTP-shaped flow boundaries |
 | `examples/lite-cli-practical` | Commander, Yargs, and CAC parser integrations with per-command Lite scopes |
+| `examples/parking-lot-shared` | Shared parking lot business logic with roles, booking, payment pairing, receipts, refunds, disputes, reports, and SQLite-backed persistence behind a store port |
+| `examples/parking-lot-cli` | CLI entrypoint that creates per-command scopes and executes parking lot flows |
+| `examples/parking-lot-hono` | Hono API entrypoint through per-request Lite execution contexts |
+| `examples/parking-lot-tanstack-start` | TanStack Start server-function handlers over parking lot flows |
+| `examples/parking-lot-spa` | Vite React SPA that observes and dispatches parking lot flows through Lite React providers |
 | `benchmarks/lite-perf` | Runtime and React observer performance checks |
 
 ## Local Development

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,12 +15,17 @@ surfaces for documented patterns, not publishing targets.
 | `lite-hono-todo-practical/` | `@pumped-fn/lite-hono-todo-practical` | Hono backend integration for a todo API. |
 | `lite-tanstack-start-todo-practical/` | `@pumped-fn/lite-tanstack-start-todo-practical` | TanStack Start fullstack integration for todos. |
 | `lite-cli-practical/` | `@pumped-fn/lite-cli-practical` | CLI parser integrations with per-command Lite scopes. |
+| `parking-lot-shared/` | `@pumped-fn/parking-lot-shared` | Parking lot management business logic and persistence ports shared by every entrypoint. |
+| `parking-lot-cli/` | `@pumped-fn/parking-lot-cli` | CLI entrypoint over the parking lot management flows. |
+| `parking-lot-hono/` | `@pumped-fn/parking-lot-hono` | Hono API entrypoint over the parking lot management flows. |
+| `parking-lot-tanstack-start/` | `@pumped-fn/parking-lot-tanstack-start` | TanStack Start server-function entrypoint over the parking lot management flows. |
+| `parking-lot-spa/` | `@pumped-fn/parking-lot-spa` | Vite React SPA over the parking lot management flows and state. |
 | `agent-practical/` | `@pumped-fn/agent-practical` | Agent workflow examples. |
 
 ## Naming
 
-Example directories use `<surface>-practical`. Keep names explicit enough to map to the package lane
-they demonstrate.
+Small examples use `<surface>-practical`. Domain capstones use `<domain>-<surface>` with a shared
+domain package when multiple entrypoints prove the same behavior.
 
 ## Content Rules
 

--- a/examples/lite-bff-practical/src/http.ts
+++ b/examples/lite-bff-practical/src/http.ts
@@ -1,4 +1,4 @@
-import { flow, typed } from "@pumped-fn/lite"
+import { controller, flow, typed } from "@pumped-fn/lite"
 import { InvalidCredentials, InvalidSession, login, validateSession } from "./auth"
 import { dashboardView, type DashboardView } from "./dashboard"
 
@@ -48,7 +48,7 @@ export type BffResult = BffResponse<LoginResponse | DashboardView | BffError>
 export const handleBffRequest = flow({
   name: "handle-bff-request",
   parse: typed<BffRequest>(),
-  deps: { dashboardView, login, validateSession },
+  deps: { dashboardView: controller(dashboardView), login: controller(login), validateSession: controller(validateSession) },
   factory: async (ctx, { dashboardView, login, validateSession }): Promise<BffResult> => {
     const request = ctx.input
     if (request.path === "/login") {

--- a/examples/lite-practical/patterns/02-parameter-drilling/after.ts
+++ b/examples/lite-practical/patterns/02-parameter-drilling/after.ts
@@ -1,4 +1,4 @@
-import { flow, tag, tags } from "@pumped-fn/lite"
+import { controller, flow, tag, tags } from "@pumped-fn/lite"
 
 export const requestId = tag<string>({ label: "request.id" })
 export const channel = tag<string>({ label: "request.channel" })
@@ -21,19 +21,19 @@ export const metadata = flow({
 
 export const secondHop = flow({
   name: "p02.second-hop",
-  deps: { leaf },
+  deps: { leaf: controller(leaf) },
   factory: (_ctx, { leaf }) => leaf.exec(),
 })
 
 export const firstHop = flow({
   name: "p02.first-hop",
-  deps: { secondHop },
+  deps: { secondHop: controller(secondHop) },
   factory: (_ctx, { secondHop }) => secondHop.exec(),
 })
 
 export const boundary = flow({
   name: "p02.boundary",
-  deps: { firstHop },
+  deps: { firstHop: controller(firstHop) },
   factory: (_ctx, { firstHop }) => firstHop.exec(),
 })
 

--- a/examples/lite-practical/patterns/06-transaction-boilerplate/after.ts
+++ b/examples/lite-practical/patterns/06-transaction-boilerplate/after.ts
@@ -1,4 +1,4 @@
-import { flow, resource, typed } from "@pumped-fn/lite"
+import { controller, flow, resource, typed } from "@pumped-fn/lite"
 
 export type LedgerEntry = {
   readonly account: string
@@ -92,7 +92,7 @@ export const writeAuditEntry = flow({
 export const transferFunds = flow({
   name: "transfer-funds",
   parse: typed<TransferInput>(),
-  deps: { tx, writeAuditEntry },
+  deps: { tx, writeAuditEntry: controller(writeAuditEntry) },
   factory: async (ctx, { tx, writeAuditEntry }) => {
     await tx.write({ account: ctx.input.from, deltaCents: -ctx.input.cents })
     await tx.write({ account: ctx.input.to, deltaCents: ctx.input.cents })

--- a/examples/lite-practical/patterns/09-inline-cross-cutting/after.ts
+++ b/examples/lite-practical/patterns/09-inline-cross-cutting/after.ts
@@ -1,4 +1,4 @@
-import { atom, flow, resource, tag, tags, typed, type Lite } from "@pumped-fn/lite"
+import { atom, controller, flow, resource, tag, tags, typed, type Lite } from "@pumped-fn/lite"
 
 export type QuoteInput = {
   readonly items: readonly number[]
@@ -88,9 +88,9 @@ export const persistReceipt = flow({
 export const checkout = flow({
   name: "checkout",
   parse: typed<QuoteInput>(),
-  factory: async (ctx) => {
-    return ctx.exec({
-      flow: persistReceipt,
+  deps: { persistReceipt: controller(persistReceipt) },
+  factory: async (ctx, { persistReceipt }) => {
+    return persistReceipt.exec({
       input: {
         itemCount: ctx.input.items.length,
         subtotalCents: await ctx.exec({

--- a/examples/lite-practical/patterns/10-request-scoped-globals/after.ts
+++ b/examples/lite-practical/patterns/10-request-scoped-globals/after.ts
@@ -1,4 +1,4 @@
-import { flow, resource, tag, tags } from "@pumped-fn/lite"
+import { controller, flow, resource, tag, tags } from "@pumped-fn/lite"
 
 export interface RequestUser {
   readonly id: string
@@ -44,7 +44,7 @@ export const asyncSession = flow({
 
 export const nestedSession = flow({
   name: "p10.nested-session",
-  deps: { asyncSession },
+  deps: { asyncSession: controller(asyncSession) },
   factory: async (_ctx, { asyncSession }) => {
     const first = await asyncSession.exec()
     const second = await asyncSession.exec()

--- a/examples/lite-react-practical/capstone/fat/src/auth.ts
+++ b/examples/lite-react-practical/capstone/fat/src/auth.ts
@@ -94,7 +94,7 @@ export const login = flow({
 export const submitLogin = flow({
   name: "submitLogin",
   parse: typed<undefined>(),
-  deps: { formControl: controller(loginForm, { resolve: true }), login },
+  deps: { formControl: controller(loginForm, { resolve: true }), login: controller(login) },
   factory: async (_ctx, { formControl, login }) => {
     const form = formControl.get()
     const validationError = loginValidationError(form)

--- a/examples/lite-react-practical/capstone/kanban/src/board.ts
+++ b/examples/lite-react-practical/capstone/kanban/src/board.ts
@@ -456,7 +456,7 @@ export const moveCard = flow({
     audit: actionAudit,
     actor: tags.required(actorId),
     projectId: tags.required(activeProjectId),
-    summarizeCard,
+    summarizeCard: controller(summarizeCard),
   },
   factory: async (ctx, { state, audit, actor, projectId, summarizeCard }) => {
     const before = state.get().cards.get(ctx.input.cardId)

--- a/examples/lite-react-practical/capstone/thin/src/signIn.ts
+++ b/examples/lite-react-practical/capstone/thin/src/signIn.ts
@@ -51,7 +51,7 @@ export const signIn = flow({
 export const submitSignIn = flow({
   name: "submitSignIn",
   parse: typed<undefined>(),
-  deps: { formControl: controller(signInForm, { resolve: true }), signIn },
+  deps: { formControl: controller(signInForm, { resolve: true }), signIn: controller(signIn) },
   factory: async (_ctx, { formControl, signIn }) => {
     const form = formControl.get()
     const validationError = signInValidationError(form)

--- a/examples/parking-lot-cli/package.json
+++ b/examples/parking-lot-cli/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pumped-fn/parking-lot-cli",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/parking-lot-shared": "workspace:*",
+    "cac": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/parking-lot-cli/src/cli.ts
+++ b/examples/parking-lot-cli/src/cli.ts
@@ -1,0 +1,52 @@
+import { cac } from "cac"
+import { createMemoryStore } from "@pumped-fn/parking-lot-shared"
+import { book, checkIn, configure, exit, fail, pay, report, type Runtime } from "./commands"
+
+const database = createMemoryStore()
+
+function runtime(role: Runtime["actor"]["role"], id = `${role}-cli`): Runtime {
+  return {
+    actor: { id, role },
+    at: new Date().toISOString(),
+    store: database,
+  }
+}
+
+export function createCli() {
+  const cli = cac("parking-lot")
+  cli.command("configure <name>", "configure a lot").action(async (name: string) => {
+    console.log(await configure(runtime("manager"), {
+      bookingLeadMinutes: 120,
+      capacity: 60,
+      currency: "USD",
+      graceMinutes: 10,
+      name,
+      rateCentsPerHour: 500,
+      refundWindowMinutes: 1440,
+    }))
+  })
+  cli.command("book <lotId> <plate>", "book a parking slot").action(async (lotId: string, plate: string) => {
+    console.log(await book(runtime("user", "cli-user"), {
+      endAt: "2026-07-01T12:00:00.000Z",
+      lotId,
+      plate,
+      startAt: "2026-07-01T10:00:00.000Z",
+    }))
+  })
+  cli.command("check-in <lotId> <plate>", "check in a drive-up vehicle").action(async (lotId: string, plate: string) => {
+    console.log(await checkIn(runtime("operator"), { lotId, plate, userId: "cli-user" }))
+  })
+  cli.command("exit <sessionId>", "prepare a vehicle exit").action(async (sessionId: string) => {
+    console.log(await exit(runtime("operator"), { sessionId }))
+  })
+  cli.command("pay <paymentId> <externalRef>", "pair a payment").action(async (paymentId: string, externalRef: string) => {
+    console.log(await pay(runtime("operator"), { externalRef, method: "card", paymentId }))
+  })
+  cli.command("fail <paymentId> <reason>", "record payment failure").action(async (paymentId: string, reason: string) => {
+    console.log(await fail(runtime("operator"), { paymentId, reason }))
+  })
+  cli.command("report", "read manager report").action(async () => {
+    console.log(await report(runtime("manager"), {}))
+  })
+  return cli
+}

--- a/examples/parking-lot-cli/src/commands.ts
+++ b/examples/parking-lot-cli/src/commands.ts
@@ -1,0 +1,112 @@
+import { createScope, preset } from "@pumped-fn/lite"
+import {
+  actor,
+  bookSpace,
+  checkInVehicle,
+  configureLot,
+  now,
+  pairPayment,
+  prepareExit,
+  readReport,
+  recordPaymentFailure,
+  store,
+  type Actor,
+  type BookSpaceInput,
+  type CheckInVehicleInput,
+  type ConfigureLotInput,
+  type PairPaymentInput,
+  type ParkingStore,
+  type PrepareExitInput,
+  type ReadReportInput,
+  type RecordPaymentFailureInput,
+} from "@pumped-fn/parking-lot-shared"
+
+export interface Runtime {
+  actor: Actor
+  at: string
+  store: ParkingStore
+}
+
+export async function configure(runtime: Runtime, input: ConfigureLotInput) {
+  const scope = createScope({
+    presets: [preset(store, runtime.store)],
+    tags: [actor(runtime.actor), now(() => runtime.at)],
+  })
+  const ctx = scope.createContext()
+  const output = await ctx.exec({ flow: configureLot, input })
+  await ctx.close({ ok: true })
+  await scope.dispose()
+  return output
+}
+
+export async function book(runtime: Runtime, input: BookSpaceInput) {
+  const scope = createScope({
+    presets: [preset(store, runtime.store)],
+    tags: [actor(runtime.actor), now(() => runtime.at)],
+  })
+  const ctx = scope.createContext()
+  const output = await ctx.exec({ flow: bookSpace, input })
+  await ctx.close({ ok: true })
+  await scope.dispose()
+  return output
+}
+
+export async function checkIn(runtime: Runtime, input: CheckInVehicleInput) {
+  const scope = createScope({
+    presets: [preset(store, runtime.store)],
+    tags: [actor(runtime.actor), now(() => runtime.at)],
+  })
+  const ctx = scope.createContext()
+  const output = await ctx.exec({ flow: checkInVehicle, input })
+  await ctx.close({ ok: true })
+  await scope.dispose()
+  return output
+}
+
+export async function exit(runtime: Runtime, input: PrepareExitInput) {
+  const scope = createScope({
+    presets: [preset(store, runtime.store)],
+    tags: [actor(runtime.actor), now(() => runtime.at)],
+  })
+  const ctx = scope.createContext()
+  const output = await ctx.exec({ flow: prepareExit, input })
+  await ctx.close({ ok: true })
+  await scope.dispose()
+  return output
+}
+
+export async function pay(runtime: Runtime, input: PairPaymentInput) {
+  const scope = createScope({
+    presets: [preset(store, runtime.store)],
+    tags: [actor(runtime.actor), now(() => runtime.at)],
+  })
+  const ctx = scope.createContext()
+  const output = await ctx.exec({ flow: pairPayment, input })
+  await ctx.close({ ok: true })
+  await scope.dispose()
+  return output
+}
+
+export async function fail(runtime: Runtime, input: RecordPaymentFailureInput) {
+  const scope = createScope({
+    presets: [preset(store, runtime.store)],
+    tags: [actor(runtime.actor), now(() => runtime.at)],
+  })
+  const ctx = scope.createContext()
+  const output = await ctx.exec({ flow: recordPaymentFailure, input })
+  await ctx.close({ ok: true })
+  await scope.dispose()
+  return output
+}
+
+export async function report(runtime: Runtime, input: ReadReportInput) {
+  const scope = createScope({
+    presets: [preset(store, runtime.store)],
+    tags: [actor(runtime.actor), now(() => runtime.at)],
+  })
+  const ctx = scope.createContext()
+  const output = await ctx.exec({ flow: readReport, input })
+  await ctx.close({ ok: true })
+  await scope.dispose()
+  return output
+}

--- a/examples/parking-lot-cli/src/index.ts
+++ b/examples/parking-lot-cli/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./cli"
+export * from "./commands"

--- a/examples/parking-lot-cli/tests/commands.test.ts
+++ b/examples/parking-lot-cli/tests/commands.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest"
+import { createMemoryStore } from "@pumped-fn/parking-lot-shared"
+import { book, checkIn, configure, exit, fail, pay, report } from "../src"
+
+describe("parking lot CLI commands", () => {
+  test("executes shared flows through per-command scopes", async () => {
+    const backing = createMemoryStore()
+    const manager = { actor: { id: "manager-cli", role: "manager" as const }, at: "2026-07-01T08:00:00.000Z", store: backing }
+    const operator = { actor: { id: "operator-cli", role: "operator" as const }, at: "2026-07-01T10:00:00.000Z", store: backing }
+    const user = { actor: { id: "user-cli", role: "user" as const }, at: "2026-07-01T08:10:00.000Z", store: backing }
+
+    const lot = await configure(manager, {
+      bookingLeadMinutes: 60,
+      capacity: 3,
+      currency: "USD",
+      graceMinutes: 0,
+      name: "CLI Garage",
+      rateCentsPerHour: 400,
+      refundWindowMinutes: 1440,
+    })
+    const booking = await book(user, {
+      endAt: "2026-07-01T12:00:00.000Z",
+      lotId: lot.id,
+      plate: "cli-123",
+      startAt: "2026-07-01T10:00:00.000Z",
+    })
+    expect(booking).toMatchObject({ status: "held", userId: "user-cli" })
+
+    const session = await checkIn(operator, { lotId: lot.id, plate: "cli-456", userId: "user-cli" })
+    const prepared = await exit({ ...operator, at: "2026-07-01T11:20:00.000Z" }, { sessionId: session.id })
+    const paired = await pay(operator, { externalRef: "cli-payment", method: "card", paymentId: prepared.payment.id })
+    const failedSession = await checkIn(operator, { lotId: lot.id, plate: "cli-789", userId: "user-cli" })
+    const failedExit = await exit({ ...operator, at: "2026-07-01T11:20:00.000Z" }, { sessionId: failedSession.id })
+    const failed = await fail(operator, { paymentId: failedExit.payment.id, reason: "cash drawer mismatch" })
+    const current = await report(manager, {})
+
+    expect(paired.receipt).toMatchObject({ type: "charge" })
+    expect(failed).toMatchObject({ status: "failed" })
+    expect(current.totals).toMatchObject({ failedPayments: 1, revenueCents: 800 })
+  })
+})

--- a/examples/parking-lot-cli/tsconfig.json
+++ b/examples/parking-lot-cli/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/parking-lot-cli/vitest.config.ts
+++ b/examples/parking-lot-cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+})

--- a/examples/parking-lot-hono/package.json
+++ b/examples/parking-lot-hono/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@pumped-fn/parking-lot-hono",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-hono": "workspace:*",
+    "@pumped-fn/parking-lot-shared": "workspace:*",
+    "hono": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/parking-lot-hono/src/app.ts
+++ b/examples/parking-lot-hono/src/app.ts
@@ -1,0 +1,80 @@
+import { createScope, preset } from "@pumped-fn/lite"
+import { hono } from "@pumped-fn/lite-hono"
+import {
+  actor,
+  bookSpace,
+  checkInVehicle,
+  configureLot,
+  now,
+  pairPayment,
+  prepareExit,
+  readReport,
+  store,
+  type Actor,
+  type ParkingStore,
+  type Role,
+} from "@pumped-fn/parking-lot-shared"
+import { Hono } from "hono"
+
+export interface Runtime {
+  at: string | (() => string)
+  store: ParkingStore
+}
+
+export function createApp(runtime: Runtime) {
+  const lite = hono.adapter()
+  const scope = createScope({
+    presets: [preset(store, runtime.store)],
+    extensions: [lite],
+  })
+  const app = new Hono<hono.Env>()
+
+  app.use("*", lite.middleware({
+    tags: (request) => [
+      actor(readActor(request.headers.get("x-actor-id") ?? undefined, request.headers.get("x-role") ?? undefined)),
+      now(() => readAt(runtime)),
+    ],
+  }))
+  app.post("/lots", async (context) => context.json(await context.var.lite.exec({
+    flow: configureLot,
+    rawInput: await context.req.json(),
+  })))
+  app.post("/bookings", async (context) => context.json(await context.var.lite.exec({
+    flow: bookSpace,
+    rawInput: await context.req.json(),
+  })))
+  app.post("/check-ins", async (context) => context.json(await context.var.lite.exec({
+    flow: checkInVehicle,
+    rawInput: await context.req.json(),
+  })))
+  app.post("/exits", async (context) => context.json(await context.var.lite.exec({
+    flow: prepareExit,
+    rawInput: await context.req.json(),
+  })))
+  app.post("/payments/pair", async (context) => context.json(await context.var.lite.exec({
+    flow: pairPayment,
+    rawInput: await context.req.json(),
+  })))
+  app.post("/reports", async (context) => context.json(await context.var.lite.exec({
+    flow: readReport,
+    rawInput: await context.req.json(),
+  })))
+
+  return { app, scope }
+}
+
+function readActor(id: string | undefined, role: string | undefined): Actor {
+  return {
+    id: id ?? "anonymous",
+    role: readRole(role),
+  }
+}
+
+function readAt(runtime: Runtime): string {
+  return typeof runtime.at === "string" ? runtime.at : runtime.at()
+}
+
+function readRole(value: string | undefined): Role {
+  if (value === "manager" || value === "operator" || value === "user") return value
+  throw new Error(`unknown role: ${value ?? "missing"}`)
+}

--- a/examples/parking-lot-hono/src/index.ts
+++ b/examples/parking-lot-hono/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./app"

--- a/examples/parking-lot-hono/tests/app.test.ts
+++ b/examples/parking-lot-hono/tests/app.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "vitest"
+import { createMemoryStore } from "@pumped-fn/parking-lot-shared"
+import { createApp } from "../src"
+
+describe("parking lot Hono app", () => {
+  test("routes run shared flows through per-request Lite contexts", async () => {
+    let at = "2026-07-01T08:00:00.000Z"
+    const { app, scope } = createApp({
+      at: () => at,
+      store: createMemoryStore(),
+    })
+    const manager = { "content-type": "application/json", "x-actor-id": "manager-api", "x-role": "manager" }
+    const operator = { "content-type": "application/json", "x-actor-id": "operator-api", "x-role": "operator" }
+    const user = { "content-type": "application/json", "x-actor-id": "user-api", "x-role": "user" }
+
+    const lotResponse = await app.request("/lots", {
+      body: JSON.stringify({
+        bookingLeadMinutes: 60,
+        capacity: 2,
+        currency: "USD",
+        graceMinutes: 0,
+        name: "Hono Garage",
+        rateCentsPerHour: 600,
+        refundWindowMinutes: 1440,
+      }),
+      headers: manager,
+      method: "POST",
+    })
+    const lot = await lotResponse.json() as { id: string }
+
+    const bookingResponse = await app.request("/bookings", {
+      body: JSON.stringify({
+        endAt: "2026-07-01T12:00:00.000Z",
+        lotId: lot.id,
+        plate: "api-111",
+        startAt: "2026-07-01T10:00:00.000Z",
+      }),
+      headers: user,
+      method: "POST",
+    })
+    expect(await bookingResponse.json()).toMatchObject({ status: "held", userId: "user-api" })
+
+    const sessionResponse = await app.request("/check-ins", {
+      body: JSON.stringify({ lotId: lot.id, plate: "api-222", userId: "user-api" }),
+      headers: operator,
+      method: "POST",
+    })
+    const session = await sessionResponse.json() as { id: string }
+    at = "2026-07-01T08:50:00.000Z"
+    const exitResponse = await app.request("/exits", {
+      body: JSON.stringify({ sessionId: session.id }),
+      headers: operator,
+      method: "POST",
+    })
+    const prepared = await exitResponse.json() as { payment: { id: string } }
+    const pairedResponse = await app.request("/payments/pair", {
+      body: JSON.stringify({ externalRef: "api-payment", method: "card", paymentId: prepared.payment.id }),
+      headers: operator,
+      method: "POST",
+    })
+    expect(await pairedResponse.json()).toMatchObject({ receipt: { type: "charge" } })
+
+    const reportResponse = await app.request("/reports", {
+      body: JSON.stringify({}),
+      headers: manager,
+      method: "POST",
+    })
+    expect(await reportResponse.json()).toMatchObject({ totals: { revenueCents: 600 } })
+    await scope.dispose()
+  })
+})

--- a/examples/parking-lot-hono/tsconfig.json
+++ b/examples/parking-lot-hono/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/parking-lot-hono/vitest.config.ts
+++ b/examples/parking-lot-hono/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+})

--- a/examples/parking-lot-shared/package.json
+++ b/examples/parking-lot-shared/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@pumped-fn/parking-lot-shared",
+  "private": true,
+  "type": "module",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./sqlite": "./src/sqlite.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/parking-lot-shared/src/graph.ts
+++ b/examples/parking-lot-shared/src/graph.ts
@@ -1,0 +1,509 @@
+import { atom, flow, resource, tag, tags, typed } from "@pumped-fn/lite"
+import type {
+  Actor,
+  AuditRecord,
+  Booking,
+  Dispute,
+  Lot,
+  LotReport,
+  ParkingSession,
+  Payment,
+  Receipt,
+  Report,
+  Role,
+} from "./model"
+import { createMemoryStore, type ParkingStore } from "./store"
+
+export const actor = tag<Actor>({ label: "parking.actor" })
+
+export const now = tag<() => string>({
+  default: () => new Date().toISOString(),
+  label: "parking.now",
+})
+
+export const store = atom({
+  factory: () => createMemoryStore(),
+})
+
+interface Work {
+  actor: Actor
+  at(): string
+  id(prefix: string): string
+  record(type: string, targetId: string, data?: Record<string, string | number | boolean | null>): void
+  store: ParkingStore
+}
+
+export const tx = resource({
+  name: "parking.tx",
+  ownership: "current",
+  deps: {
+    actor: tags.required(actor),
+    now: tags.required(now),
+    store,
+  },
+  factory: (ctx, deps): Work => {
+    const events: AuditRecord[] = []
+    ctx.cleanup(() => {
+      for (const event of events) deps.store.saveAudit(event)
+    })
+    return {
+      actor: deps.actor,
+      at: deps.now,
+      id: (prefix) => deps.store.nextId(prefix),
+      record: (type, targetId, data = {}) => {
+        events.push({
+          actorId: deps.actor.id,
+          at: deps.now(),
+          data,
+          id: deps.store.nextId("audit"),
+          role: deps.actor.role,
+          targetId,
+          type,
+        })
+      },
+      store: deps.store,
+    }
+  },
+})
+
+export interface ConfigureLotInput {
+  bookingLeadMinutes: number
+  capacity: number
+  currency: string
+  graceMinutes: number
+  lotId?: string
+  name: string
+  rateCentsPerHour: number
+  refundWindowMinutes: number
+}
+
+export interface BookSpaceInput {
+  endAt: string
+  lotId: string
+  plate: string
+  startAt: string
+}
+
+export interface CancelBookingInput {
+  bookingId: string
+}
+
+export interface CheckInVehicleInput {
+  lotId: string
+  plate: string
+  userId?: string
+}
+
+export interface CheckInBookingInput {
+  bookingId: string
+}
+
+export interface PrepareExitInput {
+  sessionId: string
+}
+
+export interface PairPaymentInput {
+  externalRef: string
+  method: string
+  paymentId: string
+}
+
+export interface RecordPaymentFailureInput {
+  paymentId: string
+  reason: string
+}
+
+export interface RefundPaymentInput {
+  paymentId: string
+  reason: string
+}
+
+export interface OpenDisputeInput {
+  paymentId: string
+  reason: string
+}
+
+export interface ResolveDisputeInput {
+  decision: "accepted" | "rejected"
+  disputeId: string
+}
+
+export interface ReadReportInput {
+  lotId?: string
+}
+
+export interface ListReceiptsInput {
+  userId?: string
+}
+
+export const configureLot = flow({
+  name: "parking.configure-lot",
+  parse: typed<ConfigureLotInput>(),
+  deps: { tx },
+  factory: (ctx, deps): Lot => {
+    allow(deps.tx.actor, ["manager"], "configure lot")
+    const lot: Lot = {
+      capacity: ctx.input.capacity,
+      id: ctx.input.lotId ?? deps.tx.id("lot"),
+      name: ctx.input.name,
+      rateCentsPerHour: ctx.input.rateCentsPerHour,
+      settings: {
+        bookingLeadMinutes: ctx.input.bookingLeadMinutes,
+        currency: ctx.input.currency,
+        graceMinutes: ctx.input.graceMinutes,
+        refundWindowMinutes: ctx.input.refundWindowMinutes,
+      },
+    }
+    deps.tx.store.saveLot(lot)
+    deps.tx.record("lot.configured", lot.id, { capacity: lot.capacity, rateCentsPerHour: lot.rateCentsPerHour })
+    return lot
+  },
+})
+
+export const bookSpace = flow({
+  name: "parking.book-space",
+  parse: typed<BookSpaceInput>(),
+  deps: { tx },
+  factory: (ctx, deps): Booking => {
+    allow(deps.tx.actor, ["user"], "book space")
+    const lot = deps.tx.store.lot(ctx.input.lotId)
+    assertCapacity(deps.tx.store, lot, ctx.input.startAt, ctx.input.endAt)
+    const booking: Booking = {
+      createdAt: deps.tx.at(),
+      endAt: ctx.input.endAt,
+      id: deps.tx.id("booking"),
+      lotId: lot.id,
+      plate: normalizePlate(ctx.input.plate),
+      startAt: ctx.input.startAt,
+      status: "held",
+      userId: deps.tx.actor.id,
+    }
+    deps.tx.store.saveBooking(booking)
+    deps.tx.record("booking.held", booking.id, { lotId: lot.id, userId: booking.userId })
+    return booking
+  },
+})
+
+export const cancelBooking = flow({
+  name: "parking.cancel-booking",
+  parse: typed<CancelBookingInput>(),
+  deps: { tx },
+  factory: (ctx, deps): Booking => {
+    const booking = deps.tx.store.booking(ctx.input.bookingId)
+    if (deps.tx.actor.role !== "manager" && deps.tx.actor.id !== booking.userId) {
+      throw new Error(`role ${deps.tx.actor.role} cannot cancel booking ${booking.id}`)
+    }
+    if (booking.status !== "held") throw new Error(`booking ${booking.id} is not held`)
+    const next = deps.tx.store.saveBooking({
+      ...booking,
+      cancelledAt: deps.tx.at(),
+      status: "cancelled",
+    })
+    deps.tx.record("booking.cancelled", next.id, { userId: next.userId })
+    return next
+  },
+})
+
+export const checkInVehicle = flow({
+  name: "parking.check-in-vehicle",
+  parse: typed<CheckInVehicleInput>(),
+  deps: { tx },
+  factory: (ctx, deps): ParkingSession => {
+    allow(deps.tx.actor, ["operator"], "check in vehicle")
+    const lot = deps.tx.store.lot(ctx.input.lotId)
+    assertDriveUpCapacity(deps.tx.store, lot)
+    const session: ParkingSession = {
+      enteredAt: deps.tx.at(),
+      id: deps.tx.id("session"),
+      lotId: lot.id,
+      plate: normalizePlate(ctx.input.plate),
+      status: "parked",
+      userId: ctx.input.userId,
+    }
+    deps.tx.store.saveSession(session)
+    deps.tx.record("session.parked", session.id, { lotId: lot.id, plate: session.plate })
+    return session
+  },
+})
+
+export const checkInBooking = flow({
+  name: "parking.check-in-booking",
+  parse: typed<CheckInBookingInput>(),
+  deps: { tx },
+  factory: (ctx, deps): ParkingSession => {
+    allow(deps.tx.actor, ["operator"], "check in booking")
+    const booking = deps.tx.store.booking(ctx.input.bookingId)
+    if (booking.status !== "held") throw new Error(`booking ${booking.id} is not held`)
+    const lot = deps.tx.store.lot(booking.lotId)
+    assertDriveUpCapacity(deps.tx.store, lot)
+    const session: ParkingSession = {
+      bookingId: booking.id,
+      enteredAt: deps.tx.at(),
+      id: deps.tx.id("session"),
+      lotId: lot.id,
+      plate: booking.plate,
+      status: "parked",
+      userId: booking.userId,
+    }
+    deps.tx.store.saveSession(session)
+    deps.tx.store.saveBooking({ ...booking, sessionId: session.id, status: "checked_in" })
+    deps.tx.record("booking.checked-in", booking.id, { sessionId: session.id })
+    return session
+  },
+})
+
+export const prepareExit = flow({
+  name: "parking.prepare-exit",
+  parse: typed<PrepareExitInput>(),
+  deps: { tx },
+  factory: (ctx, deps): { payment: Payment; session: ParkingSession } => {
+    allow(deps.tx.actor, ["operator"], "prepare exit")
+    const session = deps.tx.store.session(ctx.input.sessionId)
+    if (session.status !== "parked") throw new Error(`session ${session.id} is not parked`)
+    const exitedAt = deps.tx.at()
+    const lot = deps.tx.store.lot(session.lotId)
+    const payment: Payment = {
+      amountCents: amountDue(lot, session.enteredAt, exitedAt),
+      createdAt: exitedAt,
+      id: deps.tx.id("payment"),
+      sessionId: session.id,
+      status: "pending",
+    }
+    const next = deps.tx.store.saveSession({ ...session, exitedAt, status: "awaiting_payment" })
+    deps.tx.store.savePayment(payment)
+    completeBookingForSession(deps.tx.store, next)
+    deps.tx.record("session.exit-prepared", next.id, { amountCents: payment.amountCents, paymentId: payment.id })
+    return { payment, session: next }
+  },
+})
+
+export const pairPayment = flow({
+  name: "parking.pair-payment",
+  parse: typed<PairPaymentInput>(),
+  deps: { tx },
+  factory: (ctx, deps): { payment: Payment; receipt: Receipt; session: ParkingSession } => {
+    allow(deps.tx.actor, ["operator"], "pair payment")
+    const payment = deps.tx.store.payment(ctx.input.paymentId)
+    if (payment.status !== "pending" && payment.status !== "failed") {
+      throw new Error(`payment ${payment.id} cannot be paired from ${payment.status}`)
+    }
+    const session = deps.tx.store.session(payment.sessionId)
+    const paired: Payment = {
+      ...payment,
+      externalRef: ctx.input.externalRef,
+      method: ctx.input.method,
+      pairedAt: deps.tx.at(),
+      status: "paired",
+    }
+    const receipt = issueReceipt(deps.tx, paired, "charge", paired.amountCents)
+    const released = deps.tx.store.saveSession({ ...session, status: "released" })
+    deps.tx.store.savePayment(paired)
+    deps.tx.record("payment.paired", paired.id, { amountCents: paired.amountCents, receiptId: receipt.id })
+    return { payment: paired, receipt, session: released }
+  },
+})
+
+export const recordPaymentFailure = flow({
+  name: "parking.record-payment-failure",
+  parse: typed<RecordPaymentFailureInput>(),
+  deps: { tx },
+  factory: (ctx, deps): Payment => {
+    allow(deps.tx.actor, ["operator"], "record payment failure")
+    const payment = deps.tx.store.payment(ctx.input.paymentId)
+    if (payment.status !== "pending") throw new Error(`payment ${payment.id} is not pending`)
+    const failed = deps.tx.store.savePayment({
+      ...payment,
+      failureReason: ctx.input.reason,
+      status: "failed",
+    })
+    deps.tx.record("payment.failed", failed.id, { reason: ctx.input.reason })
+    return failed
+  },
+})
+
+export const refundPayment = flow({
+  name: "parking.refund-payment",
+  parse: typed<RefundPaymentInput>(),
+  deps: { tx },
+  factory: (ctx, deps): { payment: Payment; receipt: Receipt } => {
+    allow(deps.tx.actor, ["manager"], "refund payment")
+    const payment = deps.tx.store.payment(ctx.input.paymentId)
+    if (payment.status !== "paired" && payment.status !== "disputed") {
+      throw new Error(`payment ${payment.id} cannot be refunded from ${payment.status}`)
+    }
+    const refunded = deps.tx.store.savePayment({
+      ...payment,
+      refundedAt: deps.tx.at(),
+      status: "refunded",
+    })
+    const receipt = issueReceipt(deps.tx, refunded, "refund", -refunded.amountCents)
+    deps.tx.record("payment.refunded", refunded.id, { reason: ctx.input.reason, receiptId: receipt.id })
+    return { payment: refunded, receipt }
+  },
+})
+
+export const openDispute = flow({
+  name: "parking.open-dispute",
+  parse: typed<OpenDisputeInput>(),
+  deps: { tx },
+  factory: (ctx, deps): { dispute: Dispute; payment: Payment; receipt: Receipt } => {
+    allow(deps.tx.actor, ["user"], "open dispute")
+    const payment = deps.tx.store.payment(ctx.input.paymentId)
+    const session = deps.tx.store.session(payment.sessionId)
+    if (session.userId !== deps.tx.actor.id) throw new Error(`user ${deps.tx.actor.id} cannot dispute payment ${payment.id}`)
+    if (payment.status !== "paired") throw new Error(`payment ${payment.id} cannot be disputed from ${payment.status}`)
+    const disputed = deps.tx.store.savePayment({
+      ...payment,
+      disputedAt: deps.tx.at(),
+      status: "disputed",
+    })
+    const dispute: Dispute = deps.tx.store.saveDispute({
+      id: deps.tx.id("dispute"),
+      openedAt: deps.tx.at(),
+      paymentId: payment.id,
+      reason: ctx.input.reason,
+      status: "open",
+      userId: deps.tx.actor.id,
+    })
+    const receipt = issueReceipt(deps.tx, disputed, "dispute", 0)
+    deps.tx.record("payment.disputed", disputed.id, { disputeId: dispute.id, receiptId: receipt.id })
+    return { dispute, payment: disputed, receipt }
+  },
+})
+
+export const resolveDispute = flow({
+  name: "parking.resolve-dispute",
+  parse: typed<ResolveDisputeInput>(),
+  deps: { tx },
+  factory: (ctx, deps): { dispute: Dispute; payment: Payment; receipt?: Receipt } => {
+    allow(deps.tx.actor, ["manager"], "resolve dispute")
+    const dispute = deps.tx.store.dispute(ctx.input.disputeId)
+    if (dispute.status !== "open") throw new Error(`dispute ${dispute.id} is not open`)
+    const payment = deps.tx.store.payment(dispute.paymentId)
+    const resolved = deps.tx.store.saveDispute({
+      ...dispute,
+      resolvedAt: deps.tx.at(),
+      status: ctx.input.decision,
+    })
+    if (ctx.input.decision === "rejected") {
+      const paired = deps.tx.store.savePayment({ ...payment, status: "paired" })
+      deps.tx.record("dispute.rejected", resolved.id, { paymentId: payment.id })
+      return { dispute: resolved, payment: paired }
+    }
+    const refunded = deps.tx.store.savePayment({
+      ...payment,
+      refundedAt: deps.tx.at(),
+      status: "refunded",
+    })
+    const receipt = issueReceipt(deps.tx, refunded, "refund", -refunded.amountCents)
+    deps.tx.record("dispute.accepted", resolved.id, { paymentId: payment.id, receiptId: receipt.id })
+    return { dispute: resolved, payment: refunded, receipt }
+  },
+})
+
+export const listReceipts = flow({
+  name: "parking.list-receipts",
+  parse: typed<ListReceiptsInput>(),
+  deps: { tx },
+  factory: (ctx, deps): Receipt[] => {
+    const requestedUser = ctx.input.userId ?? deps.tx.actor.id
+    if (deps.tx.actor.role === "user" && requestedUser !== deps.tx.actor.id) {
+      throw new Error(`user ${deps.tx.actor.id} cannot read receipts for ${requestedUser}`)
+    }
+    return deps.tx.store.receipts().filter((receipt) => {
+      if (deps.tx.actor.role !== "user") return true
+      return deps.tx.store.session(receipt.sessionId).userId === requestedUser
+    })
+  },
+})
+
+export const readReport = flow({
+  name: "parking.read-report",
+  parse: typed<ReadReportInput>(),
+  deps: { tx },
+  factory: (ctx, deps): Report => {
+    allow(deps.tx.actor, ["manager"], "read report")
+    const lots = deps.tx.store.lots()
+      .filter((lot) => ctx.input.lotId === undefined || lot.id === ctx.input.lotId)
+      .map((lot): LotReport => {
+        const sessions = deps.tx.store.sessions().filter((session) => session.lotId === lot.id)
+        const payments = deps.tx.store.payments().filter((payment) => sessions.some((session) => session.id === payment.sessionId))
+        const disputes = deps.tx.store.disputes().filter((dispute) => payments.some((payment) => payment.id === dispute.paymentId))
+        return {
+          awaitingPayment: sessions.filter((session) => session.status === "awaiting_payment").length,
+          capacity: lot.capacity,
+          failedPayments: payments.filter((payment) => payment.status === "failed").length,
+          heldBookings: deps.tx.store.bookings().filter((booking) => booking.lotId === lot.id && booking.status === "held").length,
+          lotId: lot.id,
+          name: lot.name,
+          openDisputes: disputes.filter((dispute) => dispute.status === "open").length,
+          parked: sessions.filter((session) => session.status === "parked").length,
+          revenueCents: deps.tx.store.receipts().filter((receipt) => receipt.type === "charge").reduce((sum, receipt) => sum + receipt.amountCents, 0),
+        }
+      })
+    return {
+      generatedAt: deps.tx.at(),
+      lots,
+      totals: {
+        capacity: lots.reduce((sum, lot) => sum + lot.capacity, 0),
+        failedPayments: lots.reduce((sum, lot) => sum + lot.failedPayments, 0),
+        openDisputes: lots.reduce((sum, lot) => sum + lot.openDisputes, 0),
+        parked: lots.reduce((sum, lot) => sum + lot.parked, 0),
+        revenueCents: lots.reduce((sum, lot) => sum + lot.revenueCents, 0),
+      },
+    }
+  },
+})
+
+function allow(actor: Actor, roles: readonly Role[], action: string): void {
+  if (!roles.includes(actor.role)) throw new Error(`role ${actor.role} cannot ${action}`)
+}
+
+function amountDue(lot: Lot, enteredAt: string, exitedAt: string): number {
+  const minutes = Math.max(0, Math.ceil((Date.parse(exitedAt) - Date.parse(enteredAt)) / 60000))
+  const billable = Math.max(0, minutes - lot.settings.graceMinutes)
+  return billable === 0 ? 0 : Math.max(1, Math.ceil(billable / 60)) * lot.rateCentsPerHour
+}
+
+function assertCapacity(store: ParkingStore, lot: Lot, startAt: string, endAt: string): void {
+  const held = store.bookings().filter((booking) =>
+    booking.lotId === lot.id &&
+    booking.status === "held" &&
+    overlaps(startAt, endAt, booking.startAt, booking.endAt)
+  ).length
+  const parked = parkedCount(store, lot.id)
+  if (held + parked >= lot.capacity) throw new Error(`lot ${lot.id} has no reservable capacity`)
+}
+
+function assertDriveUpCapacity(store: ParkingStore, lot: Lot): void {
+  if (parkedCount(store, lot.id) >= lot.capacity) throw new Error(`lot ${lot.id} is full`)
+}
+
+function completeBookingForSession(store: ParkingStore, session: ParkingSession): void {
+  if (session.bookingId === undefined) return
+  const booking = store.booking(session.bookingId)
+  store.saveBooking({ ...booking, status: "completed" })
+}
+
+function issueReceipt(work: Work, payment: Payment, type: Receipt["type"], amountCents: number): Receipt {
+  return work.store.saveReceipt({
+    amountCents,
+    id: work.id("receipt"),
+    issuedAt: work.at(),
+    paymentId: payment.id,
+    sessionId: payment.sessionId,
+    type,
+  })
+}
+
+function normalizePlate(value: string): string {
+  return value.trim().toUpperCase()
+}
+
+function overlaps(leftStart: string, leftEnd: string, rightStart: string, rightEnd: string): boolean {
+  return Date.parse(leftStart) < Date.parse(rightEnd) && Date.parse(rightStart) < Date.parse(leftEnd)
+}
+
+function parkedCount(store: ParkingStore, lotId: string): number {
+  return store.sessions().filter((session) => session.lotId === lotId && session.status === "parked").length
+}

--- a/examples/parking-lot-shared/src/index.ts
+++ b/examples/parking-lot-shared/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./graph"
+export * from "./model"
+export * from "./store"

--- a/examples/parking-lot-shared/src/model.ts
+++ b/examples/parking-lot-shared/src/model.ts
@@ -1,0 +1,147 @@
+export type Role = "manager" | "operator" | "user"
+
+export interface Actor {
+  id: string
+  role: Role
+}
+
+export interface LotSettings {
+  bookingLeadMinutes: number
+  currency: string
+  graceMinutes: number
+  refundWindowMinutes: number
+}
+
+export interface Lot {
+  id: string
+  name: string
+  capacity: number
+  rateCentsPerHour: number
+  settings: LotSettings
+}
+
+export type BookingStatus = "held" | "checked_in" | "cancelled" | "completed"
+
+export interface Booking {
+  id: string
+  lotId: string
+  userId: string
+  plate: string
+  startAt: string
+  endAt: string
+  status: BookingStatus
+  createdAt: string
+  cancelledAt?: string
+  sessionId?: string
+}
+
+export type SessionStatus = "parked" | "awaiting_payment" | "released"
+
+export interface ParkingSession {
+  id: string
+  lotId: string
+  plate: string
+  userId?: string
+  bookingId?: string
+  enteredAt: string
+  exitedAt?: string
+  status: SessionStatus
+}
+
+export type PaymentStatus = "pending" | "failed" | "paired" | "refunded" | "disputed"
+
+export interface Payment {
+  id: string
+  sessionId: string
+  amountCents: number
+  status: PaymentStatus
+  createdAt: string
+  method?: string
+  externalRef?: string
+  failureReason?: string
+  pairedAt?: string
+  refundedAt?: string
+  disputedAt?: string
+}
+
+export type ReceiptType = "charge" | "refund" | "dispute"
+
+export interface Receipt {
+  id: string
+  paymentId: string
+  sessionId: string
+  type: ReceiptType
+  amountCents: number
+  issuedAt: string
+}
+
+export type DisputeStatus = "open" | "accepted" | "rejected"
+
+export interface Dispute {
+  id: string
+  paymentId: string
+  userId: string
+  reason: string
+  status: DisputeStatus
+  openedAt: string
+  resolvedAt?: string
+}
+
+export interface AuditRecord {
+  id: string
+  actorId: string
+  at: string
+  data: Record<string, string | number | boolean | null>
+  role: Role
+  targetId: string
+  type: string
+}
+
+export interface ParkingSnapshot {
+  audits: AuditRecord[]
+  bookings: Booking[]
+  disputes: Dispute[]
+  lots: Lot[]
+  payments: Payment[]
+  receipts: Receipt[]
+  sessions: ParkingSession[]
+}
+
+export interface LotReport {
+  lotId: string
+  name: string
+  capacity: number
+  parked: number
+  heldBookings: number
+  awaitingPayment: number
+  failedPayments: number
+  openDisputes: number
+  revenueCents: number
+}
+
+export interface Report {
+  generatedAt: string
+  lots: LotReport[]
+  totals: {
+    capacity: number
+    failedPayments: number
+    openDisputes: number
+    parked: number
+    revenueCents: number
+  }
+}
+
+export const acceptedWorkflows = [
+  "manager.configure-lot",
+  "manager.read-report",
+  "user.book-space",
+  "user.cancel-booking",
+  "operator.check-in-drive-up",
+  "operator.check-in-booking",
+  "operator.prepare-exit",
+  "operator.pair-payment",
+  "operator.record-payment-failure",
+  "manager.refund-payment",
+  "user.open-dispute",
+  "manager.resolve-dispute",
+] as const

--- a/examples/parking-lot-shared/src/sqlite.ts
+++ b/examples/parking-lot-shared/src/sqlite.ts
@@ -1,0 +1,184 @@
+import { DatabaseSync } from "node:sqlite"
+import type {
+  AuditRecord,
+  Booking,
+  Dispute,
+  Lot,
+  ParkingSession,
+  ParkingSnapshot,
+  Payment,
+  Receipt,
+} from "./model"
+import type { ParkingStore } from "./store"
+
+type Kind =
+  | "audit"
+  | "booking"
+  | "dispute"
+  | "lot"
+  | "payment"
+  | "receipt"
+  | "session"
+
+interface Row {
+  body: string
+}
+
+interface CounterRow {
+  value: number
+}
+
+export class SqliteParkingStore implements ParkingStore {
+  private readonly db: DatabaseSync
+
+  constructor(path: string) {
+    this.db = new DatabaseSync(path)
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS parking_documents (
+        kind TEXT NOT NULL,
+        id TEXT NOT NULL,
+        body TEXT NOT NULL,
+        PRIMARY KEY (kind, id)
+      );
+      CREATE TABLE IF NOT EXISTS parking_counters (
+        name TEXT PRIMARY KEY,
+        value INTEGER NOT NULL
+      );
+    `)
+  }
+
+  audit(id: string): AuditRecord {
+    return this.read("audit", id)
+  }
+
+  audits(): AuditRecord[] {
+    return this.list("audit")
+  }
+
+  booking(id: string): Booking {
+    return this.read("booking", id)
+  }
+
+  bookings(): Booking[] {
+    return this.list("booking")
+  }
+
+  close(): void {
+    this.db.close()
+  }
+
+  dispute(id: string): Dispute {
+    return this.read("dispute", id)
+  }
+
+  disputes(): Dispute[] {
+    return this.list("dispute")
+  }
+
+  lot(id: string): Lot {
+    return this.read("lot", id)
+  }
+
+  lots(): Lot[] {
+    return this.list("lot")
+  }
+
+  nextId(prefix: string): string {
+    const row = this.db.prepare("SELECT value FROM parking_counters WHERE name = ?").get(prefix) as CounterRow | undefined
+    const next = (row?.value ?? 0) + 1
+    this.db.prepare(`
+      INSERT INTO parking_counters (name, value)
+      VALUES (?, ?)
+      ON CONFLICT(name) DO UPDATE SET value = excluded.value
+    `).run(prefix, next)
+    return `${prefix}-${next.toString().padStart(4, "0")}`
+  }
+
+  payment(id: string): Payment {
+    return this.read("payment", id)
+  }
+
+  payments(): Payment[] {
+    return this.list("payment")
+  }
+
+  receipt(id: string): Receipt {
+    return this.read("receipt", id)
+  }
+
+  receipts(): Receipt[] {
+    return this.list("receipt")
+  }
+
+  saveAudit(record: AuditRecord): AuditRecord {
+    return this.save("audit", record.id, record)
+  }
+
+  saveBooking(booking: Booking): Booking {
+    return this.save("booking", booking.id, booking)
+  }
+
+  saveDispute(dispute: Dispute): Dispute {
+    return this.save("dispute", dispute.id, dispute)
+  }
+
+  saveLot(lot: Lot): Lot {
+    return this.save("lot", lot.id, lot)
+  }
+
+  savePayment(payment: Payment): Payment {
+    return this.save("payment", payment.id, payment)
+  }
+
+  saveReceipt(receipt: Receipt): Receipt {
+    return this.save("receipt", receipt.id, receipt)
+  }
+
+  saveSession(session: ParkingSession): ParkingSession {
+    return this.save("session", session.id, session)
+  }
+
+  session(id: string): ParkingSession {
+    return this.read("session", id)
+  }
+
+  sessions(): ParkingSession[] {
+    return this.list("session")
+  }
+
+  snapshot(): ParkingSnapshot {
+    return {
+      audits: this.audits(),
+      bookings: this.bookings(),
+      disputes: this.disputes(),
+      lots: this.lots(),
+      payments: this.payments(),
+      receipts: this.receipts(),
+      sessions: this.sessions(),
+    }
+  }
+
+  private list<T>(kind: Kind): T[] {
+    return this.db.prepare("SELECT body FROM parking_documents WHERE kind = ? ORDER BY id").all(kind)
+      .map((row) => JSON.parse((row as unknown as Row).body) as T)
+  }
+
+  private read<T>(kind: Kind, id: string): T {
+    const row = this.db.prepare("SELECT body FROM parking_documents WHERE kind = ? AND id = ?").get(kind, id) as Row | undefined
+    if (row === undefined) throw new Error(`unknown ${kind}: ${id}`)
+    return JSON.parse(row.body) as T
+  }
+
+  private save<T>(kind: Kind, id: string, value: T): T {
+    this.db.prepare(`
+      INSERT INTO parking_documents (kind, id, body)
+      VALUES (?, ?, ?)
+      ON CONFLICT(kind, id) DO UPDATE SET body = excluded.body
+    `).run(kind, id, JSON.stringify(value))
+    return value
+  }
+}
+
+export function createSqliteStore(path = ":memory:"): SqliteParkingStore {
+  return new SqliteParkingStore(path)
+}

--- a/examples/parking-lot-shared/src/store.ts
+++ b/examples/parking-lot-shared/src/store.ts
@@ -1,0 +1,184 @@
+import type {
+  AuditRecord,
+  Booking,
+  Dispute,
+  Lot,
+  ParkingSession,
+  ParkingSnapshot,
+  Payment,
+  Receipt,
+} from "./model"
+
+export interface ParkingStore {
+  audit(id: string): AuditRecord
+  audits(): AuditRecord[]
+  booking(id: string): Booking
+  bookings(): Booking[]
+  dispute(id: string): Dispute
+  disputes(): Dispute[]
+  lot(id: string): Lot
+  lots(): Lot[]
+  nextId(prefix: string): string
+  payment(id: string): Payment
+  payments(): Payment[]
+  receipt(id: string): Receipt
+  receipts(): Receipt[]
+  saveAudit(record: AuditRecord): AuditRecord
+  saveBooking(booking: Booking): Booking
+  saveDispute(dispute: Dispute): Dispute
+  saveLot(lot: Lot): Lot
+  savePayment(payment: Payment): Payment
+  saveReceipt(receipt: Receipt): Receipt
+  saveSession(session: ParkingSession): ParkingSession
+  session(id: string): ParkingSession
+  sessions(): ParkingSession[]
+  snapshot(): ParkingSnapshot
+}
+
+type Kind =
+  | "audit"
+  | "booking"
+  | "dispute"
+  | "lot"
+  | "payment"
+  | "receipt"
+  | "session"
+
+type Entity =
+  | AuditRecord
+  | Booking
+  | Dispute
+  | Lot
+  | ParkingSession
+  | Payment
+  | Receipt
+
+export class MemoryParkingStore implements ParkingStore {
+  private readonly auditRecords = new Map<string, AuditRecord>()
+  private readonly bookingRecords = new Map<string, Booking>()
+  private readonly disputeRecords = new Map<string, Dispute>()
+  private readonly lotRecords = new Map<string, Lot>()
+  private readonly paymentRecords = new Map<string, Payment>()
+  private readonly receiptRecords = new Map<string, Receipt>()
+  private readonly sessionRecords = new Map<string, ParkingSession>()
+  private readonly counters = new Map<string, number>()
+
+  audit(id: string): AuditRecord {
+    return this.must(this.auditRecords, id, "audit")
+  }
+
+  audits(): AuditRecord[] {
+    return [...this.auditRecords.values()]
+  }
+
+  booking(id: string): Booking {
+    return this.must(this.bookingRecords, id, "booking")
+  }
+
+  bookings(): Booking[] {
+    return [...this.bookingRecords.values()]
+  }
+
+  dispute(id: string): Dispute {
+    return this.must(this.disputeRecords, id, "dispute")
+  }
+
+  disputes(): Dispute[] {
+    return [...this.disputeRecords.values()]
+  }
+
+  lot(id: string): Lot {
+    return this.must(this.lotRecords, id, "lot")
+  }
+
+  lots(): Lot[] {
+    return [...this.lotRecords.values()]
+  }
+
+  nextId(prefix: string): string {
+    const next = (this.counters.get(prefix) ?? 0) + 1
+    this.counters.set(prefix, next)
+    return `${prefix}-${next.toString().padStart(4, "0")}`
+  }
+
+  payment(id: string): Payment {
+    return this.must(this.paymentRecords, id, "payment")
+  }
+
+  payments(): Payment[] {
+    return [...this.paymentRecords.values()]
+  }
+
+  receipt(id: string): Receipt {
+    return this.must(this.receiptRecords, id, "receipt")
+  }
+
+  receipts(): Receipt[] {
+    return [...this.receiptRecords.values()]
+  }
+
+  saveAudit(record: AuditRecord): AuditRecord {
+    this.auditRecords.set(record.id, record)
+    return record
+  }
+
+  saveBooking(booking: Booking): Booking {
+    this.bookingRecords.set(booking.id, booking)
+    return booking
+  }
+
+  saveDispute(dispute: Dispute): Dispute {
+    this.disputeRecords.set(dispute.id, dispute)
+    return dispute
+  }
+
+  saveLot(lot: Lot): Lot {
+    this.lotRecords.set(lot.id, lot)
+    return lot
+  }
+
+  savePayment(payment: Payment): Payment {
+    this.paymentRecords.set(payment.id, payment)
+    return payment
+  }
+
+  saveReceipt(receipt: Receipt): Receipt {
+    this.receiptRecords.set(receipt.id, receipt)
+    return receipt
+  }
+
+  saveSession(session: ParkingSession): ParkingSession {
+    this.sessionRecords.set(session.id, session)
+    return session
+  }
+
+  session(id: string): ParkingSession {
+    return this.must(this.sessionRecords, id, "session")
+  }
+
+  sessions(): ParkingSession[] {
+    return [...this.sessionRecords.values()]
+  }
+
+  snapshot(): ParkingSnapshot {
+    return {
+      audits: this.audits(),
+      bookings: this.bookings(),
+      disputes: this.disputes(),
+      lots: this.lots(),
+      payments: this.payments(),
+      receipts: this.receipts(),
+      sessions: this.sessions(),
+    }
+  }
+
+  private must<T extends Entity>(records: Map<string, T>, id: string, kind: Kind): T {
+    const record = records.get(id)
+    if (record === undefined) throw new Error(`unknown ${kind}: ${id}`)
+    return record
+  }
+}
+
+export function createMemoryStore(): ParkingStore {
+  return new MemoryParkingStore()
+}

--- a/examples/parking-lot-shared/tests/workflows.test.ts
+++ b/examples/parking-lot-shared/tests/workflows.test.ts
@@ -1,0 +1,237 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { createScope, preset } from "@pumped-fn/lite"
+import { describe, expect, test } from "vitest"
+import {
+  acceptedWorkflows,
+  actor,
+  bookSpace,
+  cancelBooking,
+  checkInBooking,
+  checkInVehicle,
+  configureLot,
+  createMemoryStore,
+  listReceipts,
+  now,
+  openDispute,
+  pairPayment,
+  prepareExit,
+  readReport,
+  recordPaymentFailure,
+  refundPayment,
+  resolveDispute,
+  store,
+} from "../src"
+import { createSqliteStore } from "../src/sqlite"
+
+describe("parking lot workflows", () => {
+  test("accepts a real multi-role workflow matrix through the scope seam", async () => {
+    const backing = createMemoryStore()
+    const managerScope = createScope({
+      presets: [preset(store, backing)],
+      tags: [actor({ id: "manager-1", role: "manager" }), now(() => "2026-07-01T08:00:00.000Z")],
+    })
+    const manager = managerScope.createContext()
+
+    const lot = await manager.exec({
+      flow: configureLot,
+      input: {
+        bookingLeadMinutes: 120,
+        capacity: 2,
+        currency: "USD",
+        graceMinutes: 10,
+        name: "Central Garage",
+        rateCentsPerHour: 500,
+        refundWindowMinutes: 1440,
+      },
+    })
+
+    const userScope = createScope({
+      presets: [preset(store, backing)],
+      tags: [actor({ id: "user-1", role: "user" }), now(() => "2026-07-01T08:05:00.000Z")],
+    })
+    const user = userScope.createContext()
+
+    const cancelled = await user.exec({
+      flow: bookSpace,
+      input: {
+        endAt: "2026-07-02T10:00:00.000Z",
+        lotId: lot.id,
+        plate: "abc-111",
+        startAt: "2026-07-02T08:00:00.000Z",
+      },
+    })
+    expect(await user.exec({ flow: cancelBooking, input: { bookingId: cancelled.id } })).toMatchObject({
+      status: "cancelled",
+    })
+
+    const booking = await user.exec({
+      flow: bookSpace,
+      input: {
+        endAt: "2026-07-02T12:00:00.000Z",
+        lotId: lot.id,
+        plate: "abc-222",
+        startAt: "2026-07-02T08:00:00.000Z",
+      },
+    })
+
+    const operatorScope = createScope({
+      presets: [preset(store, backing)],
+      tags: [actor({ id: "operator-1", role: "operator" }), now(() => "2026-07-02T08:10:00.000Z")],
+    })
+    const operator = operatorScope.createContext()
+    const bookedSession = await operator.exec({ flow: checkInBooking, input: { bookingId: booking.id } })
+
+    const exitScope = createScope({
+      presets: [preset(store, backing)],
+      tags: [actor({ id: "operator-1", role: "operator" }), now(() => "2026-07-02T10:20:00.000Z")],
+    })
+    const exit = exitScope.createContext()
+    const bookedExit = await exit.exec({ flow: prepareExit, input: { sessionId: bookedSession.id } })
+    const bookedPair = await exit.exec({
+      flow: pairPayment,
+      input: {
+        externalRef: "pay-booked",
+        method: "card",
+        paymentId: bookedExit.payment.id,
+      },
+    })
+
+    expect(bookedPair.receipt).toMatchObject({ amountCents: 1000, type: "charge" })
+    expect(await user.exec({ flow: listReceipts, input: {} })).toHaveLength(1)
+
+    const driveUp = await operator.exec({
+      flow: checkInVehicle,
+      input: {
+        lotId: lot.id,
+        plate: "xyz-333",
+        userId: "user-1",
+      },
+    })
+    const failedExit = await exit.exec({ flow: prepareExit, input: { sessionId: driveUp.id } })
+    expect(await exit.exec({
+      flow: recordPaymentFailure,
+      input: {
+        paymentId: failedExit.payment.id,
+        reason: "terminal timeout",
+      },
+    })).toMatchObject({ status: "failed" })
+
+    const disputeSession = await operator.exec({
+      flow: checkInVehicle,
+      input: {
+        lotId: lot.id,
+        plate: "xyz-444",
+        userId: "user-1",
+      },
+    })
+    const disputeExit = await exit.exec({ flow: prepareExit, input: { sessionId: disputeSession.id } })
+    const disputePair = await exit.exec({
+      flow: pairPayment,
+      input: {
+        externalRef: "pay-dispute",
+        method: "wallet",
+        paymentId: disputeExit.payment.id,
+      },
+    })
+    const opened = await user.exec({
+      flow: openDispute,
+      input: {
+        paymentId: disputePair.payment.id,
+        reason: "gate stayed closed after payment",
+      },
+    })
+    const resolved = await manager.exec({
+      flow: resolveDispute,
+      input: {
+        decision: "accepted",
+        disputeId: opened.dispute.id,
+      },
+    })
+    const refunded = await manager.exec({
+      flow: refundPayment,
+      input: {
+        paymentId: bookedPair.payment.id,
+        reason: "operator courtesy",
+      },
+    })
+    const report = await manager.exec({ flow: readReport, input: { lotId: lot.id } })
+
+    expect(acceptedWorkflows).toHaveLength(12)
+    expect(acceptedWorkflows.length).toBeGreaterThanOrEqual(10)
+    expect(resolved).toMatchObject({ dispute: { status: "accepted" }, payment: { status: "refunded" } })
+    expect(refunded.receipt).toMatchObject({ amountCents: -1000, type: "refund" })
+    expect(report.totals).toMatchObject({
+      failedPayments: 1,
+      openDisputes: 0,
+      parked: 0,
+      revenueCents: 2000,
+    })
+
+    await manager.close({ ok: true })
+    await user.close({ ok: true })
+    await operator.close({ ok: true })
+    await exit.close({ ok: true })
+    await managerScope.dispose()
+    await userScope.dispose()
+    await operatorScope.dispose()
+    await exitScope.dispose()
+  })
+
+  test("enforces role boundaries through tags", async () => {
+    const scope = createScope({
+      tags: [actor({ id: "user-1", role: "user" }), now(() => "2026-07-01T08:00:00.000Z")],
+    })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({
+      flow: configureLot,
+      input: {
+        bookingLeadMinutes: 60,
+        capacity: 1,
+        currency: "USD",
+        graceMinutes: 0,
+        name: "Side Lot",
+        rateCentsPerHour: 300,
+        refundWindowMinutes: 60,
+      },
+    })).rejects.toThrow("role user cannot configure lot")
+
+    await ctx.close({ ok: true })
+    await scope.dispose()
+  })
+
+  test("keeps SQLite behind the same store atom seam", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "parking-lot-"))
+    const path = join(dir, "parking.sqlite")
+    const sqlite = createSqliteStore(path)
+    const scope = createScope({
+      presets: [preset(store, sqlite)],
+      tags: [actor({ id: "manager-1", role: "manager" }), now(() => "2026-07-01T08:00:00.000Z")],
+    })
+    const ctx = scope.createContext()
+
+    const lot = await ctx.exec({
+      flow: configureLot,
+      input: {
+        bookingLeadMinutes: 60,
+        capacity: 4,
+        currency: "USD",
+        graceMinutes: 5,
+        name: "SQLite Garage",
+        rateCentsPerHour: 700,
+        refundWindowMinutes: 720,
+      },
+    })
+
+    await ctx.close({ ok: true })
+    await scope.dispose()
+    sqlite.close()
+
+    const reopened = createSqliteStore(path)
+    expect(reopened.lot(lot.id)).toMatchObject({ name: "SQLite Garage", rateCentsPerHour: 700 })
+    reopened.close()
+    rmSync(dir, { force: true, recursive: true })
+  })
+})

--- a/examples/parking-lot-shared/tsconfig.json
+++ b/examples/parking-lot-shared/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/parking-lot-shared/vitest.config.ts
+++ b/examples/parking-lot-shared/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+})

--- a/examples/parking-lot-spa/index.html
+++ b/examples/parking-lot-spa/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Parking Lot</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/parking-lot-spa/package.json
+++ b/examples/parking-lot-spa/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@pumped-fn/parking-lot-spa",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite --host 0.0.0.0",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-react": "workspace:*",
+    "@pumped-fn/parking-lot-shared": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "catalog:",
+    "@testing-library/react": "catalog:",
+    "@types/node": "catalog:",
+    "@types/react": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "@vitest/browser-playwright": "catalog:",
+    "playwright": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/parking-lot-spa/src/app.tsx
+++ b/examples/parking-lot-spa/src/app.tsx
@@ -1,0 +1,154 @@
+import { createScope } from "@pumped-fn/lite"
+import { ExecutionContextProvider, ScopeProvider, useAtom, useFlow } from "@pumped-fn/lite-react"
+import {
+  actor,
+  now,
+  type Role,
+} from "@pumped-fn/parking-lot-shared"
+import { useMemo, useRef } from "react"
+import * as app from "./state"
+
+const roleLabels: Role[] = ["manager", "operator", "user"]
+
+export function ParkingLotRoot() {
+  const scope = useMemo(() => createScope(), [])
+  return (
+    <ScopeProvider scope={scope}>
+      <ParkingLotApp />
+    </ScopeProvider>
+  )
+}
+
+export function ParkingLotApp() {
+  const state = useAtom(app.ui, { suspense: false, resolve: true })
+  const value = state.data ?? app.initialUi
+  const clock = useRef("2026-07-01T08:00:00.000Z")
+  const tags = useMemo(() => [
+    actor({ id: `${value.role}-spa`, role: value.role }),
+    now(() => clock.current),
+  ], [value.role])
+
+  return (
+    <ExecutionContextProvider tags={tags}>
+      <ParkingLotScreen clock={clock} />
+    </ExecutionContextProvider>
+  )
+}
+
+interface ScreenProps {
+  clock: { current: string }
+}
+
+function ParkingLotScreen({ clock }: ScreenProps) {
+  const state = useAtom(app.ui, { suspense: false, resolve: true })
+  const value = state.data ?? app.initialUi
+  const selectRole = useFlow(app.selectRole)
+  const configure = useFlow(app.configure)
+  const book = useFlow(app.book)
+  const checkIn = useFlow(app.checkIn)
+  const exit = useFlow(app.exit)
+  const pay = useFlow(app.pay)
+  const read = useFlow(app.read)
+
+  return (
+    <main className="shell">
+      <header className="topbar">
+        <div>
+          <h1>Parking Lot</h1>
+          <p>{value.message}</p>
+        </div>
+        <nav aria-label="Role" className="tabs">
+          {roleLabels.map((item) => (
+            <button
+              aria-pressed={value.role === item}
+              className={value.role === item ? "tab active" : "tab"}
+              key={item}
+              onClick={() => selectRole.execute(item)}
+              type="button"
+            >
+              {item}
+            </button>
+          ))}
+        </nav>
+      </header>
+      <section className="grid">
+        <div className="panel">
+          <h2>Manager</h2>
+          <button
+            onClick={() => {
+              clock.current = "2026-07-01T08:00:00.000Z"
+              configure.execute()
+            }}
+            type="button"
+          >
+            Configure
+          </button>
+          <button
+            onClick={() => read.execute()}
+            type="button"
+          >
+            Report
+          </button>
+        </div>
+        <div className="panel">
+          <h2>User</h2>
+          <button
+            onClick={() => book.execute()}
+            type="button"
+          >
+            Book
+          </button>
+        </div>
+        <div className="panel">
+          <h2>Operator</h2>
+          <button
+            onClick={() => {
+              clock.current = "2026-07-01T09:00:00.000Z"
+              checkIn.execute()
+            }}
+            type="button"
+          >
+            Check In
+          </button>
+          <button
+            onClick={() => {
+              clock.current = "2026-07-01T11:20:00.000Z"
+              exit.execute()
+            }}
+            type="button"
+          >
+            Exit
+          </button>
+          <button
+            onClick={() => pay.execute()}
+            type="button"
+          >
+            Pair
+          </button>
+        </div>
+      </section>
+      <section className="metrics" aria-label="Metrics">
+        <div>
+          <span>Lot</span>
+          <strong>{value.lotId || "-"}</strong>
+        </div>
+        <div>
+          <span>Session</span>
+          <strong>{value.sessionId || "-"}</strong>
+        </div>
+        <div>
+          <span>Payment</span>
+          <strong>{value.paymentId || "-"}</strong>
+        </div>
+        <div>
+          <span>Revenue</span>
+          <strong>{money(value.revenueCents)}</strong>
+        </div>
+      </section>
+    </main>
+  )
+}
+
+function money(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`
+}

--- a/examples/parking-lot-spa/src/main.tsx
+++ b/examples/parking-lot-spa/src/main.tsx
@@ -1,0 +1,8 @@
+import { createRoot } from "react-dom/client"
+import { ParkingLotRoot } from "./app"
+import "./styles.css"
+
+const root = document.getElementById("root")
+if (root === null) throw new Error("root container missing")
+
+createRoot(root).render(<ParkingLotRoot />)

--- a/examples/parking-lot-spa/src/react-dom-client.d.ts
+++ b/examples/parking-lot-spa/src/react-dom-client.d.ts
@@ -1,0 +1,10 @@
+declare module "react-dom/client" {
+  import type { ReactNode } from "react"
+
+  export interface Root {
+    render(children: ReactNode): void
+    unmount(): void
+  }
+
+  export function createRoot(container: Element | DocumentFragment): Root
+}

--- a/examples/parking-lot-spa/src/state.ts
+++ b/examples/parking-lot-spa/src/state.ts
@@ -37,10 +37,12 @@ export const selectRole = flow({
 
 export const configure = flow({
   name: "parking-spa.configure",
-  deps: { ui: controller(ui, { resolve: true }) },
-  factory: async (ctx, deps): Promise<UiState> => {
-    const lot = await ctx.exec({
-      flow: parking.configureLot,
+  deps: {
+    configureLot: controller(parking.configureLot),
+    ui: controller(ui, { resolve: true }),
+  },
+  factory: async (_ctx, deps): Promise<UiState> => {
+    const lot = await deps.configureLot.exec({
       input: {
         bookingLeadMinutes: 120,
         capacity: 36,
@@ -59,11 +61,13 @@ export const configure = flow({
 
 export const book = flow({
   name: "parking-spa.book",
-  deps: { ui: controller(ui, { resolve: true }) },
-  factory: async (ctx, deps): Promise<UiState> => {
+  deps: {
+    bookSpace: controller(parking.bookSpace),
+    ui: controller(ui, { resolve: true }),
+  },
+  factory: async (_ctx, deps): Promise<UiState> => {
     const state = deps.ui.get()
-    const booking = await ctx.exec({
-      flow: parking.bookSpace,
+    const booking = await deps.bookSpace.exec({
       input: {
         endAt: "2026-07-02T12:00:00.000Z",
         lotId: state.lotId,
@@ -79,11 +83,13 @@ export const book = flow({
 
 export const checkIn = flow({
   name: "parking-spa.check-in",
-  deps: { ui: controller(ui, { resolve: true }) },
-  factory: async (ctx, deps): Promise<UiState> => {
+  deps: {
+    checkInVehicle: controller(parking.checkInVehicle),
+    ui: controller(ui, { resolve: true }),
+  },
+  factory: async (_ctx, deps): Promise<UiState> => {
     const state = deps.ui.get()
-    const session = await ctx.exec({
-      flow: parking.checkInVehicle,
+    const session = await deps.checkInVehicle.exec({
       input: { lotId: state.lotId, plate: "SPA-202", userId: "user-spa" },
     })
     const next = { ...state, message: `Parked ${session.plate}`, sessionId: session.id }
@@ -94,11 +100,13 @@ export const checkIn = flow({
 
 export const exit = flow({
   name: "parking-spa.exit",
-  deps: { ui: controller(ui, { resolve: true }) },
-  factory: async (ctx, deps): Promise<UiState> => {
+  deps: {
+    prepareExit: controller(parking.prepareExit),
+    ui: controller(ui, { resolve: true }),
+  },
+  factory: async (_ctx, deps): Promise<UiState> => {
     const state = deps.ui.get()
-    const prepared = await ctx.exec({
-      flow: parking.prepareExit,
+    const prepared = await deps.prepareExit.exec({
       input: { sessionId: state.sessionId },
     })
     const next = {
@@ -113,11 +121,13 @@ export const exit = flow({
 
 export const pay = flow({
   name: "parking-spa.pay",
-  deps: { ui: controller(ui, { resolve: true }) },
-  factory: async (ctx, deps): Promise<UiState> => {
+  deps: {
+    pairPayment: controller(parking.pairPayment),
+    ui: controller(ui, { resolve: true }),
+  },
+  factory: async (_ctx, deps): Promise<UiState> => {
     const state = deps.ui.get()
-    const paid = await ctx.exec({
-      flow: parking.pairPayment,
+    const paid = await deps.pairPayment.exec({
       input: { externalRef: "spa-payment", method: "card", paymentId: state.paymentId },
     })
     const next = { ...state, message: `Receipt ${paid.receipt.id}` }
@@ -128,10 +138,13 @@ export const pay = flow({
 
 export const read = flow({
   name: "parking-spa.read",
-  deps: { ui: controller(ui, { resolve: true }) },
-  factory: async (ctx, deps): Promise<UiState> => {
+  deps: {
+    readReport: controller(parking.readReport),
+    ui: controller(ui, { resolve: true }),
+  },
+  factory: async (_ctx, deps): Promise<UiState> => {
     const state = deps.ui.get()
-    const report = await ctx.exec({ flow: parking.readReport, input: { lotId: state.lotId } })
+    const report = await deps.readReport.exec({ input: { lotId: state.lotId } })
     const next = { ...state, message: "Report updated", revenueCents: report.totals.revenueCents }
     deps.ui.set(next)
     return next

--- a/examples/parking-lot-spa/src/state.ts
+++ b/examples/parking-lot-spa/src/state.ts
@@ -1,0 +1,143 @@
+import { atom, controller, flow, typed } from "@pumped-fn/lite"
+import * as parking from "@pumped-fn/parking-lot-shared"
+import type { Role } from "@pumped-fn/parking-lot-shared"
+
+export interface UiState {
+  lotId: string
+  message: string
+  paymentId: string
+  revenueCents: number
+  role: Role
+  sessionId: string
+}
+
+export const initialUi: UiState = {
+  lotId: "",
+  message: "Ready",
+  paymentId: "",
+  revenueCents: 0,
+  role: "manager",
+  sessionId: "",
+}
+
+export const ui = atom({
+  factory: () => initialUi,
+})
+
+export const selectRole = flow({
+  name: "parking-spa.select-role",
+  parse: typed<Role>(),
+  deps: { ui: controller(ui, { resolve: true }) },
+  factory: (ctx, deps): UiState => {
+    const next = { ...deps.ui.get(), role: ctx.input }
+    deps.ui.set(next)
+    return next
+  },
+})
+
+export const configure = flow({
+  name: "parking-spa.configure",
+  deps: { ui: controller(ui, { resolve: true }) },
+  factory: async (ctx, deps): Promise<UiState> => {
+    const lot = await ctx.exec({
+      flow: parking.configureLot,
+      input: {
+        bookingLeadMinutes: 120,
+        capacity: 36,
+        currency: "USD",
+        graceMinutes: 10,
+        name: "North Deck",
+        rateCentsPerHour: 500,
+        refundWindowMinutes: 1440,
+      },
+    })
+    const next = { ...deps.ui.get(), lotId: lot.id, message: `Configured ${lot.name}` }
+    deps.ui.set(next)
+    return next
+  },
+})
+
+export const book = flow({
+  name: "parking-spa.book",
+  deps: { ui: controller(ui, { resolve: true }) },
+  factory: async (ctx, deps): Promise<UiState> => {
+    const state = deps.ui.get()
+    const booking = await ctx.exec({
+      flow: parking.bookSpace,
+      input: {
+        endAt: "2026-07-02T12:00:00.000Z",
+        lotId: state.lotId,
+        plate: "SPA-101",
+        startAt: "2026-07-02T09:00:00.000Z",
+      },
+    })
+    const next = { ...state, message: `Booked ${booking.plate}` }
+    deps.ui.set(next)
+    return next
+  },
+})
+
+export const checkIn = flow({
+  name: "parking-spa.check-in",
+  deps: { ui: controller(ui, { resolve: true }) },
+  factory: async (ctx, deps): Promise<UiState> => {
+    const state = deps.ui.get()
+    const session = await ctx.exec({
+      flow: parking.checkInVehicle,
+      input: { lotId: state.lotId, plate: "SPA-202", userId: "user-spa" },
+    })
+    const next = { ...state, message: `Parked ${session.plate}`, sessionId: session.id }
+    deps.ui.set(next)
+    return next
+  },
+})
+
+export const exit = flow({
+  name: "parking-spa.exit",
+  deps: { ui: controller(ui, { resolve: true }) },
+  factory: async (ctx, deps): Promise<UiState> => {
+    const state = deps.ui.get()
+    const prepared = await ctx.exec({
+      flow: parking.prepareExit,
+      input: { sessionId: state.sessionId },
+    })
+    const next = {
+      ...state,
+      message: `Due ${money(prepared.payment.amountCents)}`,
+      paymentId: prepared.payment.id,
+    }
+    deps.ui.set(next)
+    return next
+  },
+})
+
+export const pay = flow({
+  name: "parking-spa.pay",
+  deps: { ui: controller(ui, { resolve: true }) },
+  factory: async (ctx, deps): Promise<UiState> => {
+    const state = deps.ui.get()
+    const paid = await ctx.exec({
+      flow: parking.pairPayment,
+      input: { externalRef: "spa-payment", method: "card", paymentId: state.paymentId },
+    })
+    const next = { ...state, message: `Receipt ${paid.receipt.id}` }
+    deps.ui.set(next)
+    return next
+  },
+})
+
+export const read = flow({
+  name: "parking-spa.read",
+  deps: { ui: controller(ui, { resolve: true }) },
+  factory: async (ctx, deps): Promise<UiState> => {
+    const state = deps.ui.get()
+    const report = await ctx.exec({ flow: parking.readReport, input: { lotId: state.lotId } })
+    const next = { ...state, message: "Report updated", revenueCents: report.totals.revenueCents }
+    deps.ui.set(next)
+    return next
+  },
+})
+
+function money(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`
+}

--- a/examples/parking-lot-spa/src/styles.css
+++ b/examples/parking-lot-spa/src/styles.css
@@ -1,0 +1,125 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f6f7f9;
+  color: #171717;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+button {
+  min-height: 2.25rem;
+  border: 1px solid #cbd5e1;
+  border-radius: 6px;
+  background: #ffffff;
+  color: #171717;
+  cursor: pointer;
+  font: inherit;
+  padding: 0.45rem 0.7rem;
+}
+
+button:hover {
+  background: #eef6ff;
+  border-color: #7aa7d9;
+}
+
+.shell {
+  max-width: 1060px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.topbar {
+  align-items: center;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+
+.topbar h1 {
+  font-size: 1.55rem;
+  line-height: 1.2;
+  margin: 0;
+}
+
+.topbar p {
+  color: #475569;
+  margin: 4px 0 0;
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+}
+
+.tab.active {
+  background: #12324d;
+  border-color: #12324d;
+  color: #ffffff;
+}
+
+.grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.panel {
+  background: #ffffff;
+  border: 1px solid #d7dee8;
+  border-radius: 8px;
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+}
+
+.panel h2 {
+  font-size: 1rem;
+  margin: 0;
+}
+
+.metrics {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin-top: 12px;
+}
+
+.metrics div {
+  background: #ffffff;
+  border: 1px solid #d7dee8;
+  border-radius: 8px;
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+  padding: 14px;
+}
+
+.metrics span {
+  color: #64748b;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+}
+
+.metrics strong {
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 760px) {
+  .grid,
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .tabs {
+    flex-wrap: wrap;
+  }
+}

--- a/examples/parking-lot-spa/src/styles.d.ts
+++ b/examples/parking-lot-spa/src/styles.d.ts
@@ -1,0 +1,4 @@
+declare module "*.css" {
+  const href: string
+  export default href
+}

--- a/examples/parking-lot-spa/tests/app.browser.test.tsx
+++ b/examples/parking-lot-spa/tests/app.browser.test.tsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, test } from "vitest"
+import { ParkingLotRoot } from "../src/app"
+
+describe("parking lot SPA", () => {
+  test("dispatches real shared workflows from the browser UI", async () => {
+    render(<ParkingLotRoot />)
+
+    fireEvent.click(await screen.findByRole("button", { name: "Configure" }))
+    await waitFor(() => expect(screen.getByText("Configured North Deck")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "user" }))
+    fireEvent.click(screen.getByRole("button", { name: "Book" }))
+    await waitFor(() => expect(screen.getByText("Booked SPA-101")).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "operator" }))
+    fireEvent.click(screen.getByRole("button", { name: "Check In" }))
+    await waitFor(() => expect(screen.getByText("Parked SPA-202")).toBeInTheDocument())
+    fireEvent.click(screen.getByRole("button", { name: "Exit" }))
+    await waitFor(() => expect(screen.getByText("Due $15.00")).toBeInTheDocument())
+    fireEvent.click(screen.getByRole("button", { name: "Pair" }))
+    await waitFor(() => expect(screen.getByText(/^Receipt/)).toBeInTheDocument())
+
+    fireEvent.click(screen.getByRole("button", { name: "manager" }))
+    fireEvent.click(screen.getByRole("button", { name: "Report" }))
+    await waitFor(() => expect(screen.getByText("Report updated")).toBeInTheDocument())
+    expect(screen.getByText("$15.00")).toBeInTheDocument()
+  })
+})

--- a/examples/parking-lot-spa/tests/setup.browser.ts
+++ b/examples/parking-lot-spa/tests/setup.browser.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest"

--- a/examples/parking-lot-spa/tsconfig.json
+++ b/examples/parking-lot-spa/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/parking-lot-spa/vitest.config.ts
+++ b/examples/parking-lot-spa/vitest.config.ts
@@ -1,0 +1,33 @@
+import { playwright } from "@vitest/browser-playwright"
+import { configDefaults, defineConfig } from "vitest/config"
+
+export default defineConfig({
+  optimizeDeps: {
+    include: [
+      "@testing-library/jest-dom/vitest",
+      "@testing-library/react",
+      "react",
+      "react-dom/client",
+      "react/jsx-dev-runtime",
+      "react/jsx-runtime",
+    ],
+  },
+  test: {
+    projects: [
+      {
+        test: {
+          name: "browser",
+          include: ["**/*.browser.test.tsx"],
+          exclude: [...configDefaults.exclude],
+          setupFiles: ["./tests/setup.browser.ts"],
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright(),
+            instances: [{ browser: "chromium" }],
+          },
+        },
+      },
+    ],
+  },
+})

--- a/examples/parking-lot-tanstack-start/package.json
+++ b/examples/parking-lot-tanstack-start/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@pumped-fn/parking-lot-tanstack-start",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "@pumped-fn/lite": "workspace:*",
+    "@pumped-fn/lite-tanstack-start": "workspace:*",
+    "@pumped-fn/parking-lot-shared": "workspace:*",
+    "@tanstack/react-start": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typescript/native-preview": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/examples/parking-lot-tanstack-start/src/handlers.ts
+++ b/examples/parking-lot-tanstack-start/src/handlers.ts
@@ -1,0 +1,18 @@
+import { tanstackStart } from "@pumped-fn/lite-tanstack-start"
+import {
+  bookSpace,
+  checkInVehicle,
+  configureLot,
+  pairPayment,
+  prepareExit,
+  readReport,
+} from "@pumped-fn/parking-lot-shared"
+
+export const lite = tanstackStart.adapter()
+
+export const configure = lite.handler(configureLot)
+export const book = lite.handler(bookSpace)
+export const checkIn = lite.handler(checkInVehicle)
+export const exit = lite.handler(prepareExit)
+export const pay = lite.handler(pairPayment)
+export const report = lite.handler(readReport)

--- a/examples/parking-lot-tanstack-start/src/index.ts
+++ b/examples/parking-lot-tanstack-start/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./handlers"

--- a/examples/parking-lot-tanstack-start/tests/handlers.test.ts
+++ b/examples/parking-lot-tanstack-start/tests/handlers.test.ts
@@ -1,0 +1,74 @@
+import { createScope, preset } from "@pumped-fn/lite"
+import { actor, createMemoryStore, now, store } from "@pumped-fn/parking-lot-shared"
+import { describe, expect, test } from "vitest"
+import { book, checkIn, configure, exit, pay, report } from "../src"
+
+describe("parking lot TanStack Start handlers", () => {
+  test("server-function handlers exec shared flows through Lite context", async () => {
+    const backing = createMemoryStore()
+    const scope = createScope({
+      presets: [preset(store, backing)],
+    })
+    const manager = scope.createContext({
+      tags: [actor({ id: "manager-start", role: "manager" }), now(() => "2026-07-01T08:00:00.000Z")],
+    })
+    const user = scope.createContext({
+      tags: [actor({ id: "user-start", role: "user" }), now(() => "2026-07-01T08:10:00.000Z")],
+    })
+    const operator = scope.createContext({
+      tags: [actor({ id: "operator-start", role: "operator" }), now(() => "2026-07-01T10:00:00.000Z")],
+    })
+    const exitOperator = scope.createContext({
+      tags: [actor({ id: "operator-start", role: "operator" }), now(() => "2026-07-01T10:50:00.000Z")],
+    })
+
+    const lot = await configure({
+      context: { lite: manager },
+      data: {
+        bookingLeadMinutes: 60,
+        capacity: 2,
+        currency: "USD",
+        graceMinutes: 0,
+        name: "Start Garage",
+        rateCentsPerHour: 900,
+        refundWindowMinutes: 1440,
+      },
+    })
+    const booking = await book({
+      context: { lite: user },
+      data: {
+        endAt: "2026-07-01T12:00:00.000Z",
+        lotId: lot.id,
+        plate: "start-111",
+        startAt: "2026-07-01T10:00:00.000Z",
+      },
+    })
+    const session = await checkIn({
+      context: { lite: operator },
+      data: {
+        lotId: lot.id,
+        plate: "start-222",
+        userId: booking.userId,
+      },
+    })
+    const prepared = await exit({ context: { lite: exitOperator }, data: { sessionId: session.id } })
+    const paired = await pay({
+      context: { lite: exitOperator },
+      data: {
+        externalRef: "start-payment",
+        method: "card",
+        paymentId: prepared.payment.id,
+      },
+    })
+    const current = await report({ context: { lite: manager }, data: {} })
+
+    expect(paired.receipt).toMatchObject({ amountCents: 900, type: "charge" })
+    expect(current.totals).toMatchObject({ revenueCents: 900 })
+
+    await manager.close({ ok: true })
+    await user.close({ ok: true })
+    await operator.close({ ok: true })
+    await exitOperator.close({ ok: true })
+    await scope.dispose()
+  })
+})

--- a/examples/parking-lot-tanstack-start/tsconfig.json
+++ b/examples/parking-lot-tanstack-start/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["node", "vitest"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["vitest.config.ts", "src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/parking-lot-tanstack-start/vitest.config.ts
+++ b/examples/parking-lot-tanstack-start/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+})

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "verify": "pnpm build && pnpm test && pnpm typecheck",
     "format": "echo 'Formatting disabled'",
     "format:check": "echo 'Format check disabled'",
-    "lint": "pnpm -F @pumped-fn/lite-lint build && node pkg/tool/lint/dist/cli.mjs pkg/core/lite/README.md pkg/core/lite/PATTERNS.md pkg/react/lite-react/README.md pkg/react/lite-react/PATTERNS.md examples/lite-practical examples/lite-react-practical examples/lite-bff-practical examples/lite-hono-todo-practical examples/lite-tanstack-start-todo-practical examples/lite-cli-practical",
+    "lint": "pnpm -F @pumped-fn/lite-lint build && node pkg/tool/lint/dist/cli.mjs pkg/core/lite/README.md pkg/core/lite/PATTERNS.md pkg/react/lite-react/README.md pkg/react/lite-react/PATTERNS.md examples/lite-practical examples/lite-react-practical examples/lite-bff-practical examples/lite-hono-todo-practical examples/lite-tanstack-start-todo-practical examples/lite-cli-practical examples/parking-lot-shared examples/parking-lot-cli examples/parking-lot-hono examples/parking-lot-tanstack-start examples/parking-lot-spa",
     "lint:check": "pnpm lint",
     "actionlint": "github-actionlint .github/workflows/*.yml",
     "act": "node scripts/act.mjs",

--- a/pkg/tool/lint/README.md
+++ b/pkg/tool/lint/README.md
@@ -26,6 +26,7 @@ pnpm lint
 | `pumped/no-jsdom-backend` | Browser-emulator test markers and DOM-suffixed observer tests; rendered observer tests use Vitest Browser Mode. |
 | `pumped/no-test-only-branches` | Product branches keyed on test mode; use presets instead. |
 | `pumped/no-definition-handle-suffix` | `fooAtom`, `runFlow`, `txResource`, `requestTag`; rely on inference. |
+| `pumped/no-direct-flow-composition` | Flows calling child flows with hidden `ctx.exec({ flow })` or raw same-file flow deps; use `controller(childFlow)` deps. |
 | `pumped/no-shared-scope-factory` | Helpers that return preconfigured `createScope(...)`; each use site should own tags, presets, and extensions. |
 | `pumped/no-scope-argument` | Exported product helpers accepting `scope`; composition roots and tests own scope. |
 | `pumped/no-render-outside-browser-test` | Testing Library `render` outside `*.browser.test.tsx`; DOM observer tests run in browser mode. |

--- a/pkg/tool/lint/src/index.ts
+++ b/pkg/tool/lint/src/index.ts
@@ -5,6 +5,7 @@ import ts from "typescript"
 export type RuleId =
   | "pumped/no-ambient-io-outside-boundary"
   | "pumped/no-definition-handle-suffix"
+  | "pumped/no-direct-flow-composition"
   | "pumped/no-internal-example-label"
   | "pumped/no-jsdom-backend"
   | "pumped/no-module-mocks"
@@ -36,7 +37,9 @@ export interface ScanOptions {
 
 type Imports = {
   createScope: Set<string>
+  controller: Set<string>
   creators: Set<string>
+  flow: Set<string>
   liteNamespaces: Set<string>
   liteReactNamespaces: Set<string>
   mockFns: Set<string>
@@ -199,7 +202,9 @@ function addTextDiagnostics(source: string, filePath: string, diagnostics: Diagn
 function collectImports(sourceFile: ts.SourceFile): Imports {
   const imports: Imports = {
     createScope: new Set(),
+    controller: new Set(),
     creators: new Set(),
+    flow: new Set(),
     liteNamespaces: new Set(),
     liteReactNamespaces: new Set(),
     mockFns: new Set(),
@@ -231,6 +236,12 @@ function collectImports(sourceFile: ts.SourceFile): Imports {
       const local = specifier.name.text
       if (moduleName === "@pumped-fn/lite" && imported === "createScope") {
         imports.createScope.add(local)
+      }
+      if (moduleName === "@pumped-fn/lite" && imported === "controller") {
+        imports.controller.add(local)
+      }
+      if (moduleName === "@pumped-fn/lite" && imported === "flow") {
+        imports.flow.add(local)
       }
       if ((moduleName === "@pumped-fn/lite" || moduleName === "@pumped-fn/lite-react") && creatorNames.has(imported)) {
         imports.creators.add(local)
@@ -277,6 +288,11 @@ function isCreatorCall(expression: ts.Expression, imports: Imports): boolean {
   if (!ts.isPropertyAccessExpression(expression) || !creatorNames.has(expression.name.text)) return false
   if (!ts.isIdentifier(expression.expression)) return false
   return imports.liteNamespaces.has(expression.expression.text) || imports.liteReactNamespaces.has(expression.expression.text)
+}
+
+function isFlowCall(expression: ts.Expression, imports: Imports): boolean {
+  if (ts.isIdentifier(expression)) return imports.flow.has(expression.text)
+  return isNamespaceCall(expression, imports.liteNamespaces, "flow")
 }
 
 function isCreateScopeCall(expression: ts.Expression, imports: Imports): boolean {
@@ -353,6 +369,54 @@ function isAmbientCall(expression: ts.Expression): boolean {
   return false
 }
 
+function propertyNameText(name: ts.PropertyName): string | null {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text
+  return null
+}
+
+function objectProperty(object: ts.ObjectLiteralExpression, name: string): ts.PropertyAssignment | null {
+  for (const property of object.properties) {
+    if (!ts.isPropertyAssignment(property)) continue
+    if (propertyNameText(property.name) === name) return property
+  }
+  return null
+}
+
+function containsFlowProperty(object: ts.ObjectLiteralExpression): boolean {
+  return object.properties.some((property) =>
+    ts.isPropertyAssignment(property) && propertyNameText(property.name) === "flow"
+  )
+}
+
+function flowCallObject(node: ts.CallExpression, imports: Imports): ts.ObjectLiteralExpression | null {
+  if (!isFlowCall(node.expression, imports)) return null
+  const config = node.arguments[0]
+  return config && ts.isObjectLiteralExpression(config) ? config : null
+}
+
+function enclosingFlowFactory(node: ts.Node, imports: Imports): ts.PropertyAssignment | null {
+  let current: ts.Node | undefined = node
+  while (current) {
+    if (
+      ts.isPropertyAssignment(current)
+      && propertyNameText(current.name) === "factory"
+      && (ts.isArrowFunction(current.initializer) || ts.isFunctionExpression(current.initializer))
+    ) {
+      const config = current.parent
+      const call = config.parent
+      if (
+        ts.isObjectLiteralExpression(config)
+        && ts.isCallExpression(call)
+        && flowCallObject(call, imports) === config
+      ) {
+        return current
+      }
+    }
+    current = current.parent
+  }
+  return null
+}
+
 function shouldScanAst(filePath: string): boolean {
   return isSourceFile(filePath)
 }
@@ -371,6 +435,7 @@ function addAstDiagnostics(source: string, filePath: string, diagnostics: Diagno
   const reactFeature = isReactFeaturePath(filePath)
   const allowScopeArgument = isTestPath(filePath) || isCompositionPath(filePath)
   const allowScopeFactory = isCompositionPath(filePath)
+  const localFlows = new Set<string>()
 
   function visit(node: ts.Node): void {
     if (ts.isCallExpression(node)) {
@@ -529,9 +594,35 @@ function addAstDiagnostics(source: string, filePath: string, diagnostics: Diagno
           "Raw ambient IO belongs in transport atoms or composition-root adapters.",
         )
       }
+
+      if (
+        enclosingFlowFactory(node, imports)
+        && ts.isPropertyAccessExpression(node.expression)
+        && node.expression.name.text === "exec"
+        && node.arguments[0]
+        && ts.isObjectLiteralExpression(node.arguments[0])
+        && containsFlowProperty(node.arguments[0])
+      ) {
+        pushNodeDiagnostic(
+          diagnostics,
+          sourceFile,
+          filePath,
+          "pumped/no-direct-flow-composition",
+          node.expression,
+          "Flows should compose child flows through deps: { child: controller(childFlow) } and child.exec(...).",
+        )
+      }
     }
 
     if (ts.isVariableDeclaration(node) && node.initializer) {
+      if (
+        ts.isIdentifier(node.name)
+        && ts.isCallExpression(node.initializer)
+        && isFlowCall(node.initializer.expression, imports)
+      ) {
+        localFlows.add(node.name.text)
+      }
+
       if (ts.isIdentifier(node.name)) {
         if (ts.isIdentifier(node.initializer) && imports.viObjects.has(node.initializer.text)) {
           imports.viObjects.add(node.name.text)
@@ -593,6 +684,33 @@ function addAstDiagnostics(source: string, filePath: string, diagnostics: Diagno
         node.name,
         "Definition handles should rely on inference instead of Atom/Flow/Resource/Tag suffixes.",
       )
+    }
+
+    if (ts.isCallExpression(node)) {
+      const config = flowCallObject(node, imports)
+      if (config) {
+        const deps = objectProperty(config, "deps")
+        if (deps && ts.isObjectLiteralExpression(deps.initializer)) {
+          for (const property of deps.initializer.properties) {
+            const initializer = ts.isShorthandPropertyAssignment(property)
+              ? property.name
+              : ts.isPropertyAssignment(property)
+                ? property.initializer
+                : null
+            if (!initializer) continue
+            if (ts.isIdentifier(initializer) && localFlows.has(initializer.text)) {
+              pushNodeDiagnostic(
+                diagnostics,
+                sourceFile,
+                filePath,
+                "pumped/no-direct-flow-composition",
+                initializer,
+                "Flow dependencies should be explicit controller(childFlow) deps, not raw flow handles.",
+              )
+            }
+          }
+        }
+      }
     }
 
     if (!allowScopeFactory) {

--- a/pkg/tool/lint/tests/scanner.test.ts
+++ b/pkg/tool/lint/tests/scanner.test.ts
@@ -68,6 +68,38 @@ describe("lite lint scanner", () => {
     ])
   })
 
+  it("finds direct flow composition inside flow factories", () => {
+    expect(ids(`
+      import { controller, flow, typed } from "@pumped-fn/lite"
+
+      const load = flow({
+        name: "load",
+        parse: typed<{ id: string }>(),
+        factory: (ctx) => ctx.input.id,
+      })
+
+      const hidden = flow({
+        name: "hidden",
+        factory: (ctx) => ctx.exec({ flow: load, input: { id: "hidden" } }),
+      })
+
+      const raw = flow({
+        name: "raw",
+        deps: { load },
+        factory: (_ctx, deps) => deps.load.exec({ input: { id: "raw" } }),
+      })
+
+      const explicit = flow({
+        name: "explicit",
+        deps: { load: controller(load) },
+        factory: (_ctx, deps) => deps.load.exec({ input: { id: "explicit" } }),
+      })
+    `)).toEqual([
+      "pumped/no-direct-flow-composition",
+      "pumped/no-direct-flow-composition",
+    ])
+  })
+
   it("finds aliased module mocks and rendered node observer tests", () => {
     expect(ids(`
       import { render } from "@testing-library/react"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,6 +451,167 @@ importers:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  examples/parking-lot-cli:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+      '@pumped-fn/parking-lot-shared':
+        specifier: workspace:*
+        version: link:../parking-lot-shared
+      cac:
+        specifier: 'catalog:'
+        version: 7.0.0
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  examples/parking-lot-hono:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+      '@pumped-fn/lite-hono':
+        specifier: workspace:*
+        version: link:../../pkg/framework/hono
+      '@pumped-fn/parking-lot-shared':
+        specifier: workspace:*
+        version: link:../parking-lot-shared
+      hono:
+        specifier: 'catalog:'
+        version: 4.12.27
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  examples/parking-lot-shared:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  examples/parking-lot-spa:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+      '@pumped-fn/lite-react':
+        specifier: workspace:*
+        version: link:../../pkg/react/lite-react
+      '@pumped-fn/parking-lot-shared':
+        specifier: workspace:*
+        version: link:../parking-lot-shared
+    devDependencies:
+      '@testing-library/jest-dom':
+        specifier: 'catalog:'
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.15
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      '@vitest/browser-playwright':
+        specifier: 'catalog:'
+        version: 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+      playwright:
+        specifier: 'catalog:'
+        version: 1.61.0
+      react:
+        specifier: 'catalog:'
+        version: 19.2.6
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.6(react@19.2.6)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  examples/parking-lot-tanstack-start:
+    dependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../pkg/core/lite
+      '@pumped-fn/lite-tanstack-start':
+        specifier: workspace:*
+        version: link:../../pkg/framework/tanstack-start
+      '@pumped-fn/parking-lot-shared':
+        specifier: workspace:*
+        version: link:../parking-lot-shared
+      '@tanstack/react-start':
+        specifier: 'catalog:'
+        version: 1.168.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
   pkg/agent/bash:
     dependencies:
       just-bash:


### PR DESCRIPTION
## Summary

Adds a real parking-lot management example suite that exercises shared pumped-fn business logic across CLI, Hono, TanStack Start, and Vite React entrypoints. The example is intentionally domain-sized so the same scope seam proves manager, operator, and user workflows across adapters.

## Changes

- Add `parking-lot-shared` with manager/operator/user workflows, booking, occupancy, payment pairing, receipts, refunds, disputes, reporting, memory persistence, and SQLite persistence behind a store port.
- Add CLI, Hono, TanStack Start, and SPA entrypoints that reuse the shared flows through Lite scopes, contexts, and framework adapters.
- Add example docs, lockfile importers, and root lint coverage for the new parking-lot packages.

## Testing

- `pnpm build`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm install --frozen-lockfile`
- `pnpm -F @pumped-fn/parking-lot-spa build`
- `git diff --check`