### PR TITLE
build: consolidated tsconfig.base.json for build-free typecheck

### DIFF
--- a/.changeset/tsconfig-base-buildfree.md
+++ b/.changeset/tsconfig-base-buildfree.md
@@ -1,0 +1,4 @@
+---
+---
+
+Build tooling only: consolidated every package onto a shared `tsconfig.base.json` so a fresh checkout typechecks without building `dist` first. No published output changes — `tsconfig.json` is not shipped, and the one `@pumped-fn/lite-hmr` source touch (`process.env['NODE_ENV']`) compiles to identical JS.

--- a/examples/invoice-triage/tsconfig.json
+++ b/examples/invoice-triage/tsconfig.json
@@ -1,27 +1,20 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node", "vitest"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "noEmit": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "paths": {
-      "@pumped-fn/lite": ["../../pkg/core/lite/src/index.ts"],
-      "@pumped-fn/lite-extension-logging": ["../../pkg/ext/logging/src/index.ts"],
-      "@pumped-fn/lite-extension-observable": ["../../pkg/ext/observable/src/index.ts"],
-      "@pumped-fn/lite-extension-observable-otel": ["../../pkg/ext/observable-otel/src/index.ts"],
-      "@pumped-fn/lite-extension-scheduler": ["../../pkg/ext/scheduler/src/index.ts"],
-      "@pumped-fn/sdk": ["../../pkg/sdk/core/src/index.ts"],
-      "@pumped-fn/sdk-test": ["../../pkg/sdk/test/src/index.ts"]
-    }
+    "types": [
+      "node",
+      "vitest"
+    ],
+    "noEmit": true
   },
-  "include": ["vitest.config.ts", "src/**/*", "tests/**/*", "bin/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "vitest.config.ts",
+    "src/**/*",
+    "tests/**/*",
+    "bin/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/pkg/core/lite/tsconfig.json
+++ b/pkg/core/lite/tsconfig.json
@@ -1,22 +1,17 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests", "src/__experiments"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests",
+    "src/__experiments"
+  ]
 }

--- a/pkg/core/lite/tsconfig.test.json
+++ b/pkg/core/lite/tsconfig.test.json
@@ -1,10 +1,14 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
     "noEmit": true,
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"]
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "src/**/*",

--- a/pkg/ext/hmr/src/plugin.ts
+++ b/pkg/ext/hmr/src/plugin.ts
@@ -26,7 +26,7 @@ export function pumpedHmr(options: PumpedHmrOptions = {}): Plugin {
     enforce: "pre",
 
     transform(code, id) {
-      if (process.env.NODE_ENV === "production") {
+      if (process.env["NODE_ENV"] === "production") {
         return null
       }
 

--- a/pkg/ext/hmr/tsconfig.json
+++ b/pkg/ext/hmr/tsconfig.json
@@ -1,18 +1,11 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src"
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/ext/logging-pino/tsconfig.json
+++ b/pkg/ext/logging-pino/tsconfig.json
@@ -1,25 +1,17 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite-extension-logging": ["../logging/src/index.ts"]
-    }
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/ext/logging/tsconfig.json
+++ b/pkg/ext/logging/tsconfig.json
@@ -1,25 +1,17 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/ext/observable-otel/tsconfig.json
+++ b/pkg/ext/observable-otel/tsconfig.json
@@ -1,25 +1,17 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite-extension-observable": ["../observable/src/index.ts"]
-    }
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/ext/observable/tsconfig.json
+++ b/pkg/ext/observable/tsconfig.json
@@ -1,25 +1,17 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/ext/scheduler-nats/tsconfig.json
+++ b/pkg/ext/scheduler-nats/tsconfig.json
@@ -1,26 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "types": ["node"],
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite-extension-scheduler": ["../scheduler/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/ext/scheduler/tsconfig.json
+++ b/pkg/ext/scheduler/tsconfig.json
@@ -1,25 +1,17 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/ext/suspense/tsconfig.json
+++ b/pkg/ext/suspense/tsconfig.json
@@ -1,26 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/ext/sync-nats/tsconfig.json
+++ b/pkg/ext/sync-nats/tsconfig.json
@@ -1,26 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "types": ["node"],
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite-extension-sync": ["../sync/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/ext/sync/tsconfig.json
+++ b/pkg/ext/sync/tsconfig.json
@@ -1,25 +1,17 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/framework/hono/tsconfig.json
+++ b/pkg/framework/hono/tsconfig.json
@@ -1,26 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/framework/hono/tsconfig.test.json
+++ b/pkg/framework/hono/tsconfig.test.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "../..",
     "noEmit": true
   },
   "include": [

--- a/pkg/framework/pumped/tsconfig.json
+++ b/pkg/framework/pumped/tsconfig.json
@@ -1,27 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"],
-      "@pumped-fn/lite-hono": ["../hono/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/framework/pumped/tsconfig.test.json
+++ b/pkg/framework/pumped/tsconfig.test.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "../..",
     "noEmit": true
   },
   "include": [

--- a/pkg/framework/tanstack-start/tsconfig.json
+++ b/pkg/framework/tanstack-start/tsconfig.json
@@ -1,26 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/framework/tanstack-start/tsconfig.test.json
+++ b/pkg/framework/tanstack-start/tsconfig.test.json
@@ -1,7 +1,6 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "../..",
     "noEmit": true
   },
   "include": [

--- a/pkg/react/json/tsconfig.json
+++ b/pkg/react/json/tsconfig.json
@@ -1,21 +1,11 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/react/json/tsconfig.test.json
+++ b/pkg/react/json/tsconfig.test.json
@@ -1,10 +1,18 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
     "noEmit": true,
-    "types": ["node", "vitest"]
+    "types": [
+      "node",
+      "vitest"
+    ]
   },
-  "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/pkg/react/lite-react/tsconfig.json
+++ b/pkg/react/lite-react/tsconfig.json
@@ -1,22 +1,14 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "jsx": "react-jsx",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true
+    "jsx": "react-jsx"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/react/lite-react/tsconfig.test.json
+++ b/pkg/react/lite-react/tsconfig.test.json
@@ -1,10 +1,14 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
     "noEmit": true,
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"]
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "types": [
+      "node"
+    ]
   },
   "include": [
     "src/**/*",

--- a/pkg/render/core/tsconfig.json
+++ b/pkg/render/core/tsconfig.json
@@ -1,21 +1,11 @@
 {
-  "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true
-  },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "extends": "../../../tsconfig.base.json",
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/render/core/tsconfig.test.json
+++ b/pkg/render/core/tsconfig.test.json
@@ -1,10 +1,17 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
     "noEmit": true,
-    "types": ["vitest"]
+    "types": [
+      "vitest"
+    ]
   },
-  "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/pkg/render/react/tsconfig.json
+++ b/pkg/render/react/tsconfig.json
@@ -1,22 +1,14 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "jsx": "react-jsx",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true
+    "jsx": "react-jsx"
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/render/react/tsconfig.test.json
+++ b/pkg/render/react/tsconfig.test.json
@@ -1,11 +1,21 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
     "noEmit": true,
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"]
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*", "tests/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
 }

--- a/pkg/sdk/bash/tsconfig.json
+++ b/pkg/sdk/bash/tsconfig.json
@@ -1,28 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/sdk": ["../core/src/index.ts"],
-      "@pumped-fn/lite-extension-suspense": ["../../ext/suspense/src/index.ts"],
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/sdk/claude/tsconfig.json
+++ b/pkg/sdk/claude/tsconfig.json
@@ -1,28 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/sdk": ["../core/src/index.ts"],
-      "@pumped-fn/lite-extension-suspense": ["../../ext/suspense/src/index.ts"],
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/sdk/codex/tsconfig.json
+++ b/pkg/sdk/codex/tsconfig.json
@@ -1,28 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/sdk": ["../core/src/index.ts"],
-      "@pumped-fn/lite-extension-suspense": ["../../ext/suspense/src/index.ts"],
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/sdk/core/tsconfig.json
+++ b/pkg/sdk/core/tsconfig.json
@@ -1,27 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/lite-extension-suspense": ["../../ext/suspense/src/index.ts"],
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/sdk/test/tsconfig.json
+++ b/pkg/sdk/test/tsconfig.json
@@ -1,28 +1,20 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022", "DOM"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "../..",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "typeRoots": ["./node_modules/@types", "../../core/lite/node_modules/@types"],
-    "paths": {
-      "@pumped-fn/sdk": ["../core/src/index.ts"],
-      "@pumped-fn/lite-extension-suspense": ["../../ext/suspense/src/index.ts"],
-      "@pumped-fn/lite": ["../../core/lite/src/index.ts"]
-    }
+    "types": [
+      "node"
+    ],
+    "typeRoots": [
+      "./node_modules/@types",
+      "../../core/lite/node_modules/@types"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/sdk/test/tsconfig.test.json
+++ b/pkg/sdk/test/tsconfig.test.json
@@ -1,8 +1,12 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": ".",
     "noEmit": true
   },
-  "include": ["src/**/*", "examples/**/*", "tests/**/*", "vitest.config.ts"]
+  "include": [
+    "src/**/*",
+    "examples/**/*",
+    "tests/**/*",
+    "vitest.config.ts"
+  ]
 }

--- a/pkg/tool/codemod/tsconfig.json
+++ b/pkg/tool/codemod/tsconfig.json
@@ -1,22 +1,16 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/pkg/tool/lint/tsconfig.json
+++ b/pkg/tool/lint/tsconfig.json
@@ -1,22 +1,16 @@
 {
+  "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "lib": ["ES2022"],
-    "types": ["node"],
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "tests"
+  ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,100 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@pumped-fn/codemod": [
+        "./pkg/tool/codemod/src/index.ts"
+      ],
+      "@pumped-fn/lite": [
+        "./pkg/core/lite/src/index.ts"
+      ],
+      "@pumped-fn/lite-extension-logging": [
+        "./pkg/ext/logging/src/index.ts"
+      ],
+      "@pumped-fn/lite-extension-logging-pino": [
+        "./pkg/ext/logging-pino/src/index.ts"
+      ],
+      "@pumped-fn/lite-extension-observable": [
+        "./pkg/ext/observable/src/index.ts"
+      ],
+      "@pumped-fn/lite-extension-observable-otel": [
+        "./pkg/ext/observable-otel/src/index.ts"
+      ],
+      "@pumped-fn/lite-extension-scheduler": [
+        "./pkg/ext/scheduler/src/index.ts"
+      ],
+      "@pumped-fn/lite-extension-scheduler-nats": [
+        "./pkg/ext/scheduler-nats/src/index.ts"
+      ],
+      "@pumped-fn/lite-extension-suspense": [
+        "./pkg/ext/suspense/src/index.ts"
+      ],
+      "@pumped-fn/lite-extension-sync": [
+        "./pkg/ext/sync/src/index.ts"
+      ],
+      "@pumped-fn/lite-extension-sync-nats": [
+        "./pkg/ext/sync-nats/src/index.ts"
+      ],
+      "@pumped-fn/lite-hmr": [
+        "./pkg/ext/hmr/src/index.ts"
+      ],
+      "@pumped-fn/lite-hono": [
+        "./pkg/framework/hono/src/index.ts"
+      ],
+      "@pumped-fn/lite-lint": [
+        "./pkg/tool/lint/src/index.ts"
+      ],
+      "@pumped-fn/lite-react": [
+        "./pkg/react/lite-react/src/index.ts"
+      ],
+      "@pumped-fn/lite-react-json-render": [
+        "./pkg/react/json/src/index.ts"
+      ],
+      "@pumped-fn/lite-render-core": [
+        "./pkg/render/core/src/index.ts"
+      ],
+      "@pumped-fn/lite-render-react": [
+        "./pkg/render/react/src/index.ts"
+      ],
+      "@pumped-fn/lite-tanstack-start": [
+        "./pkg/framework/tanstack-start/src/index.ts"
+      ],
+      "@pumped-fn/pumped": [
+        "./pkg/framework/pumped/src/index.ts"
+      ],
+      "@pumped-fn/sdk": [
+        "./pkg/sdk/core/src/index.ts"
+      ],
+      "@pumped-fn/sdk-claude": [
+        "./pkg/sdk/claude/src/index.ts"
+      ],
+      "@pumped-fn/sdk-codex": [
+        "./pkg/sdk/codex/src/index.ts"
+      ],
+      "@pumped-fn/sdk-just-bash": [
+        "./pkg/sdk/bash/src/index.ts"
+      ],
+      "@pumped-fn/sdk-test": [
+        "./pkg/sdk/test/src/index.ts"
+      ],
+      "@pumped-fn/lite/*": [
+        "./pkg/core/lite/src/*"
+      ]
+    },
+    "noEmit": true,
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Problem

A fresh checkout of the monorepo fails `pnpm -r typecheck` (and shows red in editors) until `pnpm build` runs first — downstream packages resolve `@pumped-fn/lite` and siblings through their built `dist`, which doesn't exist yet. The reported symptom: "quite some type errors" on the branch.

## Fix

Every package `extends` a single root **`tsconfig.base.json`** that carries the shared `compilerOptions` and the full `@pumped-fn/* → src` path map. Consumers resolve siblings to **source**, so typecheck needs no prior build.

**Proof:** `rm -rf pkg/*/dist && pnpm -r typecheck` → **26/26 packages, exit 0**.

## What changed

- One source of truth for compiler options + paths; replaces the per-package `paths` blocks (18 packages had them in N relative spellings; 7 lacked them and were the ones that broke).
- Base is **typecheck-only** (`noEmit`; all 25 packages build with `tsdown`, not `tsc`), so the vestigial `declaration`/`rootDir`/`outDir` that forced rootDir-containment errors are gone.
- `baseUrl` removed (tsgo/TS7 dropped it); path targets are relative (`./pkg/...`).
- `jsx: react-jsx` in the base so a package resolving a React sibling's `.tsx` source compiles it (no-op for non-JSX packages).
- `pkg/ext/hmr` inherited the strict flags it previously lacked; fixed the one latent `process.env['NODE_ENV']` it surfaced.

## Safety

- **Runtime and publish untouched** — `paths` affect only `tsc`/`tsgo`. Node/bundler/publish still resolve via `exports` → `dist`.
- **Vitest resolution unchanged** — the existing `resolve.alias` blocks stay; unifying them via `vite-tsconfig-paths` (so one map feeds both tsc and vitest) is a tightly-scoped follow-up.
- All suites green; lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dxugfz1yqBbeENrm28PNA2