### PR TITLE
Add @pumped-fn/ui authoring package

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Current source packages live under one-word lanes in `pkg/`.
 | `pkg/core/lite` | `@pumped-fn/lite` | Core runtime: scopes, atoms, flows, resources, tags, presets, controllers, extensions |
 | `pkg/react/lite-react` | `@pumped-fn/lite-react` | React integration: providers, Suspense/ErrorBoundary-aware observers, scoped frontend state |
 | `pkg/react/json` | `@pumped-fn/lite-react-json-render` | json-render state and action adapters for Lite React scoped values and flows |
+| `pkg/ui/ui` | `@pumped-fn/ui` | Succinct TSX and graph-handle UI authoring |
 | `pkg/framework/pumped` | `@pumped-fn/pumped` | Convention-driven scope compiler: discovers flows on disk, assembles a scope, and drives it as a CLI or HTTP server |
 | `pkg/framework/hono` | `@pumped-fn/lite-hono` | Hono middleware and request helpers for per-request Lite execution contexts |
 | `pkg/framework/tanstack-start` | `@pumped-fn/lite-tanstack-start` | TanStack Start request/function middleware and server-function flow helpers |

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "verify": "pnpm build && pnpm test && pnpm typecheck",
     "format": "echo 'Formatting disabled'",
     "format:check": "echo 'Format check disabled'",
-    "lint": "pnpm -F @pumped-fn/lite-lint build && node pkg/tool/lint/dist/cli.mjs README.md examples/README.md scripts/README.md pkg/README.md pkg/sdk/README.md pkg/core/README.md pkg/ext/README.md pkg/framework/README.md pkg/react/README.md pkg/render/README.md pkg/tool/README.md pkg/core/lite/README.md pkg/core/lite/PATTERNS.md pkg/react/lite-react/README.md pkg/react/lite-react/PATTERNS.md examples/invoice-triage && node scripts/check-example-alignment.mjs",
+    "lint": "pnpm -F @pumped-fn/lite-lint build && node pkg/tool/lint/dist/cli.mjs README.md examples/README.md scripts/README.md pkg/README.md pkg/sdk/README.md pkg/core/README.md pkg/ext/README.md pkg/framework/README.md pkg/react/README.md pkg/render/README.md pkg/ui/README.md pkg/tool/README.md pkg/core/lite/README.md pkg/core/lite/PATTERNS.md pkg/react/lite-react/README.md pkg/react/lite-react/PATTERNS.md examples/invoice-triage && node scripts/check-example-alignment.mjs",
     "lint:check": "pnpm lint",
     "examples:check": "node scripts/check-example-alignment.mjs",
     "actionlint": "github-actionlint .github/workflows/*.yml",

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -15,6 +15,7 @@ names so new packages can be added without turning the workspace into a flat lis
 | `ext/` | Optional Lite extensions and development add-ons. |
 | `sdk/` | Generic runtime primitive SDK packages (workflow, sessions, materials, events, guards, sandboxes, agents/models) and provider integrations. |
 | `render/` | Portable render contracts and renderer bindings. |
+| `ui/` | Graph-composed UI authoring packages. |
 | `tool/` | Repository tooling, scanners, and migration CLIs. |
 
 Packages live at `pkg/<lane>/<package>/`. `pnpm-workspace.yaml` includes `pkg/*/*`, so every

--- a/pkg/ui/README.md
+++ b/pkg/ui/README.md
@@ -1,0 +1,24 @@
+# UI Lane
+
+## Purpose
+
+`pkg/ui/` holds graph-composed UI authoring packages.
+
+## Structure
+
+| Directory | Package | Role |
+| --- | --- | --- |
+| `ui/` | `@pumped-fn/ui` | Succinct TSX and graph-handle UI authoring. |
+
+## Naming
+
+Keep public package names short. Use `@pumped-fn/ui` for the primary UI authoring surface.
+
+## Boundaries
+
+UI authoring packages compose graph handles into portable plans. Runtime state, flows, resources, tags,
+environment capabilities, and target renderers still belong to Lite and implementation packs.
+
+Implementation packs should expose their own small binding vocabulary for target components, actions, state
+drivers, scope tags, and adapter capabilities. The spec vocabulary stays in `@pumped-fn/ui`; React, Vue,
+React Native, json-render, and test runtimes decide how to bind and execute it.

--- a/pkg/ui/ui/CHANGELOG.md
+++ b/pkg/ui/ui/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @pumped-fn/ui
+
+## 0.1.0
+
+### Minor Changes
+
+- Add the initial graph-handle UI authoring surface.

--- a/pkg/ui/ui/LICENSE
+++ b/pkg/ui/ui/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pumped-fn contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/ui/ui/README.md
+++ b/pkg/ui/ui/README.md
@@ -1,0 +1,145 @@
+# @pumped-fn/ui
+
+Target-neutral TSX authoring for pumped-fn.
+
+Use `@pumped-fn/ui` when UI code should be composed from graph-owned state and actions, then lowered by a
+host implementation. The spec is structured: `p.object(...)`, `p.array(...)`, and scalar `p.*` nodes carry
+runtime shape for adapters. The `~standard` marker keeps a Standard Schema-style type channel available for
+implementation packages without making validation or json-render the foundation.
+
+## Install
+
+```bash
+npm install @pumped-fn/ui
+```
+
+## Usage
+
+```json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "@pumped-fn/ui"
+  }
+}
+```
+
+```tsx
+import { p, part, ui } from "@pumped-fn/ui"
+
+const todo = p.object({
+  id: p.string,
+  title: p.string,
+  detail: p.nullableString,
+  done: p.boolean,
+  tone: p.string,
+})
+
+const u = ui({
+  state: p.object({
+    draft: p.string,
+    headline: p.string,
+    open: p.number,
+    done: p.number,
+    items: p.array(todo),
+  }),
+  action: {
+    draft: p.object({ text: p.string }),
+    add: p.object({ text: p.string }),
+    toggle: p.object({ id: p.string }),
+    clear: p.object({}),
+  },
+  view: {
+    Board: part({
+      props: {
+        title: p.string,
+        open: p.number,
+        done: p.number,
+      },
+      slots: ["default"],
+    }),
+    Composer: part({
+      props: {
+        value: p.string,
+        placeholder: p.string,
+      },
+      on: {
+        change: p.object({ value: p.string }),
+        submit: p.object({}),
+      },
+    }),
+    Lane: part({
+      props: {
+        title: p.string,
+        items: p.array(todo),
+      },
+      slots: ["rows"],
+    }),
+    Todo: part({
+      props: {
+        title: p.string,
+        detail: p.nullableString,
+        done: p.boolean,
+        tone: p.string,
+      },
+      on: {
+        toggle: p.object({}),
+      },
+    }),
+    Toolbar: part({
+      props: {
+        label: p.string,
+      },
+      on: {
+        clear: p.object({}),
+      },
+    }),
+  },
+})
+
+const plan = u.plan(
+  <u.view.Board title={u.state.headline} open={u.state.open} done={u.state.done}>
+    <u.view.Composer
+      value={u.state.draft}
+      placeholder="Add a crisp next action"
+      onChange={(event) => u.action.draft({ text: event.value })}
+      onSubmit={u.action.add({ text: u.state.draft })}
+    />
+    <u.view.Lane title="Today" items={u.state.items}>
+      {u.slot(
+        "rows",
+        u.each(u.state.items, (todo) => (
+          <u.view.Todo
+            title={todo.title}
+            detail={todo.detail}
+            done={todo.done}
+            tone={todo.tone}
+            onToggle={u.action.toggle({ id: todo.id })}
+          />
+        ))
+      )}
+    </u.view.Lane>
+    <u.view.Toolbar label="Clear completed" onClear={u.action.clear({})} />
+  </u.view.Board>
+)
+```
+
+The authored code uses graph handles (`u.state.draft`, `u.action.add`, repeat `todo.id`) instead of path
+strings. The output is a `Plan`, and `u.spec` keeps the state/action/view shape for target adapters such as
+json-render.
+
+## API
+
+- `p` - structured schema vocabulary for state, actions, props, and events.
+- `ui(spec)` - creates the authoring surface from a structured UI spec.
+- `part(config)` - view part contract builder.
+- `u.state` - state handles.
+- `u.action` - action handles.
+- `u.view` - component tags and component calls.
+- `u.each(collection, child)` - repeat item context.
+- `u.slot(name, value)` - named slot placement for TSX children.
+- `u.text(template, args)` - template expression.
+
+## License
+
+MIT

--- a/pkg/ui/ui/package.json
+++ b/pkg/ui/ui/package.json
@@ -1,0 +1,79 @@
+{
+  "name": "@pumped-fn/ui",
+  "version": "0.1.0",
+  "description": "Target-neutral TSX UI authoring for pumped-fn",
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./jsx-runtime": {
+      "import": {
+        "types": "./dist/jsx-runtime.d.mts",
+        "default": "./dist/jsx-runtime.mjs"
+      },
+      "require": {
+        "types": "./dist/jsx-runtime.d.cts",
+        "default": "./dist/jsx-runtime.cjs"
+      }
+    },
+    "./jsx-dev-runtime": {
+      "import": {
+        "types": "./dist/jsx-dev-runtime.d.mts",
+        "default": "./dist/jsx-dev-runtime.mjs"
+      },
+      "require": {
+        "types": "./dist/jsx-dev-runtime.d.cts",
+        "default": "./dist/jsx-dev-runtime.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+  ],
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.test.json",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "directory": "pkg/ui/ui",
+    "url": "git+https://github.com/pumped-fn/pumped-fn.git"
+  },
+  "keywords": [
+    "ui",
+    "render",
+    "graph",
+    "pumped-fn",
+    "lite"
+  ],
+  "license": "MIT"
+}

--- a/pkg/ui/ui/src/index.ts
+++ b/pkg/ui/ui/src/index.ts
@@ -1,0 +1,546 @@
+const exprKey: unique symbol = Symbol("pumped.ui.expr")
+const actKey: unique symbol = Symbol("pumped.ui.act")
+const partKey: unique symbol = Symbol("pumped.ui.part")
+
+type Standard<T> = {
+  readonly "~standard": {
+    readonly version: 1
+    readonly vendor: string
+    readonly types?: {
+      readonly input: unknown
+      readonly output: T
+    }
+  }
+}
+
+const valueKinds = ["string", "number", "boolean", "nullableString", "array", "object"] as const
+
+type ValueKind = (typeof valueKinds)[number]
+
+type LeafKind = Exclude<ValueKind, "array" | "object">
+
+type KindFor<T> =
+  [T] extends [readonly unknown[]] ? "array" :
+    [null] extends [T] ? "nullableString" :
+      [T] extends [string] ? "string" :
+        [T] extends [number] ? "number" :
+          [T] extends [boolean] ? "boolean" :
+            never
+
+interface BaseSchema<T = unknown> extends Standard<T> {
+  readonly node: "leaf" | "array" | "object"
+}
+
+interface LeafSchema<T> extends BaseSchema<T> {
+  readonly node: "leaf"
+  readonly kind: LeafKind
+}
+
+interface ArraySchema<Item extends BaseSchema> extends BaseSchema<readonly InferSchema<Item>[]> {
+  readonly node: "array"
+  readonly item: Item
+}
+
+interface ObjectSchema<Fields extends Record<string, BaseSchema>> extends BaseSchema<{ readonly [Name in keyof Fields & string]: InferSchema<Fields[Name]> }> {
+  readonly node: "object"
+  readonly fields: Fields
+}
+
+type Schema<T = unknown> = BaseSchema<T>
+
+type InferSchema<S> = S extends Standard<infer Output> ? Output : never
+
+type Infer<S> = InferSchema<S>
+
+type KindOfSchema<S extends BaseSchema> =
+  S extends LeafSchema<infer Output> ? KindFor<Output> :
+    S extends { readonly node: "array" } ? "array" :
+      S extends { readonly node: "object" } ? "object" :
+        never
+
+function standard<T>() {
+  return { "~standard": { version: 1, vendor: "@pumped-fn/ui" } } as Standard<T>
+}
+
+function leaf<T>(kind: LeafKind): LeafSchema<T> {
+  return { ...standard<T>(), node: "leaf", kind }
+}
+
+const p = {
+  string: leaf<string>("string"),
+  number: leaf<number>("number"),
+  boolean: leaf<boolean>("boolean"),
+  nullableString: leaf<string | null>("nullableString"),
+  array: <Item extends BaseSchema>(item: Item): ArraySchema<Item> => ({ ...standard<readonly InferSchema<Item>[]>(), node: "array", item }),
+  object: <const Fields extends Record<string, BaseSchema>>(
+    fields: Fields & { readonly [Name in keyof Fields]: Name extends `${string}/${string}` ? never : unknown }
+  ): ObjectSchema<Fields> => {
+    const invalid = Object.keys(fields).find((name) => name.includes("/"))
+    if (invalid !== undefined) throw new Error(`schema field "${invalid}" cannot contain "/"`)
+    return { ...standard<{ readonly [Name in keyof Fields & string]: InferSchema<Fields[Name]> }>(), node: "object", fields }
+  },
+}
+
+type Val = string | number | boolean | null | readonly Val[] | { readonly [key: string]: Val }
+
+type Ref =
+  | { readonly kind: "state"; readonly path: readonly string[] }
+  | { readonly kind: "item"; readonly path: readonly string[] }
+  | { readonly kind: "event"; readonly path: readonly string[] }
+  | { readonly kind: "text"; readonly template: string; readonly args: Record<string, Val | Ref> }
+
+type Expr<T = unknown> = {
+  readonly [exprKey]: Ref
+}
+
+type Raw<T> =
+  T extends string ? string :
+    T extends number ? number :
+      T extends boolean ? boolean :
+        T extends null ? null :
+          T extends readonly (infer Item)[] ? readonly Raw<Item>[] :
+            T extends object ? { readonly [K in keyof T & string]: Raw<T[K]> } :
+              never
+
+type Input<T> = Raw<T> | Expr<T>
+
+type Collection<T> = Expr<readonly T[]>
+
+type Field<T> = Expr<T>
+
+type State<T> =
+  T extends readonly (infer Item)[] ? Collection<Item> :
+    T extends object ? Expr<T> & { readonly [K in keyof T & string]: State<T[K]> } :
+      Field<T>
+
+type Item<T> =
+  T extends object ? Expr<T> & { readonly [K in keyof T & string]: Field<T[K]> } :
+    Expr<T>
+
+type Evt<Shape> =
+  Shape extends object ? Expr<Shape> & { readonly [K in keyof Shape & string]: Expr<Shape[K]> } :
+    Expr<Shape>
+
+type Part<Props = {}, Slots = {}, Events = {}> = {
+  readonly [partKey]?: {
+    readonly props: Props
+    readonly slots: Slots
+    readonly on: Events
+  }
+}
+
+type Call = {
+  readonly name: string
+  readonly input: Record<string, Val | Ref>
+}
+
+type Act = {
+  readonly [actKey]: Call
+}
+
+type Node = {
+  readonly kind: "node"
+  readonly type: string
+  readonly props: Record<string, Val | Ref>
+  readonly slots?: Record<string, Slot>
+  readonly on?: Record<string, Call>
+  readonly watch?: Record<string, Call>
+  readonly visible?: VisibleOut
+}
+
+type Each = {
+  readonly kind: "each"
+  readonly source: Ref
+  readonly nodes: readonly Node[]
+}
+
+type Tree = Node | Each
+
+type Slot = readonly Tree[]
+
+type NamedSlot = {
+  readonly kind: "slot"
+  readonly name: string
+  readonly value: Slot
+}
+
+type Child = Tree | NamedSlot | readonly Child[]
+
+type Plan = {
+  readonly root: Node
+}
+
+type Visible = {
+  readonly state: Expr<unknown>
+  readonly eq?: Val
+}
+
+type VisibleOut = {
+  readonly state: Ref
+  readonly eq?: Val
+}
+
+type PropsOf<C> = C extends Part<infer Props, unknown, unknown> ? Props : {}
+
+type SlotsOf<C> = C extends Part<unknown, infer Slots, unknown> ? Slots : {}
+
+type EventsOf<C> = C extends Part<unknown, unknown, infer Events> ? Events : {}
+
+type Props<InputShape> = {
+  readonly [Name in keyof InputShape & string]: Input<InputShape[Name]>
+}
+
+type Actions<Registry> = {
+  readonly [Name in keyof Registry & string]: (input: Props<Registry[Name]>) => Act
+}
+
+type EventInput<Shape> =
+  | Act
+  | ((event: Evt<Shape>) => Act)
+
+type Events<Component> = {
+  readonly [Name in keyof EventsOf<Component> & string]?: EventInput<EventsOf<Component>[Name]>
+}
+
+type EventAttrs<Component> = {
+  readonly [Name in keyof EventsOf<Component> & string as `on${Capitalize<Name>}`]?: EventInput<EventsOf<Component>[Name]>
+}
+
+type SlotInput = Tree | readonly Tree[]
+
+type Slots<Component> = {
+  readonly [Name in keyof SlotsOf<Component> & string]?: SlotInput
+}
+
+type JsxNodeInput<Component, Registry> =
+  Props<PropsOf<Component>>
+  & EventAttrs<Component>
+  & {
+    readonly children?: Child
+    readonly watch?: Partial<Record<keyof Registry & string, Act>>
+    readonly visible?: Visible
+  }
+
+type NodeInput<Component, Registry> = {
+  readonly props: Props<PropsOf<Component>>
+  readonly slots?: Slots<Component>
+  readonly on?: Events<Component>
+  readonly watch?: Partial<Record<keyof Registry & string, Act>>
+  readonly visible?: Visible
+}
+
+type NodeFn<Component, Registry> = {
+  (input: JsxNodeInput<Component, Registry>): Node
+  (input: NodeInput<Component, Registry>): Node
+}
+
+type Nodes<Catalog, Registry> = {
+  readonly [Name in keyof Catalog & string]: NodeFn<Catalog[Name], Registry>
+}
+
+type Def = {
+  readonly state: unknown
+  readonly action: object
+  readonly view: object
+}
+
+type SchemaShape = Record<string, Schema>
+
+type SlotShape = readonly string[] | Record<string, unknown>
+
+type PartConfig<Props extends SchemaShape = {}, Slots extends SlotShape = readonly [], Events extends SchemaShape = {}> = {
+  readonly props?: Props
+  readonly slots?: Slots
+  readonly on?: Events
+}
+
+type AnyPartConfig = PartConfig<SchemaShape, SlotShape, SchemaShape>
+
+type InferShape<S> = {
+  readonly [Name in keyof S & string]: InferSchema<S[Name]>
+}
+
+type InferSlots<S> =
+  S extends readonly (infer Name extends string)[] ? { readonly [Key in Name]: true } :
+    S extends Record<string, unknown> ? { readonly [Key in keyof S & string]: true } :
+      {}
+
+type PropsFrom<C> = C extends { readonly props: infer Props extends SchemaShape } ? Props : {}
+
+type SlotsFrom<C> = C extends { readonly slots: infer Slots extends SlotShape } ? Slots : readonly []
+
+type EventsFrom<C> = C extends { readonly on: infer Events extends SchemaShape } ? Events : {}
+
+type InferPart<C extends AnyPartConfig> = Part<InferShape<PropsFrom<C>>, InferSlots<SlotsFrom<C>>, InferShape<EventsFrom<C>>>
+
+type Spec = {
+  readonly state: Schema
+  readonly action: Record<string, Schema>
+  readonly view: Record<string, Part>
+}
+
+type InferSpec<S extends Spec> = {
+  readonly state: InferSchema<S["state"]>
+  readonly action: InferShape<S["action"]>
+  readonly view: S["view"]
+}
+
+type Ui<D extends Def, S = undefined> = {
+  readonly spec: S
+  readonly state: State<D["state"]>
+  readonly action: Actions<D["action"]>
+  readonly view: Nodes<D["view"], D["action"]>
+  readonly plan: (root: Node) => Plan
+  readonly each: <T>(source: Collection<T>, child: (item: Item<T>) => Node | readonly Node[]) => Each
+  readonly slot: (name: string, input: SlotInput) => NamedSlot
+  readonly text: (template: string, args: Record<string, Val | Expr<unknown>>) => Expr<string | null>
+}
+
+function bind<T>(ref: Ref): Expr<T> {
+  return { [exprKey]: ref }
+}
+
+function part<const C extends AnyPartConfig>(config: C): InferPart<C> {
+  return config as unknown as InferPart<C>
+}
+
+function field(source: "state" | "item" | "event", path: readonly string[]): unknown {
+  return new Proxy(bind({ kind: source, path }) as Record<PropertyKey, unknown>, {
+    get(target, property) {
+      if (property === exprKey) return target[property]
+      if (typeof property !== "string") return target[property]
+      return field(source, [...path, property])
+    },
+  })
+}
+
+function isExpr(input: unknown): input is Expr<unknown> {
+  return typeof input === "object" && input !== null && exprKey in input
+}
+
+function expr(input: Val | Expr<unknown>): Val | Ref {
+  if (isExpr(input)) return input[exprKey]
+  return input
+}
+
+function props(input: Record<string, Val | Expr<unknown>>): Record<string, Val | Ref> {
+  return Object.fromEntries(Object.entries(input).map(([key, value]) => [key, expr(value)]))
+}
+
+function act(input: Act): Call {
+  return input[actKey]
+}
+
+function actions<Registry>(): Actions<Registry> {
+  return new Proxy({} as Record<PropertyKey, unknown>, {
+    get(_target, property) {
+      if (typeof property !== "string") return undefined
+      return (input: Record<string, Val | Expr<unknown>>) => ({ [actKey]: { name: property, input: props(input) } })
+    },
+  }) as Actions<Registry>
+}
+
+function events(input: Record<string, EventInput<unknown> | undefined> | undefined): Record<string, Call> | undefined {
+  if (!input) return undefined
+  const entries = Object.entries(input).filter((entry): entry is [string, EventInput<unknown>] => entry[1] !== undefined)
+  return Object.fromEntries(entries.map(([key, value]) => {
+    const call = typeof value === "function" ? value(field("event", []) as Evt<unknown>) : value
+    return [key, act(call)]
+  }))
+}
+
+function isTreeList(input: SlotInput): input is readonly Tree[] {
+  return Array.isArray(input)
+}
+
+function slotValue(input: SlotInput): Slot {
+  if (isTreeList(input)) return input
+  return [input]
+}
+
+function slots(input: Record<string, SlotInput | undefined> | undefined): Record<string, Slot> | undefined {
+  if (!input) return undefined
+  const entries = Object.entries(input).filter((entry): entry is [string, SlotInput] => entry[1] !== undefined)
+  return Object.fromEntries(entries.map(([key, value]) => [key, slotValue(value)]))
+}
+
+function visible(input: Visible): VisibleOut {
+  const value = expr(input.state)
+  const output: { state: Ref; eq?: Val } = { state: value as Ref }
+  if ("eq" in input) output.eq = input.eq
+  return output
+}
+
+function watches(input: Partial<Record<string, Act>> | undefined): Record<string, Call> | undefined {
+  if (!input) return undefined
+  const entries = Object.entries(input).filter((entry): entry is [string, Act] => entry[1] !== undefined)
+  return Object.fromEntries(entries.map(([key, value]) => [key, act(value)]))
+}
+
+function eventName(key: string): string | undefined {
+  if (!key.startsWith("on") || key.length < 3) return undefined
+  return `${key.slice(2, 3).toLowerCase()}${key.slice(3)}`
+}
+
+function jsxProps(input: Record<string, unknown>): Record<string, Val | Expr<unknown>> {
+  const entries = Object.entries(input).filter(([key]) => key !== "children" && key !== "watch" && key !== "visible" && eventName(key) === undefined)
+  return Object.fromEntries(entries.map(([key, value]) => [key, value as Val | Expr<unknown>]))
+}
+
+function jsxEvents(input: Record<string, unknown>): Record<string, EventInput<unknown> | undefined> | undefined {
+  const entries = Object.entries(input).flatMap(([key, value]) => {
+    const name = eventName(key)
+    return name === undefined ? [] : [[name, value as EventInput<unknown> | undefined] as const]
+  })
+  return entries.length === 0 ? undefined : Object.fromEntries(entries)
+}
+
+function isNamedSlot(input: Tree | NamedSlot): input is NamedSlot {
+  return input.kind === "slot"
+}
+
+function isChildList(input: Child): input is readonly Child[] {
+  return Array.isArray(input)
+}
+
+function childList(input: Child | undefined): readonly (Tree | NamedSlot)[] {
+  if (input === undefined) return []
+  if (isChildList(input)) return input.flatMap((child) => childList(child))
+  return [input]
+}
+
+function jsxSlots(input: Child | undefined): Record<string, Slot> | undefined {
+  const children = childList(input)
+  const output: Record<string, Slot> = {}
+  const defaults: Tree[] = []
+  for (const child of children) {
+    if (isNamedSlot(child)) output[child.name] = child.value
+    else defaults.push(child)
+  }
+  if (defaults.length > 0) output["default"] = defaults
+  return Object.keys(output).length === 0 ? undefined : output
+}
+
+function fromJsx<Registry>(input: JsxNodeInput<unknown, Registry>): NodeInput<unknown, Registry> {
+  const raw = input as Record<string, unknown>
+  return {
+    props: jsxProps(raw),
+    slots: jsxSlots(input.children),
+    on: jsxEvents(raw),
+    watch: input.watch,
+    visible: input.visible,
+  }
+}
+
+function inputOf<Registry>(input: NodeInput<unknown, Registry> | JsxNodeInput<unknown, Registry>): NodeInput<unknown, Registry> {
+  if ("props" in input) return input
+  return fromJsx(input)
+}
+
+function node<Catalog, Registry>(): Nodes<Catalog, Registry> {
+  return new Proxy({} as Record<PropertyKey, unknown>, {
+    get(_target, property) {
+      if (typeof property !== "string") return undefined
+      return ((raw: NodeInput<unknown, Registry> | JsxNodeInput<unknown, Registry>): Node => {
+        const input = inputOf(raw)
+        const output: Node = { kind: "node", type: property, props: props(input.props) }
+        const loweredSlots = slots(input.slots)
+        const loweredEvents = events(input.on)
+        const loweredWatches = watches(input.watch)
+        return {
+          ...output,
+          ...(loweredSlots ? { slots: loweredSlots } : {}),
+          ...(loweredEvents ? { on: loweredEvents } : {}),
+          ...(loweredWatches ? { watch: loweredWatches } : {}),
+          ...(input.visible ? { visible: visible(input.visible) } : {}),
+        }
+      }) as NodeFn<unknown, Registry>
+    },
+  }) as Nodes<Catalog, Registry>
+}
+
+function jsx<T>(type: (input: Record<string, unknown>) => T, input: Record<string, unknown>): T {
+  return type(input)
+}
+
+function Fragment(input: { readonly children?: Child }): readonly Node[] {
+  return childList(input.children).filter((child): child is Node => child.kind === "node")
+}
+
+const jsxs = jsx
+
+function named(name: string, input: SlotInput): NamedSlot {
+  return {
+    kind: "slot",
+    name,
+    value: slotValue(input),
+  }
+}
+
+function each<T>(source: Collection<T>, child: (item: Item<T>) => Node | readonly Node[]): Each {
+  const result = child(field("item", []) as Item<T>)
+  return {
+    kind: "each",
+    source: expr(source) as Ref,
+    nodes: Array.isArray(result) ? result : [result],
+  }
+}
+
+function ui<D extends Def>(): Ui<D>
+function ui<const S extends Spec>(spec: S): Ui<InferSpec<S>, S>
+function ui(spec?: unknown): Ui<Def, unknown> {
+  const view = node<object, object>()
+  return {
+    spec,
+    state: field("state", []) as State<Def["state"]>,
+    action: actions<Def["action"]>(),
+    view,
+    plan: (root) => ({ root }),
+    each,
+    slot: named,
+    text: (template, args) => bind({ kind: "text", template, args: props(args) }),
+  }
+}
+
+export { Fragment, jsx, jsxs, p, part, ui, valueKinds }
+export type {
+  Act,
+  Actions,
+  ArraySchema,
+  BaseSchema,
+  Call,
+  Child,
+  Collection,
+  Def,
+  Each,
+  Evt,
+  Expr,
+  Field,
+  Input,
+  Infer,
+  InferSchema,
+  Item,
+  KindFor,
+  KindOfSchema,
+  LeafKind,
+  LeafSchema,
+  NamedSlot,
+  Node,
+  NodeFn,
+  Nodes,
+  ObjectSchema,
+  Part,
+  PartConfig,
+  Plan,
+  Ref,
+  Schema,
+  Slot,
+  SlotInput,
+  Spec,
+  Standard,
+  State,
+  Tree,
+  Ui,
+  Val,
+  ValueKind,
+}

--- a/pkg/ui/ui/src/jsx-dev-runtime.ts
+++ b/pkg/ui/ui/src/jsx-dev-runtime.ts
@@ -1,0 +1,3 @@
+export { Fragment } from "./index"
+export { jsx as jsxDEV } from "./index"
+export type { JSX } from "./jsx-runtime"

--- a/pkg/ui/ui/src/jsx-runtime.ts
+++ b/pkg/ui/ui/src/jsx-runtime.ts
@@ -1,0 +1,13 @@
+import type { Node } from "./index"
+
+export { Fragment, jsx, jsxs } from "./index"
+
+export namespace JSX {
+  export type Element = Node
+
+  export interface ElementChildrenAttribute {
+    children: {}
+  }
+
+  export interface IntrinsicElements {}
+}

--- a/pkg/ui/ui/tests/jsx.test.tsx
+++ b/pkg/ui/ui/tests/jsx.test.tsx
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "vitest"
+import { p, part, ui } from "../src"
+
+const todo = p.object({
+  id: p.string,
+  title: p.string,
+  detail: p.nullableString,
+  done: p.boolean,
+  tone: p.string,
+})
+
+const u = ui({
+  state: p.object({
+    draft: p.string,
+    headline: p.string,
+    open: p.number,
+    done: p.number,
+    items: p.array(todo),
+  }),
+  action: {
+    draft: p.object({ text: p.string }),
+    add: p.object({ text: p.string }),
+    toggle: p.object({ id: p.string }),
+    clear: p.object({}),
+  },
+  view: {
+    Board: part({
+      props: {
+        title: p.string,
+        open: p.number,
+        done: p.number,
+      },
+      slots: ["default"],
+    }),
+    Composer: part({
+      props: {
+        value: p.string,
+        placeholder: p.string,
+      },
+      on: {
+        change: p.object({ value: p.string }),
+        submit: p.object({}),
+      },
+    }),
+    Lane: part({
+      props: {
+        title: p.string,
+        items: p.array(todo),
+      },
+      slots: ["rows"],
+    }),
+    Todo: part({
+      props: {
+        title: p.string,
+        detail: p.nullableString,
+        done: p.boolean,
+        tone: p.string,
+      },
+      on: {
+        toggle: p.object({}),
+      },
+    }),
+    Toolbar: part({
+      props: {
+        label: p.string,
+      },
+      on: {
+        clear: p.object({}),
+      },
+    }),
+  },
+})
+
+const plan = u.plan(
+  <u.view.Board title={u.state.headline} open={u.state.open} done={u.state.done}>
+    <u.view.Composer
+      value={u.state.draft}
+      placeholder="Add a crisp next action"
+      onChange={(event) => u.action.draft({ text: event.value })}
+      onSubmit={u.action.add({ text: u.state.draft })}
+    />
+    <u.view.Lane title="Today" items={u.state.items}>
+      {u.slot(
+        "rows",
+        u.each(u.state.items, (todo) => (
+          <u.view.Todo
+            title={todo.title}
+            detail={todo.detail}
+            done={todo.done}
+            tone={todo.tone}
+            onToggle={u.action.toggle({ id: todo.id })}
+          />
+        ))
+      )}
+    </u.view.Lane>
+    <u.view.Toolbar label="Clear completed" onClear={u.action.clear({})} />
+  </u.view.Board>
+)
+
+describe("tsx", () => {
+  test("authors a target-neutral plan from structured JSX", () => {
+    expect(plan).toEqual({
+      root: {
+        kind: "node",
+        type: "Board",
+        props: {
+          title: { kind: "state", path: ["headline"] },
+          open: { kind: "state", path: ["open"] },
+          done: { kind: "state", path: ["done"] },
+        },
+        slots: {
+          default: [
+            {
+              kind: "node",
+              type: "Composer",
+              props: {
+                value: { kind: "state", path: ["draft"] },
+                placeholder: "Add a crisp next action",
+              },
+              on: {
+                change: { name: "draft", input: { text: { kind: "event", path: ["value"] } } },
+                submit: { name: "add", input: { text: { kind: "state", path: ["draft"] } } },
+              },
+            },
+            {
+              kind: "node",
+              type: "Lane",
+              props: {
+                title: "Today",
+                items: { kind: "state", path: ["items"] },
+              },
+              slots: {
+                rows: [
+                  {
+                    kind: "each",
+                    source: { kind: "state", path: ["items"] },
+                    nodes: [
+                      {
+                        kind: "node",
+                        type: "Todo",
+                        props: {
+                          title: { kind: "item", path: ["title"] },
+                          detail: { kind: "item", path: ["detail"] },
+                          done: { kind: "item", path: ["done"] },
+                          tone: { kind: "item", path: ["tone"] },
+                        },
+                        on: {
+                          toggle: { name: "toggle", input: { id: { kind: "item", path: ["id"] } } },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            {
+              kind: "node",
+              type: "Toolbar",
+              props: { label: "Clear completed" },
+              on: {
+                clear: { name: "clear", input: {} },
+              },
+            },
+          ],
+        },
+      },
+    })
+    expect(u.spec.state).toEqual({
+      "~standard": { version: 1, vendor: "@pumped-fn/ui" },
+      node: "object",
+      fields: {
+        draft: { "~standard": { version: 1, vendor: "@pumped-fn/ui" }, node: "leaf", kind: "string" },
+        headline: { "~standard": { version: 1, vendor: "@pumped-fn/ui" }, node: "leaf", kind: "string" },
+        open: { "~standard": { version: 1, vendor: "@pumped-fn/ui" }, node: "leaf", kind: "number" },
+        done: { "~standard": { version: 1, vendor: "@pumped-fn/ui" }, node: "leaf", kind: "number" },
+        items: {
+          "~standard": { version: 1, vendor: "@pumped-fn/ui" },
+          node: "array",
+          item: todo,
+        },
+      },
+    })
+    expect(u.spec.view.Todo).toEqual({
+      props: {
+        title: { "~standard": { version: 1, vendor: "@pumped-fn/ui" }, node: "leaf", kind: "string" },
+        detail: { "~standard": { version: 1, vendor: "@pumped-fn/ui" }, node: "leaf", kind: "nullableString" },
+        done: { "~standard": { version: 1, vendor: "@pumped-fn/ui" }, node: "leaf", kind: "boolean" },
+        tone: { "~standard": { version: 1, vendor: "@pumped-fn/ui" }, node: "leaf", kind: "string" },
+      },
+      on: {
+        toggle: { "~standard": { version: 1, vendor: "@pumped-fn/ui" }, node: "object", fields: {} },
+      },
+    })
+  })
+})

--- a/pkg/ui/ui/tests/ui.test.ts
+++ b/pkg/ui/ui/tests/ui.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "vitest"
+import { p, part, ui } from "../src"
+
+const todo = p.object({
+  id: p.string,
+  title: p.string,
+  done: p.boolean,
+})
+
+const u = ui({
+  state: p.object({
+    draft: p.string,
+    items: p.array(todo),
+  }),
+  action: {
+    draft: p.object({ text: p.string }),
+    add: p.object({ text: p.string }),
+    toggle: p.object({ id: p.string }),
+  },
+  view: {
+    App: part({ slots: ["default"] }),
+    Input: part({
+      props: { value: p.string },
+      on: {
+        change: p.object({ value: p.string }),
+        submit: p.object({}),
+      },
+    }),
+    List: part({
+      props: { items: p.array(todo) },
+      slots: ["rows"],
+    }),
+    Row: part({
+      props: {
+        title: p.string,
+        done: p.boolean,
+      },
+      on: { toggle: p.object({}) },
+    }),
+  },
+})
+
+const plan = u.plan(
+  u.view.App({
+    props: {},
+    slots: {
+      default: [
+        u.view.Input({
+          props: { value: u.state.draft },
+          on: {
+            change: (event) => u.action.draft({ text: event.value }),
+            submit: u.action.add({ text: u.state.draft }),
+          },
+        }),
+        u.view.List({
+          props: { items: u.state.items },
+          slots: {
+            rows: u.each(u.state.items, (todo) =>
+              u.view.Row({
+                props: {
+                  title: todo.title,
+                  done: todo.done,
+                },
+                on: {
+                  toggle: u.action.toggle({ id: todo.id }),
+                },
+              })
+            ),
+          },
+        }),
+      ],
+    },
+  })
+)
+
+describe("ui", () => {
+  test("authors a target-neutral plan from structured graph handles", () => {
+    expect(plan).toEqual({
+      root: {
+        kind: "node",
+        type: "App",
+        props: {},
+        slots: {
+          default: [
+            {
+              kind: "node",
+              type: "Input",
+              props: { value: { kind: "state", path: ["draft"] } },
+              on: {
+                change: { name: "draft", input: { text: { kind: "event", path: ["value"] } } },
+                submit: { name: "add", input: { text: { kind: "state", path: ["draft"] } } },
+              },
+            },
+            {
+              kind: "node",
+              type: "List",
+              props: { items: { kind: "state", path: ["items"] } },
+              slots: {
+                rows: [
+                  {
+                    kind: "each",
+                    source: { kind: "state", path: ["items"] },
+                    nodes: [
+                      {
+                        kind: "node",
+                        type: "Row",
+                        props: {
+                          title: { kind: "item", path: ["title"] },
+                          done: { kind: "item", path: ["done"] },
+                        },
+                        on: {
+                          toggle: { name: "toggle", input: { id: { kind: "item", path: ["id"] } } },
+                        },
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test("rejects slash field keys", () => {
+    const field = "bad/key" as string
+    expect(() => p.object({ [field]: p.string })).toThrow('schema field "bad/key" cannot contain "/"')
+  })
+})

--- a/pkg/ui/ui/tsconfig.json
+++ b/pkg/ui/ui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/pkg/ui/ui/tsconfig.test.json
+++ b/pkg/ui/ui/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "../src",
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["vitest"]
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pkg/ui/ui/tsdown.config.ts
+++ b/pkg/ui/ui/tsdown.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "tsdown";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/jsx-runtime.ts", "src/jsx-dev-runtime.ts"],
+  dts: true,
+  format: ["cjs", "esm"],
+  clean: true,
+});

--- a/pkg/ui/ui/vitest.config.ts
+++ b/pkg/ui/ui/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  oxc: {
+    jsx: {
+      runtime: "automatic",
+      importSource: "../src",
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -963,6 +963,21 @@ importers:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  pkg/ui/ui:
+    devDependencies:
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
 packages:
 
   '@adobe/css-tools@4.5.0':


### PR DESCRIPTION
## Summary

Adds `@pumped-fn/ui`, a standalone TSX authoring layer for composing target-neutral UI plans from graph handles. UI specs are authored with structured `p` schema nodes, so state/action/view shape stays available to adapters while json-render remains just one lowering target.

## Changes

- Adds `pkg/ui/ui` as the new `@pumped-fn/ui` package with `ui(spec)`, `p`, `part`, `state`, `action`, `view`, `each`, `slot`, `text`, and `plan` handles.
- Defines a package-owned `p` vocabulary: `string`, `number`, `boolean`, `nullableString`, `array`, and `object`, with value-kind inference and a slash-key guard for path-safe object fields.
- Keeps `u.spec` on the authoring surface so implementation packages can preserve state, action, event, prop, slot, and component contract shape instead of reconstructing it from lowered paths.
- Adds `@pumped-fn/ui/jsx-runtime` and `@pumped-fn/ui/jsx-dev-runtime` so TSX can author the same neutral `Plan` IR through `jsxImportSource @pumped-fn/ui`.
- Defines package-owned `Plan`, `Node`, `Expr`, `Ref`, `Call`, `Each`, and slot IR types so React, Vue, React Native, json-render, and tests can be separate targets.
- Documents that implementation packs should expose their own small binding vocabulary for target components, actions, state drivers, scope tags, and adapter capabilities.
- Adds object-call and TSX tests showing state reads, events, submit actions, list repetition, named slots, item-scoped actions, preserved structured specs, and schema field validation.
- Registers the new UI lane in repo package docs, root package map, lockfile, and focused lint path.

## Testing

- `pnpm -F @pumped-fn/ui typecheck`
- `pnpm -F @pumped-fn/ui test`
- `pnpm -F @pumped-fn/ui build`
- `node pkg/tool/lint/dist/cli.mjs pkg/ui/README.md pkg/ui/ui/README.md pkg/ui/ui/src pkg/ui/ui/tests --json`
- `node scripts/check-example-alignment.mjs`
- `git diff --check`
