### PR TITLE
feat(observable): parent-link spans so inline ctx.exec nests in OTel

### DIFF
--- a/.changeset/observable-parent-link.md
+++ b/.changeset/observable-parent-link.md
@@ -1,0 +1,8 @@
+---
+"@pumped-fn/lite-extension-observable": minor
+"@pumped-fn/lite-extension-observable-otel": minor
+---
+
+Observable events now carry a `parentId`, and the OTel sink uses it to nest spans. Each traced execution stamps its span id on its execution context; a nested `ctx.exec` (fn-exec or a child flow) reads the nearest traced ancestor's id via `ctx.data.seek`, so the emitted `Event` records `parentId` (undefined at the root). The OTel sink starts each span under its parent's context, so the flow → nested-exec tree is reconstructed correctly.
+
+This makes inline `ctx.exec({ fn, name })` tracing — the recommended way to instrument foreign/IO calls — actually useful in OTel: a query traced inside a flow now shows up nested under that flow instead of flat. Attribution is by the explicitly-threaded execution context (no AsyncLocalStorage), so it is concurrency-safe.

--- a/pkg/ext/observable-otel/src/index.ts
+++ b/pkg/ext/observable-otel/src/index.ts
@@ -1,4 +1,4 @@
-import { SpanStatusCode, trace, type Attributes, type TimeInput } from "@opentelemetry/api"
+import { SpanStatusCode, context, trace, type Attributes, type Context, type Span as OtelSpan, type TimeInput } from "@opentelemetry/api"
 import type { Observable } from "@pumped-fn/lite-extension-observable"
 
 export namespace Otel {
@@ -18,7 +18,8 @@ export namespace Otel {
   export interface Tracer {
     startSpan(
       name: string,
-      options?: { readonly attributes?: Attributes; readonly startTime?: TimeInput }
+      options?: { readonly attributes?: Attributes; readonly startTime?: TimeInput },
+      context?: Context
     ): Span
   }
 
@@ -70,10 +71,14 @@ function start(
 ): void {
   const current = spans.get(event.id)
   if (current) current.end(event.at)
+  const parent = event.parentId ? spans.get(event.parentId) : undefined
+  const parentContext = parent
+    ? trace.setSpan(context.active(), parent as unknown as OtelSpan)
+    : undefined
   spans.set(event.id, tracer.startSpan(spanName(options, event), {
     attributes: spanAttributes(options, event),
     startTime: event.at,
-  }))
+  }, parentContext))
 }
 
 function finish(

--- a/pkg/ext/observable/src/index.ts
+++ b/pkg/ext/observable/src/index.ts
@@ -14,6 +14,7 @@ export namespace Observable {
 
   export interface Event {
     readonly id: string
+    readonly parentId?: string
     readonly phase: Phase
     readonly kind: Kind
     readonly name: string
@@ -90,7 +91,7 @@ function extension(options?: Observable.Options): Lite.Extension {
       const current = event.kind === "resource"
         ? contextRuntime(owners, event.ctx)
         : normalize(rootRuntime(event.scope))
-      return trace(current, event.kind, getResolveName(event), undefined, run)
+      return trace(current, event.kind, getResolveName(event), undefined, run, event.kind === "resource" ? event.ctx : undefined)
     },
     wrapExec: async (run, target, ctx) => {
       return trace(
@@ -98,7 +99,8 @@ function extension(options?: Observable.Options): Lite.Extension {
         getExecKind(target),
         getExecName(target, ctx),
         ctx.input,
-        run
+        run,
+        ctx
       )
     },
     async dispose(scope) {
@@ -178,19 +180,25 @@ export const observable = {
   memory,
 } as const
 
+const spanKey = Symbol("observable.spanId")
+
 async function trace<T>(
   current: ActiveRuntime,
   kind: Observable.Kind,
   name: string,
   input: unknown,
-  run: () => Promise<T>
+  run: () => Promise<T>,
+  ctx?: Lite.ExecutionContext
 ): Promise<T> {
   if (current.sinks.length === 0 || skipped(current, kind)) return run()
 
   const id = current.id()
+  const parentId = ctx?.data.seek(spanKey) as string | undefined
+  ctx?.data.set(spanKey, id)
   const startedAt = current.now()
   const start = withInput(current, {
     id,
+    parentId,
     phase: "start",
     kind,
     name,
@@ -204,6 +212,7 @@ async function trace<T>(
     const at = current.now()
     const success = withOutput(current, {
       id,
+      parentId,
       phase: "success",
       kind,
       name,
@@ -217,6 +226,7 @@ async function trace<T>(
     const at = current.now()
     emit(current, {
       id,
+      parentId,
       phase: "error",
       kind,
       name,

--- a/pkg/ext/observable/tests/observable.test.ts
+++ b/pkg/ext/observable/tests/observable.test.ts
@@ -448,3 +448,32 @@ describe("observable extension", () => {
     expect(captured).toHaveLength(1)
   })
 })
+
+describe("parent linking", () => {
+  it("nested exec spans carry the parent span id (fn-exec under a flow)", async () => {
+    const sink = observable.memory()
+    const outer = flow({
+      name: "outer",
+      factory: async (ctx): Promise<string> => {
+        return ctx.exec({ name: "inner", params: [], fn: () => Promise.resolve("v") })
+      },
+    })
+    const scope = createScope({
+      extensions: [observable.extension()],
+      tags: [observable.runtime({ sinks: [sink] })],
+    })
+    const ctx = scope.createContext()
+
+    await ctx.exec({ flow: outer })
+
+    const starts = sink.events().filter((event) => event.phase === "start")
+    const outerStart = starts.find((event) => event.name === "outer")
+    const innerStart = starts.find((event) => event.name === "inner")
+    expect(outerStart).toBeDefined()
+    expect(innerStart).toBeDefined()
+    expect(outerStart!.parentId).toBeUndefined()
+    expect(innerStart!.parentId).toBe(outerStart!.id)
+
+    await scope.dispose()
+  })
+})


### PR DESCRIPTION
The dividend of the traced-boundary-primitive discovery run: we chose inline `ctx.exec({ fn, name })` over a fluent-tracing proxy for foreign/IO calls — but the observability layer dropped the nesting on the floor, so those inline spans showed up **flat** in OTel instead of under the flow that ran them. This fixes that.

## Change
- `Observable.Event` gains an optional **`parentId`**.
- Each traced execution stamps its span id on its execution context (`ctx.data`, a symbol key). A nested `ctx.exec` (fn-exec or child flow) reads the nearest traced ancestor's id via `ctx.data.seek` and records it as `parentId` (undefined at the root). Attribution is by the explicitly-threaded execution context — **no AsyncLocalStorage** — so it is concurrency-safe.
- The **OTel sink** starts each span under its parent's context (`trace.setSpan`), reconstructing the flow → nested-exec tree.

## Why it matters
Inline `ctx.exec({ fn })` is the endorsed way to instrument a foreign call or a db query (see the traced/serviceValue deprecation). Before this, a query traced inside a flow emitted a span with no parent — the trace was flat and much less useful. Now it nests correctly.

## Verification
`inner.parentId === outer.id` for an fn-exec under a flow (new test); root flow's `parentId` is undefined. 13 observable / 4 otel / 23 example tests; lint 0; workspace typecheck 0. Additive (`parentId` optional) — no breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dxugfz1yqBbeENrm28PNA2