### PR TITLE
test(observable-otel): cover parentId nesting branch — unblock release

### DIFF
--- a/.changeset/otel-coverage-test.md
+++ b/.changeset/otel-coverage-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test-only: cover the observable-otel `parentId` nesting branch (no published behavior change; the parent-link feature is versioned by its own changeset from #325).

--- a/pkg/ext/observable-otel/tests/otel.test.ts
+++ b/pkg/ext/observable-otel/tests/otel.test.ts
@@ -16,8 +16,10 @@ interface RecordedSpan {
 
 function recorder() {
   const spans: RecordedSpan[] = []
+  const contexts: (unknown)[] = []
   const tracer: Otel.Tracer = {
-    startSpan(name, options) {
+    startSpan(name, options, context) {
+      contexts.push(context)
       const record: RecordedSpan = {
         name,
         startTime: options?.startTime,
@@ -47,7 +49,7 @@ function recorder() {
       return span
     },
   }
-  return { spans, tracer }
+  return { spans, tracer, contexts }
 }
 
 function clock(values: readonly number[]): () => number {
@@ -208,5 +210,28 @@ describe("otel sink", () => {
     expect(sink.pending()).toBe(1)
     sink.close?.()
     expect(sink.pending()).toBe(0)
+  })
+
+  it("nests a child span under its parent via parentId", async () => {
+    const recorded = recorder()
+    const sink = otel.sink({ name: "nest", tracer: recorded.tracer })
+    let n = 0
+    const outer = flow({
+      name: "outer",
+      factory: async (ctx): Promise<string> =>
+        ctx.exec({ name: "inner", params: [], fn: () => Promise.resolve("v") }),
+    })
+    const scope = createScope({
+      extensions: [observable.extension()],
+      tags: [observable.runtime({ sinks: [sink], id: () => `s-${n++}` })],
+    })
+
+    await scope.createContext().exec({ flow: outer })
+
+    expect(recorded.spans.map((s) => s.name)).toEqual(["outer", "inner"])
+    expect(recorded.contexts[0]).toBeUndefined()
+    expect(recorded.contexts[1]).toBeDefined()
+
+    await scope.dispose()
   })
 })


### PR DESCRIPTION
#325 merged but its Release run **failed** on `@pumped-fn/lite-extension-observable-otel` branch coverage (95.65% < 100%): the new parent-context path in `start()` (parenting a span by `parentId`) had no test exercising a nested span, so lines 74-75 were uncovered and the changeset never versioned/published.

This adds a nested-flow test (outer flow → inner fn-exec) asserting the child span's `startSpan` receives a parent context and the root span's does not. Branches back to **100% (46/46)**; observable stays 100% (74/74).

Merging this re-runs Release and lets the `observable` + `observable-otel` minors (parent-link feature from #325) version and publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dxugfz1yqBbeENrm28PNA2