### PR TITLE
docs: teaching-register rewrite — docs read like docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Read the comparison: [TypeScript DI without decorators](docs/vs-di-containers.md
 
 ## pumped-fn vs Effect
 
-Use pumped-fn when adoption should stay close to normal `async` TypeScript. Flows return values or promises; streaming flows use async generators only when the result is a stream. Typed faults exist, with the documented caveat that `isFault` narrows by `FlowFault` plus flow name.
+Use pumped-fn when adoption should stay close to normal `async` TypeScript. Flows return values or promises; streaming flows use async generators only when the result is a stream. Typed faults exist, with the documented limit that `isFault` narrows by `FlowFault` plus flow name.
 
 Read the comparison: [pumped-fn vs Effect](docs/vs-effect.md).
 
@@ -182,7 +182,7 @@ Read the checklist: [How to review pumped-fn code](docs/code-review-guide.md).
 
 - [Mental model](docs/mental-model.md)
 - [Test without mocking modules](docs/test-without-mocks.md)
-- [Docs index and caveats](docs/README.md)
+- [Docs index and limits](docs/README.md)
 - [Core runtime README](pkg/core/lite/README.md)
 - [Core patterns](pkg/core/lite/PATTERNS.md)
 - [Anti-pattern scanner](pkg/tool/lint/README.md)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Read the full guide: [OpenTelemetry spans without editing business functions](do
 
 ## TypeScript DI without decorators
 
-pumped-fn is not a decorator container. Imports define graph nodes, dependency records define edges, and a scope materializes one graph with substitutions. Role tags let the root choose an implementation while feature code depends on the role.
+pumped-fn is not a decorator container. Imports define graph units, dependency records define edges, and a scope materializes one graph with substitutions. Role tags let the root choose an implementation while feature code depends on the role.
 
 Read the comparison: [TypeScript DI without decorators](docs/vs-di-containers.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
 # Docs
 
-Start with [Test without mocking modules](test-without-mocks.md) if you want the practical seam first. Start with [Mental model](mental-model.md) if you want the whole shape before picking a guide.
+Start with [Test without mocking modules](test-without-mocks.md) when you want the practical seam first. Start with [Mental model](mental-model.md) when you want the shape of scopes, tags, resources, presets, and extensions before choosing a guide.
 
-These pages cover scopes, explicit request context, observability, incremental adoption, DI shape, code review, and comparison caveats.
+Each page starts with code you can read as the main idea, then explains the parts that matter for production wiring and tests.
 
 ## Pages
 
@@ -19,19 +19,22 @@ These pages cover scopes, explicit request context, observability, incremental a
 
 ## Honest limits
 
-- `isFault` is name-based: it checks `FlowFault` plus the flow name, not object identity ([flow.ts](../pkg/core/lite/src/flow.ts#L260-L290)).
-- Required tag deps are fail-fast during dependency resolution, before the factory gets control; current source does not validate every required tag at `createScope()` construction ([scope.ts](../pkg/core/lite/src/scope.ts#L1055-L1068)).
-- Suspense durable replay rejects streaming flows today ([index.ts](../pkg/ext/suspense/src/index.ts#L101-L128)).
-- These docs make no performance or bundle-size claims beyond zero runtime dependencies and ~12 kB min+gzip.
-- Scheduler NATS is lock-guarded scheduling, not an unconditional single-run guarantee; lease expiry can become at-least-once ([README.md](../pkg/ext/scheduler-nats/README.md#L10-L14)).
-- `pkg/render/*` and `pkg/sdk/claude` are experimental and not covered here ([README.md](../README.md#L190-L192)).
+- `isFault` matches a `FlowFault` plus the flow name, not object identity.
+- Required tag deps fail during dependency resolution, before the unit factory runs — not at `createScope()` construction.
+- Suspense durable replay rejects streaming flows today.
+- Size: zero runtime dependencies, ~12 kB min+gzip. No performance benchmarks are published.
+- Scheduler NATS is lock-guarded scheduling, not an unconditional single-run guarantee; lease expiry can become at-least-once.
+- `pkg/render/*` and `pkg/sdk/claude` are experimental and not covered here.
 
-## Proven in the source
+## Source
 
-- Scope seam: [README.md:8-17](../README.md#L8-L17), [README.md:101-103](../README.md#L101-L103), [pkg/core/lite/src/types.ts:78-83](../pkg/core/lite/src/types.ts#L78-L83), [pkg/core/lite/src/scope.ts:441-456](../pkg/core/lite/src/scope.ts#L441-L456).
-- Dependency classification: [pkg/core/lite/src/deps-graph.ts:5-12](../pkg/core/lite/src/deps-graph.ts#L5-L12), [pkg/core/lite/src/deps-graph.ts:16-49](../pkg/core/lite/src/deps-graph.ts#L16-L49).
-- Extension wrappers: [pkg/core/lite/src/types.ts:500-520](../pkg/core/lite/src/types.ts#L500-L520), [pkg/core/lite/src/scope.ts:948-960](../pkg/core/lite/src/scope.ts#L948-L960), [pkg/core/lite/src/scope.ts:2377-2390](../pkg/core/lite/src/scope.ts#L2377-L2390).
-- Plain flow factories and streams: [pkg/core/lite/src/flow.ts:146-212](../pkg/core/lite/src/flow.ts#L146-L212), [pkg/core/lite/src/types.ts:586-594](../pkg/core/lite/src/types.ts#L586-L594), [pkg/core/lite/tests/exec-stream.test.ts:12-30](../pkg/core/lite/tests/exec-stream.test.ts#L12-L30).
-- Required tag timing: [pkg/core/lite/tests/scope.test.ts:1434-1465](../pkg/core/lite/tests/scope.test.ts#L1434-L1465).
-- Suspense streaming rejection: [pkg/ext/suspense/tests/streaming.test.ts:44-70](../pkg/ext/suspense/tests/streaming.test.ts#L44-L70).
-- Scheduler NATS at-least-once boundary: [pkg/ext/scheduler-nats/README.md:37-55](../pkg/ext/scheduler-nats/README.md#L37-L55), [pkg/ext/scheduler-nats/src/index.ts:47-60](../pkg/ext/scheduler-nats/src/index.ts#L47-L60), [pkg/ext/scheduler-nats/src/index.ts:122-150](../pkg/ext/scheduler-nats/src/index.ts#L122-L150).
+- [Core README](../README.md)
+- [Lite flow faults](../pkg/core/lite/src/flow.ts)
+- [Lite scope](../pkg/core/lite/src/scope.ts)
+- [Suspense extension](../pkg/ext/suspense/src/index.ts)
+- [Scheduler NATS README](../pkg/ext/scheduler-nats/README.md)
+
+## Next
+
+- [Test without mocking modules](test-without-mocks.md)
+- [Mental model](mental-model.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,50 +1,37 @@
 # Docs
 
-These pages are the repo-first content set for pumped-fn. They are meant to render on GitHub first; a docs-site build can use the same files later.
+Start with [Test without mocking modules](test-without-mocks.md) if you want the practical seam first. Start with [Mental model](mental-model.md) if you want the whole shape before picking a guide.
 
-## Spine
-
-Scope is the differentiator: application roots and tests call `createScope({ presets, tags, extensions })`, product units declare atoms, flows, resources, tags, and extensions, and tests change behavior with presets instead of module interception. Evidence: `[README.md:8-17](../README.md#L8-L17)`, `[README.md:101-103](../README.md#L101-L103)`, `[pkg/core/lite/src/types.ts:78-83](../pkg/core/lite/src/types.ts#L78-L83)`, `[pkg/core/lite/src/scope.ts:441-456](../pkg/core/lite/src/scope.ts#L441-L456)`.
-
-Graph is the mechanism: dependency records are classified as atoms, flows, controllers, tag executors, and resources. Evidence: `[pkg/core/lite/src/deps-graph.ts:5-12](../pkg/core/lite/src/deps-graph.ts#L5-L12)`, `[pkg/core/lite/src/deps-graph.ts:16-49](../pkg/core/lite/src/deps-graph.ts#L16-L49)`.
-
-Extensions are the trace pipeline: `wrapResolve` wraps atom/resource resolution and `wrapExec` wraps flow/function execution. Evidence: `[pkg/core/lite/src/types.ts:500-520](../pkg/core/lite/src/types.ts#L500-L520)`, `[pkg/core/lite/src/scope.ts:948-960](../pkg/core/lite/src/scope.ts#L948-L960)`, `[pkg/core/lite/src/scope.ts:2377-2390](../pkg/core/lite/src/scope.ts#L2377-L2390)`.
-
-Product code stays plain: scalar flow factories are normal functions returning `MaybePromise<Output>`, and streaming flow factories are async generators only when the flow streams. Evidence: `[pkg/core/lite/src/flow.ts:146-212](../pkg/core/lite/src/flow.ts#L146-L212)`, `[pkg/core/lite/src/types.ts:586-594](../pkg/core/lite/src/types.ts#L586-L594)`, `[pkg/core/lite/tests/exec-stream.test.ts:12-30](../pkg/core/lite/tests/exec-stream.test.ts#L12-L30)`.
-
-## Mandatory Caveats
-
-`isFault` is name-based: it checks `FlowFault` plus the flow name, not object identity. Evidence: `[pkg/core/lite/src/flow.ts:260-290](../pkg/core/lite/src/flow.ts#L260-L290)`.
-
-Required tag deps are fail-fast during dependency resolution, before the factory gets control; current source does not validate every required tag at `createScope()` construction. Evidence: `[pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068)`, `[pkg/core/lite/tests/scope.test.ts:1434-1465](../pkg/core/lite/tests/scope.test.ts#L1434-L1465)`.
-
-Suspense durable replay rejects streaming flows today. Evidence: `[pkg/ext/suspense/src/index.ts:101-128](../pkg/ext/suspense/src/index.ts#L101-L128)`, `[pkg/ext/suspense/tests/streaming.test.ts:44-70](../pkg/ext/suspense/tests/streaming.test.ts#L44-L70)`.
-
-Do not publish performance or bundle-size numbers from these pages. This content includes no numeric performance or bundle-size claim.
-
-Scheduler NATS is lock-guarded scheduling, not an unconditional single-run guarantee. The package README limits the guarantee to completion before `lockTtlMs` and says lease expiry can become at-least-once. Evidence: `[pkg/ext/scheduler-nats/README.md:10-14](../pkg/ext/scheduler-nats/README.md#L10-L14)`, `[pkg/ext/scheduler-nats/README.md:37-55](../pkg/ext/scheduler-nats/README.md#L37-L55)`, `[pkg/ext/scheduler-nats/src/index.ts:47-60](../pkg/ext/scheduler-nats/src/index.ts#L47-L60)`, `[pkg/ext/scheduler-nats/src/index.ts:122-150](../pkg/ext/scheduler-nats/src/index.ts#L122-L150)`.
-
-`pkg/render/*` and `pkg/sdk/claude` are sitemap hints only in this run. Do not author pages that claim maturity for them here. The README names them only as experimental packages. Evidence: `[README.md:190-192](../README.md#L190-L192)`.
+These pages cover scopes, explicit request context, observability, incremental adoption, DI shape, code review, and comparison caveats.
 
 ## Pages
 
-| Page | Reader Question | Pillar | Entry Arena / Query Family |
-| --- | --- | --- | --- |
-| [test-without-mocks](test-without-mocks.md) | How do I test TypeScript code without `vi.mock`? | Fully testable | `test without mocking modules`, `vi.mock alternative` |
-| [vs-effect](vs-effect.md) | Should I use pumped-fn instead of Effect for DI and typed errors? | Readability without losing test/trace seams | First-party comparison |
-| [vs-di-containers](vs-di-containers.md) | TypeScript DI without decorators: why use pumped-fn instead of a container? | Graph mechanism | DI hub, container comparison |
-| [mental-model](mental-model.md) | What is the pumped-fn mental model? | Scope plus graph | All entry pages |
-| [code-review-guide](code-review-guide.md) | How do I review pumped-fn code? | Testable and traceable code review | LLM/code-review guide |
-| [adopt-incrementally](adopt-incrementally.md) | Can I adopt pumped-fn one route at a time in my existing server? | Readability during adoption | Incremental backend adoption |
-| [observability](observability.md) | How do I get OpenTelemetry spans without editing business functions? | Fully traceable/observable | OTel, instrumentation |
-| [request-context-without-als](request-context-without-als.md) | Why is AsyncLocalStorage `getStore()` undefined, and what should I use instead? | Explicit request context | ALS long-tail |
+| Page | What it answers |
+| --- | --- |
+| [Test without mocking modules](test-without-mocks.md) | How do I test TypeScript code that hits DB, LLM, clock, or fetch without mocking modules? |
+| [Mental model](mental-model.md) | What are scopes, dependency records, dependencies, and effects? |
+| [Request context without AsyncLocalStorage](request-context-without-als.md) | Why is `AsyncLocalStorage.getStore()` undefined, and what should I use instead? |
+| [OpenTelemetry spans without editing business functions](observability.md) | How do I get spans without putting instrumentation inside each function? |
+| [Adopt one route at a time](adopt-incrementally.md) | Can I keep my server and move one route at a time? |
+| [TypeScript DI without decorators](vs-di-containers.md) | Why use pumped-fn instead of a decorator container? |
+| [pumped-fn vs Effect](vs-effect.md) | Can I get a typed DI/test seam and typed errors without adopting an Effect runtime? |
+| [Code review guide](code-review-guide.md) | What should I flag in a pumped-fn PR? |
 
-## Future Sections Not Authored Now
+## Honest limits
 
-| Section | Status | Reason |
-| --- | --- | --- |
-| Playground | Not authored | Decision pending DKR-3. |
-| API reference | Not authored | Should be generated or source-derived from public exports. |
-| Package lane pages | Not authored | Current run is entry architecture, not a package dump. |
-| Render pages | Hint only | Package exists, but no maturity claim in this run. |
-| sdk-claude page | Hint only | Package exists, but no maturity claim in this run. |
+- `isFault` is name-based: it checks `FlowFault` plus the flow name, not object identity ([flow.ts](../pkg/core/lite/src/flow.ts#L260-L290)).
+- Required tag deps are fail-fast during dependency resolution, before the factory gets control; current source does not validate every required tag at `createScope()` construction ([scope.ts](../pkg/core/lite/src/scope.ts#L1055-L1068)).
+- Suspense durable replay rejects streaming flows today ([index.ts](../pkg/ext/suspense/src/index.ts#L101-L128)).
+- These docs make no performance or bundle-size claims beyond zero runtime dependencies and ~12 kB min+gzip.
+- Scheduler NATS is lock-guarded scheduling, not an unconditional single-run guarantee; lease expiry can become at-least-once ([README.md](../pkg/ext/scheduler-nats/README.md#L10-L14)).
+- `pkg/render/*` and `pkg/sdk/claude` are experimental and not covered here ([README.md](../README.md#L190-L192)).
+
+## Proven in the source
+
+- Scope seam: [README.md:8-17](../README.md#L8-L17), [README.md:101-103](../README.md#L101-L103), [pkg/core/lite/src/types.ts:78-83](../pkg/core/lite/src/types.ts#L78-L83), [pkg/core/lite/src/scope.ts:441-456](../pkg/core/lite/src/scope.ts#L441-L456).
+- Dependency classification: [pkg/core/lite/src/deps-graph.ts:5-12](../pkg/core/lite/src/deps-graph.ts#L5-L12), [pkg/core/lite/src/deps-graph.ts:16-49](../pkg/core/lite/src/deps-graph.ts#L16-L49).
+- Extension wrappers: [pkg/core/lite/src/types.ts:500-520](../pkg/core/lite/src/types.ts#L500-L520), [pkg/core/lite/src/scope.ts:948-960](../pkg/core/lite/src/scope.ts#L948-L960), [pkg/core/lite/src/scope.ts:2377-2390](../pkg/core/lite/src/scope.ts#L2377-L2390).
+- Plain flow factories and streams: [pkg/core/lite/src/flow.ts:146-212](../pkg/core/lite/src/flow.ts#L146-L212), [pkg/core/lite/src/types.ts:586-594](../pkg/core/lite/src/types.ts#L586-L594), [pkg/core/lite/tests/exec-stream.test.ts:12-30](../pkg/core/lite/tests/exec-stream.test.ts#L12-L30).
+- Required tag timing: [pkg/core/lite/tests/scope.test.ts:1434-1465](../pkg/core/lite/tests/scope.test.ts#L1434-L1465).
+- Suspense streaming rejection: [pkg/ext/suspense/tests/streaming.test.ts:44-70](../pkg/ext/suspense/tests/streaming.test.ts#L44-L70).
+- Scheduler NATS at-least-once boundary: [pkg/ext/scheduler-nats/README.md:37-55](../pkg/ext/scheduler-nats/README.md#L37-L55), [pkg/ext/scheduler-nats/src/index.ts:47-60](../pkg/ext/scheduler-nats/src/index.ts#L47-L60), [pkg/ext/scheduler-nats/src/index.ts:122-150](../pkg/ext/scheduler-nats/src/index.ts#L122-L150).

--- a/docs/adopt-incrementally.md
+++ b/docs/adopt-incrementally.md
@@ -1,8 +1,6 @@
 # Can I adopt pumped-fn one route at a time in my existing server?
 
-Pattern shown with a plain handler and Hono; Express/Nest examples pending.
-
-Start at one composition boundary. Keep the existing server. Create or reuse a scope in the route module, create one execution context for the request, pass request facts as tags, and execute one flow.
+Yes. Start at one composition boundary and leave the rest of the server alone.
 
 ```ts
 import { createScope, flow, tag, tags, typed } from "@pumped-fn/lite"
@@ -35,7 +33,11 @@ export async function handleUser(request: Request): Promise<Response> {
 }
 ```
 
-Use the Hono adapter as the template for framework integration:
+The route owns the request context. It seeds request facts as tags, runs one flow, and closes the context in `finally`.
+
+> **Note:** Express and Nest examples are not covered here yet. This page shows a plain handler and Hono.
+
+If you are using Hono, put the adapter on the scope and let middleware create the context for each request.
 
 ```ts
 import { Hono } from "hono"
@@ -73,9 +75,9 @@ export async function closeApp(): Promise<void> {
 }
 ```
 
-## Phase 2: Move One Leaf Dependency At A Time
+The adapter keeps the app scope in the extension, writes the request execution context to `context.var`, and closes it after request handling. Application scope construction still belongs to your composition root.
 
-Start by adding an atom beside the old module singleton. Existing consumers keep importing the old function. New graph consumers depend on the atom. Tests or new roots can preset that atom without changing the legacy export.
+## Move One Leaf
 
 ```ts
 import { atom, createScope, flow, preset, typed } from "@pumped-fn/lite"
@@ -141,24 +143,26 @@ export async function testRoute(id: string): Promise<{ id: string } | undefined>
 }
 ```
 
+Add an atom beside the old module singleton first. Existing callers can keep importing the old function, while new graph code depends on the atom. Tests and new roots can preset that atom without changing the legacy export.
+
 Then repeat with the next leaf dependency. The route boundary does not have to move again; each leaf moves when a graph consumer needs it.
 
-## Proven in the source
+## Keep The Boundary Thin
 
-- Framework packages do not own application scope construction; adapters install through `createScope({ extensions })` and pass execution contexts through framework-native surfaces: [pkg/framework/README.md:3-11](../pkg/framework/README.md#L3-L11).
+Create scopes, root contexts, route mounts, job mounts, and disposal at composition roots. Keep feature units declared in the graph, or keep helpers pure and call them from declared graph units.
 
-- The Hono adapter stores the scope during extension init, creates a request execution context in middleware, writes it to `context.var`, and closes it after request handling: [pkg/framework/hono/src/index.ts:41-76](../pkg/framework/hono/src/index.ts#L41-L76).
+Avoid shared scope factories, global registries, framework-shaped copies of Lite primitives, public helpers that accept `scope`, and hidden framework request reads inside units. Those shapes make the seam harder to test and harder to replace one route at a time.
 
-- The Hono test creates one execution context per request and injects `requestId` from headers through tags: [pkg/framework/hono/tests/hono.test.ts:22-80](../pkg/framework/hono/tests/hono.test.ts#L22-L80).
+## Source
 
-- Framework rules reject shared scope factories, global registries, framework-shaped copies of Lite primitives, public helpers accepting `scope`, and hidden framework request reads inside units: [pkg/framework/README.md:18-27](../pkg/framework/README.md#L18-L27).
+- [Framework package rules](../pkg/framework/README.md)
+- [Hono adapter](../pkg/framework/hono/src/index.ts)
+- [Hono adapter tests](../pkg/framework/hono/tests/hono.test.ts)
+- [Lite README boundary rules](../pkg/core/lite/README.md)
+- [Preset API](../pkg/core/lite/src/preset.ts)
+- [Scope implementation](../pkg/core/lite/src/scope.ts)
 
-- Composition roots should create scopes, root contexts, route/job mounts, and disposal; feature units should stay declared in the graph or stay pure helpers called by declared graph units: [pkg/core/lite/README.md:38-48](../pkg/core/lite/README.md#L38-L48), [README.md:129-133](../README.md#L129-L133).
+## Next
 
-- The incremental leaf-dependency snippet uses the repo-exported `atom`, `flow`, `typed`, `preset`, and `createScope` APIs: [pkg/core/lite/src/index.ts:17-21](../pkg/core/lite/src/index.ts#L17-L21), [pkg/core/lite/src/atom.ts:29-44](../pkg/core/lite/src/atom.ts#L29-L44), [pkg/core/lite/src/flow.ts:18-20](../pkg/core/lite/src/flow.ts#L18-L20), [pkg/core/lite/src/flow.ts:200-212](../pkg/core/lite/src/flow.ts#L200-L212), [pkg/core/lite/src/preset.ts:25-28](../pkg/core/lite/src/preset.ts#L25-L28), [pkg/core/lite/src/scope.ts:2452-2478](../pkg/core/lite/src/scope.ts#L2452-L2478).
-
-- Scope presets are stored on scope construction and atom preset values are returned during atom resolution: [pkg/core/lite/src/scope.ts:441-449](../pkg/core/lite/src/scope.ts#L441-L449), [pkg/core/lite/src/scope.ts:819-853](../pkg/core/lite/src/scope.ts#L819-L853).
-
-- Execution contexts are created from scopes and execute flows through `ctx.exec({ flow, input })`: [pkg/core/lite/src/scope.ts:1814-1842](../pkg/core/lite/src/scope.ts#L1814-L1842), [pkg/core/lite/src/types.ts:233-245](../pkg/core/lite/src/types.ts#L233-L245), [pkg/core/lite/src/scope.ts:2084-2101](../pkg/core/lite/src/scope.ts#L2084-L2101).
-
-Express and Nest examples are not yet covered here. This page covers a plain handler and Hono.
+- [Request context without AsyncLocalStorage](request-context-without-als.md)
+- [Test without mocking modules](test-without-mocks.md)

--- a/docs/adopt-incrementally.md
+++ b/docs/adopt-incrementally.md
@@ -1,11 +1,5 @@
 # Can I adopt pumped-fn one route at a time in my existing server?
 
-Reader question: "Can I keep my server and move one route at a time?"
-
-Pillar proven: readability during adoption.
-
-Entry arena: incremental backend adoption, DI hub support.
-
 Pattern shown with a plain handler and Hono; Express/Nest examples pending.
 
 Start at one composition boundary. Keep the existing server. Create or reuse a scope in the route module, create one execution context for the request, pass request facts as tags, and execute one flow.
@@ -149,22 +143,22 @@ export async function testRoute(id: string): Promise<{ id: string } | undefined>
 
 Then repeat with the next leaf dependency. The route boundary does not have to move again; each leaf moves when a graph consumer needs it.
 
-## Claim -> Citation
+## Proven in the source
 
-Framework packages do not own application scope construction; adapters install through `createScope({ extensions })` and pass execution contexts through framework-native surfaces: `[pkg/framework/README.md:3-11](../pkg/framework/README.md#L3-L11)`.
+- Framework packages do not own application scope construction; adapters install through `createScope({ extensions })` and pass execution contexts through framework-native surfaces: [pkg/framework/README.md:3-11](../pkg/framework/README.md#L3-L11).
 
-The Hono adapter stores the scope during extension init, creates a request execution context in middleware, writes it to `context.var`, and closes it after request handling: `[pkg/framework/hono/src/index.ts:41-76](../pkg/framework/hono/src/index.ts#L41-L76)`.
+- The Hono adapter stores the scope during extension init, creates a request execution context in middleware, writes it to `context.var`, and closes it after request handling: [pkg/framework/hono/src/index.ts:41-76](../pkg/framework/hono/src/index.ts#L41-L76).
 
-The Hono test creates one execution context per request and injects `requestId` from headers through tags: `[pkg/framework/hono/tests/hono.test.ts:22-80](../pkg/framework/hono/tests/hono.test.ts#L22-L80)`.
+- The Hono test creates one execution context per request and injects `requestId` from headers through tags: [pkg/framework/hono/tests/hono.test.ts:22-80](../pkg/framework/hono/tests/hono.test.ts#L22-L80).
 
-Framework rules reject shared scope factories, global registries, framework-shaped copies of Lite primitives, public helpers accepting `scope`, and hidden framework request reads inside units: `[pkg/framework/README.md:18-27](../pkg/framework/README.md#L18-L27)`.
+- Framework rules reject shared scope factories, global registries, framework-shaped copies of Lite primitives, public helpers accepting `scope`, and hidden framework request reads inside units: [pkg/framework/README.md:18-27](../pkg/framework/README.md#L18-L27).
 
-Composition roots should create scopes, root contexts, route/job mounts, and disposal; feature units should stay graph nodes or pure helpers called by graph nodes: `[pkg/core/lite/README.md:38-48](../pkg/core/lite/README.md#L38-L48)`, `[README.md:129-133](../README.md#L129-L133)`.
+- Composition roots should create scopes, root contexts, route/job mounts, and disposal; feature units should stay declared in the graph or stay pure helpers called by declared graph units: [pkg/core/lite/README.md:38-48](../pkg/core/lite/README.md#L38-L48), [README.md:129-133](../README.md#L129-L133).
 
-The incremental leaf-dependency snippet uses the repo-exported `atom`, `flow`, `typed`, `preset`, and `createScope` APIs: `[pkg/core/lite/src/index.ts:17-21](../pkg/core/lite/src/index.ts#L17-L21)`, `[pkg/core/lite/src/atom.ts:29-44](../pkg/core/lite/src/atom.ts#L29-L44)`, `[pkg/core/lite/src/flow.ts:18-20](../pkg/core/lite/src/flow.ts#L18-L20)`, `[pkg/core/lite/src/flow.ts:200-212](../pkg/core/lite/src/flow.ts#L200-L212)`, `[pkg/core/lite/src/preset.ts:25-28](../pkg/core/lite/src/preset.ts#L25-L28)`, `[pkg/core/lite/src/scope.ts:2452-2478](../pkg/core/lite/src/scope.ts#L2452-L2478)`.
+- The incremental leaf-dependency snippet uses the repo-exported `atom`, `flow`, `typed`, `preset`, and `createScope` APIs: [pkg/core/lite/src/index.ts:17-21](../pkg/core/lite/src/index.ts#L17-L21), [pkg/core/lite/src/atom.ts:29-44](../pkg/core/lite/src/atom.ts#L29-L44), [pkg/core/lite/src/flow.ts:18-20](../pkg/core/lite/src/flow.ts#L18-L20), [pkg/core/lite/src/flow.ts:200-212](../pkg/core/lite/src/flow.ts#L200-L212), [pkg/core/lite/src/preset.ts:25-28](../pkg/core/lite/src/preset.ts#L25-L28), [pkg/core/lite/src/scope.ts:2452-2478](../pkg/core/lite/src/scope.ts#L2452-L2478).
 
-Scope presets are stored on scope construction and atom preset values are returned during atom resolution: `[pkg/core/lite/src/scope.ts:441-449](../pkg/core/lite/src/scope.ts#L441-L449)`, `[pkg/core/lite/src/scope.ts:819-853](../pkg/core/lite/src/scope.ts#L819-L853)`.
+- Scope presets are stored on scope construction and atom preset values are returned during atom resolution: [pkg/core/lite/src/scope.ts:441-449](../pkg/core/lite/src/scope.ts#L441-L449), [pkg/core/lite/src/scope.ts:819-853](../pkg/core/lite/src/scope.ts#L819-L853).
 
-Execution contexts are created from scopes and execute flows through `ctx.exec({ flow, input })`: `[pkg/core/lite/src/scope.ts:1814-1842](../pkg/core/lite/src/scope.ts#L1814-L1842)`, `[pkg/core/lite/src/types.ts:233-245](../pkg/core/lite/src/types.ts#L233-L245)`, `[pkg/core/lite/src/scope.ts:2084-2101](../pkg/core/lite/src/scope.ts#L2084-L2101)`.
+- Execution contexts are created from scopes and execute flows through `ctx.exec({ flow, input })`: [pkg/core/lite/src/scope.ts:1814-1842](../pkg/core/lite/src/scope.ts#L1814-L1842), [pkg/core/lite/src/types.ts:233-245](../pkg/core/lite/src/types.ts#L233-L245), [pkg/core/lite/src/scope.ts:2084-2101](../pkg/core/lite/src/scope.ts#L2084-L2101).
 
-External Express and Nest examples need framework-specific citations before publication. Pattern shown with a plain handler and Hono; Express/Nest examples pending.
+Express and Nest examples are not yet covered here. This page covers a plain handler and Hono.

--- a/docs/code-review-guide.md
+++ b/docs/code-review-guide.md
@@ -1,11 +1,5 @@
 # How do I review pumped-fn code?
 
-Reader question: "What should I flag in a pumped-fn PR?"
-
-Pillar proven: fully testable and fully traceable.
-
-Entry arena: code-review guide for humans and LLMs.
-
 ## Review Rules
 
 | If You See | Flag | Fix |
@@ -68,16 +62,16 @@ await ctx.close()
 await scope.dispose()
 ```
 
-## Claim -> Citation
+## Proven in the source
 
-The boundary checklist says scope is owned at composition/test boundaries, raw IO belongs in transport atoms, and composition roots stay thin: `[pkg/core/lite/PATTERNS.md:5-19](../pkg/core/lite/PATTERNS.md#L5-L19)`.
+- The boundary checklist says scope is owned at composition/test boundaries, raw IO belongs in transport atoms, and composition roots stay thin: [pkg/core/lite/PATTERNS.md:5-19](../pkg/core/lite/PATTERNS.md#L5-L19).
 
-The README says a test needing module mocks, global patches above raw transport wrappers, internal reaches, or test-only product branches means the boundary leaked: `[pkg/core/lite/README.md:38-48](../pkg/core/lite/README.md#L38-L48)`.
+- The README says a test needing module mocks, global patches above raw transport wrappers, internal reaches, or test-only product branches means the boundary leaked: [pkg/core/lite/README.md:38-48](../pkg/core/lite/README.md#L38-L48).
 
-The lint rule list covers module mocks, shared scope factories, helpers accepting scope, scope reach, naked globals, implicit tag reads, module state, unattributed awaits, and swallowed errors: `[pkg/tool/lint/README.md:23-48](../pkg/tool/lint/README.md#L23-L48)`.
+- The lint rule list covers module mocks, shared scope factories, helpers accepting scope, scope reach, naked globals, implicit tag reads, module state, unattributed awaits, and swallowed errors: [pkg/tool/lint/README.md:23-48](../pkg/tool/lint/README.md#L23-L48).
 
-The rule implementation includes `pumped/no-module-mocks`, `pumped/no-naked-globals`, `pumped/no-shared-scope-factory`, `pumped/no-scope-argument`, and `pumped/no-unattributed-await`: `[pkg/tool/lint/src/index.ts:5-29](../pkg/tool/lint/src/index.ts#L5-L29)`, `[pkg/tool/lint/src/index.ts:1160-1179](../pkg/tool/lint/src/index.ts#L1160-L1179)`, `[pkg/tool/lint/src/index.ts:1389-1464](../pkg/tool/lint/src/index.ts#L1389-L1464)`, `[pkg/tool/lint/src/index.ts:1591-1660](../pkg/tool/lint/src/index.ts#L1591-L1660)`.
+- The rule implementation includes `pumped/no-module-mocks`, `pumped/no-naked-globals`, `pumped/no-shared-scope-factory`, `pumped/no-scope-argument`, and `pumped/no-unattributed-await`: [pkg/tool/lint/src/index.ts:5-29](../pkg/tool/lint/src/index.ts#L5-L29), [pkg/tool/lint/src/index.ts:1160-1179](../pkg/tool/lint/src/index.ts#L1160-L1179), [pkg/tool/lint/src/index.ts:1389-1464](../pkg/tool/lint/src/index.ts#L1389-L1464), [pkg/tool/lint/src/index.ts:1591-1660](../pkg/tool/lint/src/index.ts#L1591-L1660).
 
-Foreign calls should be adapter atoms plus `ctx.exec({ fn, name, tags })` so the call is named and taggable: `[pkg/core/lite/PATTERNS.md:19-19](../pkg/core/lite/PATTERNS.md#L19-L19)`, `[examples/invoice-triage/src/flows.ts:260-262](../examples/invoice-triage/src/flows.ts#L260-L262)`.
+- Foreign calls should be adapter atoms plus `ctx.exec({ fn, name, tags })` so the call is named and taggable: [pkg/core/lite/PATTERNS.md:19-19](../pkg/core/lite/PATTERNS.md#L19-L19), [examples/invoice-triage/src/flows.ts:260-262](../examples/invoice-triage/src/flows.ts#L260-L262).
 
-Do not use this guide as a substitute for running `@pumped-fn/lite-lint`; the scanner exposes diagnostics through `scanPaths` and `scanText`: `[pkg/tool/lint/README.md:88-95](../pkg/tool/lint/README.md#L88-L95)`.
+- This guide does not replace `@pumped-fn/lite-lint`; the scanner exposes diagnostics through `scanPaths` and `scanText`: [pkg/tool/lint/README.md:88-95](../pkg/tool/lint/README.md#L88-L95).

--- a/docs/code-review-guide.md
+++ b/docs/code-review-guide.md
@@ -1,16 +1,6 @@
 # How do I review pumped-fn code?
 
-## Review Rules
-
-| If You See | Flag | Fix |
-| --- | --- | --- |
-| `new Date()`, `Date.now()`, `Math.random()`, `process.env`, `fetch`, timers, or raw platform modules inside a factory | Hidden side effect | Move it to a tag, transport atom, resource, or composition root |
-| Module-level DB/client singleton used by a flow | Unsubstitutable edge | Wrap the client in an atom and preset that atom in tests |
-| Exported shared scope or helper that accepts `scope` | Service-locator shape | Create scopes at composition roots and run flows through contexts |
-| Child flow called through hidden same-file `ctx.exec({ flow })` | Invisible graph edge | Put child flow in `deps`, usually with `controller(child)` |
-| Awaited foreign call on a dep without `ctx.exec({ fn, name })` or a workflow step tag | Unattributed effect | Give the call a named execution edge |
-
-Bad shape:
+Start by looking for edges the graph cannot see. This shape hides the DB client and the clock from the scope seam.
 
 ```ts
 import { flow, typed } from "@pumped-fn/lite"
@@ -25,7 +15,7 @@ const save = flow({
 })
 ```
 
-Good shape:
+Move those edges into declared dependencies. Now the clock is a tag, the client is an atom, and a test or composition root can replace either one.
 
 ```ts
 import { atom, createScope, flow, tag, tags, typed } from "@pumped-fn/lite"
@@ -62,16 +52,31 @@ await ctx.close()
 await scope.dispose()
 ```
 
-## Proven in the source
+That is the review move: find the uncontrolled edge, then ask where the graph should see it.
 
-- The boundary checklist says scope is owned at composition/test boundaries, raw IO belongs in transport atoms, and composition roots stay thin: [pkg/core/lite/PATTERNS.md:5-19](../pkg/core/lite/PATTERNS.md#L5-L19).
+## Review Rules
 
-- The README says a test needing module mocks, global patches above raw transport wrappers, internal reaches, or test-only product branches means the boundary leaked: [pkg/core/lite/README.md:38-48](../pkg/core/lite/README.md#L38-L48).
+| If You See | Flag | Fix |
+| --- | --- | --- |
+| `new Date()`, `Date.now()`, `Math.random()`, `process.env`, `fetch`, timers, or raw platform modules inside a factory | Hidden side effect | Move it to a tag, transport atom, resource, or composition root |
+| Module-level DB/client singleton used by a flow | Unsubstitutable edge | Wrap the client in an atom and preset that atom in tests |
+| Exported shared scope or helper that accepts `scope` | Service-locator shape | Create scopes at composition roots and run flows through contexts |
+| Child flow called through hidden same-file `ctx.exec({ flow })` | Invisible graph edge | Put child flow in `deps`, usually with `controller(child)` |
+| Awaited foreign call on a dep without `ctx.exec({ fn, name })` or a workflow step tag | Unattributed effect | Give the call a named execution edge |
 
-- The lint rule list covers module mocks, shared scope factories, helpers accepting scope, scope reach, naked globals, implicit tag reads, module state, unattributed awaits, and swallowed errors: [pkg/tool/lint/README.md:23-48](../pkg/tool/lint/README.md#L23-L48).
+For foreign SDK calls, prefer an adapter atom plus `ctx.exec({ fn, name, tags })`. That gives tracing and workflow tags a named edge instead of an anonymous promise.
 
-- The rule implementation includes `pumped/no-module-mocks`, `pumped/no-naked-globals`, `pumped/no-shared-scope-factory`, `pumped/no-scope-argument`, and `pumped/no-unattributed-await`: [pkg/tool/lint/src/index.ts:5-29](../pkg/tool/lint/src/index.ts#L5-L29), [pkg/tool/lint/src/index.ts:1160-1179](../pkg/tool/lint/src/index.ts#L1160-L1179), [pkg/tool/lint/src/index.ts:1389-1464](../pkg/tool/lint/src/index.ts#L1389-L1464), [pkg/tool/lint/src/index.ts:1591-1660](../pkg/tool/lint/src/index.ts#L1591-L1660).
+> **Note:** This guide does not replace `@pumped-fn/lite-lint`. Use the scanner too; it exposes diagnostics through `scanPaths` and `scanText`.
 
-- Foreign calls should be adapter atoms plus `ctx.exec({ fn, name, tags })` so the call is named and taggable: [pkg/core/lite/PATTERNS.md:19-19](../pkg/core/lite/PATTERNS.md#L19-L19), [examples/invoice-triage/src/flows.ts:260-262](../examples/invoice-triage/src/flows.ts#L260-L262).
+## Source
 
-- This guide does not replace `@pumped-fn/lite-lint`; the scanner exposes diagnostics through `scanPaths` and `scanText`: [pkg/tool/lint/README.md:88-95](../pkg/tool/lint/README.md#L88-L95).
+- [Lite patterns](../pkg/core/lite/PATTERNS.md)
+- [Lite README testing boundary](../pkg/core/lite/README.md)
+- [Lint rule list](../pkg/tool/lint/README.md)
+- [Lint implementation](../pkg/tool/lint/src/index.ts)
+- [Invoice triage flow edges](../examples/invoice-triage/src/flows.ts)
+
+## Next
+
+- [Test without mocking modules](test-without-mocks.md)
+- [Mental model](mental-model.md)

--- a/docs/mental-model.md
+++ b/docs/mental-model.md
@@ -1,11 +1,5 @@
 # What is the pumped-fn mental model?
 
-Reader question: "What are scope, graph nodes, dependencies, and effects?"
-
-Pillar proven: scope keeps testability, traceability, and readability tied together.
-
-Entry arena: supports all entry pages.
-
 ```text
 composition root
   createScope({ presets, tags, extensions })
@@ -71,20 +65,30 @@ await scope.dispose()
 
 ## Dependency Kinds
 
-| Kind | Meaning | Citation |
-| --- | --- | --- |
-| Static graph deps | Atoms, flows, controllers, and resources declared in `deps` | `[pkg/core/lite/src/deps-graph.ts:5-12](../pkg/core/lite/src/deps-graph.ts#L5-L12)`, `[pkg/core/lite/src/types.ts:530-555](../pkg/core/lite/src/types.ts#L530-L555)` |
-| Required/optional/all tag deps | Typed ambient values declared as dependencies; a missing required tag fails deterministically at dependency resolution — loud and early, never silently `undefined` at use-site | `[pkg/core/lite/src/tag.ts:253-310](../pkg/core/lite/src/tag.ts#L253-L310)`, `[pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068)`, `[pkg/core/lite/tests/scope.test.ts:1434-1465](../pkg/core/lite/tests/scope.test.ts#L1434-L1465)` |
-| First-class async deps | Factories may return promises; resources are execution-context-owned | `[pkg/core/lite/src/types.ts:45-45](../pkg/core/lite/src/types.ts#L45-L45)`, `[pkg/core/lite/src/resource.ts:3-42](../pkg/core/lite/src/resource.ts#L3-L42)`, `[pkg/core/lite/src/scope.ts:1916-1933](../pkg/core/lite/src/scope.ts#L1916-L1933)` |
-| Preset substitutions | A scope maps target handles to replacement values or handles | `[pkg/core/lite/src/scope.ts:380-380](../pkg/core/lite/src/scope.ts#L380-L380)`, `[pkg/core/lite/src/scope.ts:447-449](../pkg/core/lite/src/scope.ts#L447-L449)`, `[pkg/core/lite/src/preset.ts:69-84](../pkg/core/lite/src/preset.ts#L69-L84)` |
-| Effects as graph edges | Flow/function execution goes through `ctx.exec`; extensions wrap the execution | `[pkg/core/lite/src/types.ts:233-245](../pkg/core/lite/src/types.ts#L233-L245)`, `[pkg/core/lite/src/scope.ts:2084-2131](../pkg/core/lite/src/scope.ts#L2084-L2131)`, `[pkg/core/lite/src/scope.ts:2377-2390](../pkg/core/lite/src/scope.ts#L2377-L2390)` |
+| Kind | Meaning |
+| --- | --- |
+| Static graph deps | Atoms, flows, controllers, and resources declared in `deps` |
+| Required/optional/all tag deps | Typed ambient values declared as dependencies; a missing required tag fails deterministically at dependency resolution — loud and early, never silently `undefined` at use-site |
+| First-class async deps | Factories may return promises; resources are execution-context-owned |
+| Preset substitutions | A scope maps target handles to replacement values or handles |
+| Effects as graph edges | Flow/function execution goes through `ctx.exec`; extensions wrap the execution |
 
-## Claim -> Citation
+## Proven in the source
 
-The README defines scope, execution context, atoms, flows, resources, tags, presets, extensions, and streaming flows in one mental model: `[README.md:101-103](../README.md#L101-L103)`.
+- Static graph deps: [pkg/core/lite/src/deps-graph.ts:5-12](../pkg/core/lite/src/deps-graph.ts#L5-L12), [pkg/core/lite/src/types.ts:530-555](../pkg/core/lite/src/types.ts#L530-L555).
 
-Scope is the composition and test boundary: `[README.md:101-103](../README.md#L101-L103)`, `[pkg/core/lite/README.md:36-48](../pkg/core/lite/README.md#L36-L48)`.
+- Required/optional/all tag deps: [pkg/core/lite/src/tag.ts:253-310](../pkg/core/lite/src/tag.ts#L253-L310), [pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068), [pkg/core/lite/tests/scope.test.ts:1434-1465](../pkg/core/lite/tests/scope.test.ts#L1434-L1465).
 
-Raw ambient IO belongs in transport atoms or composition-root adapters, while feature code depends on capabilities: `[README.md:139-143](../README.md#L139-L143)`, `[pkg/core/lite/PATTERNS.md:9-19](../pkg/core/lite/PATTERNS.md#L9-L19)`.
+- First-class async deps: [pkg/core/lite/src/types.ts:45-45](../pkg/core/lite/src/types.ts#L45-L45), [pkg/core/lite/src/resource.ts:3-42](../pkg/core/lite/src/resource.ts#L3-L42), [pkg/core/lite/src/scope.ts:1916-1933](../pkg/core/lite/src/scope.ts#L1916-L1933).
 
-Required tag deps currently fail during dependency resolution, not universal `createScope()` construction: `[pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068)`.
+- Preset substitutions: [pkg/core/lite/src/scope.ts:380-380](../pkg/core/lite/src/scope.ts#L380-L380), [pkg/core/lite/src/scope.ts:447-449](../pkg/core/lite/src/scope.ts#L447-L449), [pkg/core/lite/src/preset.ts:69-84](../pkg/core/lite/src/preset.ts#L69-L84).
+
+- Effects as graph edges: [pkg/core/lite/src/types.ts:233-245](../pkg/core/lite/src/types.ts#L233-L245), [pkg/core/lite/src/scope.ts:2084-2131](../pkg/core/lite/src/scope.ts#L2084-L2131), [pkg/core/lite/src/scope.ts:2377-2390](../pkg/core/lite/src/scope.ts#L2377-L2390).
+
+- The README defines scope, execution context, atoms, flows, resources, tags, presets, extensions, and streaming flows in one mental model: [README.md:101-103](../README.md#L101-L103).
+
+- Scope is the composition and test boundary: [README.md:101-103](../README.md#L101-L103), [pkg/core/lite/README.md:36-48](../pkg/core/lite/README.md#L36-L48).
+
+- Raw ambient IO belongs in transport atoms or composition-root adapters, while feature code depends on capabilities: [README.md:139-143](../README.md#L139-L143), [pkg/core/lite/PATTERNS.md:9-19](../pkg/core/lite/PATTERNS.md#L9-L19).
+
+- Required tag deps currently fail during dependency resolution, not universal `createScope()` construction: [pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068).

--- a/docs/mental-model.md
+++ b/docs/mental-model.md
@@ -1,5 +1,7 @@
 # What is the pumped-fn mental model?
 
+Think of pumped-fn as one explicit graph seam. You build a scope, create an execution context, and run graph edges through that context.
+
 ```text
 composition root
   createScope({ presets, tags, extensions })
@@ -16,6 +18,8 @@ execution context
 extensions
   wrapResolve + wrapExec observe graph edges
 ```
+
+Here is the same shape in code.
 
 ```ts
 import { atom, createScope, flow, resource, tag, tags, typed } from "@pumped-fn/lite"
@@ -63,7 +67,13 @@ await ctx.close()
 await scope.dispose()
 ```
 
-## Dependency Kinds
+The composition root creates the scope and supplies the tenant tag. The flow declares the HTTP client, tenant, and transaction resource in `deps`, so the execution context can resolve them before the factory runs. The resource is owned by the current execution context, so its cleanup runs when that context closes.
+
+Extensions sit outside the business function. They can wrap dependency resolution and execution without changing the flow body.
+
+> **Note:** Missing required tag deps fail during dependency resolution before the unit factory runs. The current source does not validate every required tag at `createScope()` construction.
+
+## Recap
 
 | Kind | Meaning |
 | --- | --- |
@@ -73,22 +83,18 @@ await scope.dispose()
 | Preset substitutions | A scope maps target handles to replacement values or handles |
 | Effects as graph edges | Flow/function execution goes through `ctx.exec`; extensions wrap the execution |
 
-## Proven in the source
+Raw ambient IO belongs in transport atoms or composition-root adapters. Feature code should depend on capabilities declared in the graph.
 
-- Static graph deps: [pkg/core/lite/src/deps-graph.ts:5-12](../pkg/core/lite/src/deps-graph.ts#L5-L12), [pkg/core/lite/src/types.ts:530-555](../pkg/core/lite/src/types.ts#L530-L555).
+## Source
 
-- Required/optional/all tag deps: [pkg/core/lite/src/tag.ts:253-310](../pkg/core/lite/src/tag.ts#L253-L310), [pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068), [pkg/core/lite/tests/scope.test.ts:1434-1465](../pkg/core/lite/tests/scope.test.ts#L1434-L1465).
+- [Core README mental model](../README.md)
+- [Dependency graph classification](../pkg/core/lite/src/deps-graph.ts)
+- [Tag dependencies](../pkg/core/lite/src/tag.ts)
+- [Resources](../pkg/core/lite/src/resource.ts)
+- [Scope implementation](../pkg/core/lite/src/scope.ts)
+- [Lite patterns](../pkg/core/lite/PATTERNS.md)
 
-- First-class async deps: [pkg/core/lite/src/types.ts:45-45](../pkg/core/lite/src/types.ts#L45-L45), [pkg/core/lite/src/resource.ts:3-42](../pkg/core/lite/src/resource.ts#L3-L42), [pkg/core/lite/src/scope.ts:1916-1933](../pkg/core/lite/src/scope.ts#L1916-L1933).
+## Next
 
-- Preset substitutions: [pkg/core/lite/src/scope.ts:380-380](../pkg/core/lite/src/scope.ts#L380-L380), [pkg/core/lite/src/scope.ts:447-449](../pkg/core/lite/src/scope.ts#L447-L449), [pkg/core/lite/src/preset.ts:69-84](../pkg/core/lite/src/preset.ts#L69-L84).
-
-- Effects as graph edges: [pkg/core/lite/src/types.ts:233-245](../pkg/core/lite/src/types.ts#L233-L245), [pkg/core/lite/src/scope.ts:2084-2131](../pkg/core/lite/src/scope.ts#L2084-L2131), [pkg/core/lite/src/scope.ts:2377-2390](../pkg/core/lite/src/scope.ts#L2377-L2390).
-
-- The README defines scope, execution context, atoms, flows, resources, tags, presets, extensions, and streaming flows in one mental model: [README.md:101-103](../README.md#L101-L103).
-
-- Scope is the composition and test boundary: [README.md:101-103](../README.md#L101-L103), [pkg/core/lite/README.md:36-48](../pkg/core/lite/README.md#L36-L48).
-
-- Raw ambient IO belongs in transport atoms or composition-root adapters, while feature code depends on capabilities: [README.md:139-143](../README.md#L139-L143), [pkg/core/lite/PATTERNS.md:9-19](../pkg/core/lite/PATTERNS.md#L9-L19).
-
-- Required tag deps currently fail during dependency resolution, not universal `createScope()` construction: [pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068).
+- [Test without mocking modules](test-without-mocks.md)
+- [Adopt one route at a time](adopt-incrementally.md)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,6 +1,6 @@
 # How do I get OpenTelemetry spans without editing business functions?
 
-Install the extension at the scope. Put the sink in a runtime tag. Business flows stay plain.
+Install the extension at the scope and pass the sink through runtime tags. Your business flow stays plain.
 
 ```ts
 import { createScope, flow, typed } from "@pumped-fn/lite"
@@ -42,7 +42,9 @@ await ctx.close()
 await scope.dispose()
 ```
 
-Foreign SDK call shape:
+The observable extension sees atom and resource resolution, plus flow and function execution. The OTel sink turns those lifecycle events into spans, links child spans through `parentId`, records errors, sets status, and ends spans on terminal events.
+
+For a foreign SDK call, name the edge with `ctx.exec`.
 
 ```ts
 import { step } from "@pumped-fn/sdk"
@@ -55,22 +57,19 @@ await ctx.exec({
 })
 ```
 
-## Proven in the source
+The `step` tag comes from `@pumped-fn/sdk`. In the invoice example, this shape gives intake, store, model, review, and reminder work named span edges after `observable.extension()` is added at scope creation.
 
-- Extensions expose `wrapResolve` and `wrapExec`: [pkg/core/lite/src/types.ts:500-520](../pkg/core/lite/src/types.ts#L500-L520).
 
-- `createScope` stores extension instances and separates resolve wrappers from exec wrappers: [pkg/core/lite/src/scope.ts:441-456](../pkg/core/lite/src/scope.ts#L441-L456).
+## Source
 
-- The observable extension wraps atom/resource resolution and flow/function execution, emitting lifecycle events through tag-injected sinks: [pkg/ext/observable/src/index.ts:80-109](../pkg/ext/observable/src/index.ts#L80-L109), [pkg/ext/observable/src/index.ts:185-240](../pkg/ext/observable/src/index.ts#L185-L240).
+- [Extension types](../pkg/core/lite/src/types.ts)
+- [Scope extension setup](../pkg/core/lite/src/scope.ts)
+- [Observable extension](../pkg/ext/observable/src/index.ts)
+- [OTel sink](../pkg/ext/observable-otel/src/index.ts)
+- [OTel tests](../pkg/ext/observable-otel/tests/otel.test.ts)
+- [Invoice triage span test](../examples/invoice-triage/tests/invoice-triage.test.ts)
 
-- The OTel sink starts spans on start events, links child spans through `parentId`, records errors, sets status, and ends spans on terminal events: [pkg/ext/observable-otel/src/index.ts:38-64](../pkg/ext/observable-otel/src/index.ts#L38-L64), [pkg/ext/observable-otel/src/index.ts:66-105](../pkg/ext/observable-otel/src/index.ts#L66-L105).
+## Next
 
-- The OTel test proves runtime-tag setup and parent-linked nested spans: [pkg/ext/observable-otel/tests/otel.test.ts:60-121](../pkg/ext/observable-otel/tests/otel.test.ts#L60-L121), [pkg/ext/observable-otel/tests/otel.test.ts:215-236](../pkg/ext/observable-otel/tests/otel.test.ts#L215-L236).
-
-- The invoice example proves span coverage over intake, store, model, review, and reminder edges after adding `observable.extension()` at scope creation: [examples/invoice-triage/tests/invoice-triage.test.ts:1113-1164](../examples/invoice-triage/tests/invoice-triage.test.ts#L1113-L1164).
-
-- Foreign calls need named `ctx.exec({ fn, params, name, tags })` edges; the notifier call in invoice triage uses that shape: [pkg/core/lite/PATTERNS.md:19-19](../pkg/core/lite/PATTERNS.md#L19-L19), [examples/invoice-triage/src/flows.ts:260-262](../examples/invoice-triage/src/flows.ts#L260-L262).
-
-- `step` is the SDK workflow step tag and is imported from `@pumped-fn/sdk` in the invoice example: [pkg/sdk/core/src/index.ts:28-52](../pkg/sdk/core/src/index.ts#L28-L52), [examples/invoice-triage/src/flows.ts:1-4](../examples/invoice-triage/src/flows.ts#L1-L4).
-
-This page makes no performance or bundle-size claim.
+- [Code review guide](code-review-guide.md)
+- [Mental model](mental-model.md)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,11 +1,5 @@
 # How do I get OpenTelemetry spans without editing business functions?
 
-Reader question: "Can I add OTel spans without putting instrumentation inside each function?"
-
-Pillar proven: fully traceable and observable.
-
-Entry arena: OTel instrumentation.
-
 Install the extension at the scope. Put the sink in a runtime tag. Business flows stay plain.
 
 ```ts
@@ -61,22 +55,22 @@ await ctx.exec({
 })
 ```
 
-## Claim -> Citation
+## Proven in the source
 
-Extensions expose `wrapResolve` and `wrapExec`: `[pkg/core/lite/src/types.ts:500-520](../pkg/core/lite/src/types.ts#L500-L520)`.
+- Extensions expose `wrapResolve` and `wrapExec`: [pkg/core/lite/src/types.ts:500-520](../pkg/core/lite/src/types.ts#L500-L520).
 
-`createScope` stores extension instances and separates resolve wrappers from exec wrappers: `[pkg/core/lite/src/scope.ts:441-456](../pkg/core/lite/src/scope.ts#L441-L456)`.
+- `createScope` stores extension instances and separates resolve wrappers from exec wrappers: [pkg/core/lite/src/scope.ts:441-456](../pkg/core/lite/src/scope.ts#L441-L456).
 
-The observable extension wraps atom/resource resolution and flow/function execution, emitting lifecycle events through tag-injected sinks: `[pkg/ext/observable/src/index.ts:80-109](../pkg/ext/observable/src/index.ts#L80-L109)`, `[pkg/ext/observable/src/index.ts:185-240](../pkg/ext/observable/src/index.ts#L185-L240)`.
+- The observable extension wraps atom/resource resolution and flow/function execution, emitting lifecycle events through tag-injected sinks: [pkg/ext/observable/src/index.ts:80-109](../pkg/ext/observable/src/index.ts#L80-L109), [pkg/ext/observable/src/index.ts:185-240](../pkg/ext/observable/src/index.ts#L185-L240).
 
-The OTel sink starts spans on start events, links child spans through `parentId`, records errors, sets status, and ends spans on terminal events: `[pkg/ext/observable-otel/src/index.ts:38-64](../pkg/ext/observable-otel/src/index.ts#L38-L64)`, `[pkg/ext/observable-otel/src/index.ts:66-105](../pkg/ext/observable-otel/src/index.ts#L66-L105)`.
+- The OTel sink starts spans on start events, links child spans through `parentId`, records errors, sets status, and ends spans on terminal events: [pkg/ext/observable-otel/src/index.ts:38-64](../pkg/ext/observable-otel/src/index.ts#L38-L64), [pkg/ext/observable-otel/src/index.ts:66-105](../pkg/ext/observable-otel/src/index.ts#L66-L105).
 
-The OTel test proves runtime-tag setup and parent-linked nested spans: `[pkg/ext/observable-otel/tests/otel.test.ts:60-121](../pkg/ext/observable-otel/tests/otel.test.ts#L60-L121)`, `[pkg/ext/observable-otel/tests/otel.test.ts:215-236](../pkg/ext/observable-otel/tests/otel.test.ts#L215-L236)`.
+- The OTel test proves runtime-tag setup and parent-linked nested spans: [pkg/ext/observable-otel/tests/otel.test.ts:60-121](../pkg/ext/observable-otel/tests/otel.test.ts#L60-L121), [pkg/ext/observable-otel/tests/otel.test.ts:215-236](../pkg/ext/observable-otel/tests/otel.test.ts#L215-L236).
 
-The invoice example proves span coverage over intake, store, model, review, and reminder edges after adding `observable.extension()` at scope creation: `[examples/invoice-triage/tests/invoice-triage.test.ts:1113-1164](../examples/invoice-triage/tests/invoice-triage.test.ts#L1113-L1164)`.
+- The invoice example proves span coverage over intake, store, model, review, and reminder edges after adding `observable.extension()` at scope creation: [examples/invoice-triage/tests/invoice-triage.test.ts:1113-1164](../examples/invoice-triage/tests/invoice-triage.test.ts#L1113-L1164).
 
-Foreign calls need named `ctx.exec({ fn, params, name, tags })` edges; the notifier call in invoice triage uses that shape: `[pkg/core/lite/PATTERNS.md:19-19](../pkg/core/lite/PATTERNS.md#L19-L19)`, `[examples/invoice-triage/src/flows.ts:260-262](../examples/invoice-triage/src/flows.ts#L260-L262)`.
+- Foreign calls need named `ctx.exec({ fn, params, name, tags })` edges; the notifier call in invoice triage uses that shape: [pkg/core/lite/PATTERNS.md:19-19](../pkg/core/lite/PATTERNS.md#L19-L19), [examples/invoice-triage/src/flows.ts:260-262](../examples/invoice-triage/src/flows.ts#L260-L262).
 
-`step` is the SDK workflow step tag and is imported from `@pumped-fn/sdk` in the invoice example: `[pkg/sdk/core/src/index.ts:28-52](../pkg/sdk/core/src/index.ts#L28-L52)`, `[examples/invoice-triage/src/flows.ts:1-4](../examples/invoice-triage/src/flows.ts#L1-L4)`.
+- `step` is the SDK workflow step tag and is imported from `@pumped-fn/sdk` in the invoice example: [pkg/sdk/core/src/index.ts:28-52](../pkg/sdk/core/src/index.ts#L28-L52), [examples/invoice-triage/src/flows.ts:1-4](../examples/invoice-triage/src/flows.ts#L1-L4).
 
-No performance or bundle-size claim belongs on this page.
+This page makes no performance or bundle-size claim.

--- a/docs/request-context-without-als.md
+++ b/docs/request-context-without-als.md
@@ -1,6 +1,6 @@
 # Why is AsyncLocalStorage `getStore()` undefined, and what should I use instead?
 
-Use an explicit `ExecutionContext`. Middleware creates it, stores it in the framework context, seeds request tags, and closes it after the request.
+Use an explicit `ExecutionContext`. Middleware creates it, seeds request tags, stores it in the framework context, and closes it after the request.
 
 ```ts
 import { Hono } from "hono"
@@ -38,11 +38,9 @@ export async function closeApp(): Promise<void> {
 }
 ```
 
-## Why This Answers the ALS Query
-
 The request state is not discovered from ambient storage inside product code. It is declared as a tag dependency and supplied by the request boundary.
 
-The flow can run in a test with the same API:
+The same flow can run in a test with the same API.
 
 ```ts
 const scope = createScope()
@@ -54,16 +52,18 @@ await scope.dispose()
 if (id !== "test-request") throw new Error("unexpected request id")
 ```
 
-## Proven in the source
+The public execution context carries `input`, `scope`, `parent`, `data`, `resolve`, `release`, `controller`, `exec`, `execStream`, `changes`, close hooks, and failure helpers. Context data supports raw keys and tag methods, including parent-chain tag lookup. `scope.createContext({ tags, parent })` seeds context tags and then scope tags.
 
-- `ExecutionContext` is a public interface with `input`, `scope`, `parent`, `data`, `resolve`, `release`, `controller`, `exec`, `execStream`, `changes`, `onClose`, `close`, and `fail`: [pkg/core/lite/src/types.ts:233-254](../pkg/core/lite/src/types.ts#L233-L254).
+> **Note:** AsyncLocalStorage internals are not covered here. The supported control surface is explicit execution contexts plus declared tag deps.
 
-- Context data supports raw keys and tag methods, including parent-chain lookup through `seekTag`: [pkg/core/lite/src/types.ts:166-218](../pkg/core/lite/src/types.ts#L166-L218), [pkg/core/lite/src/scope.ts:42-115](../pkg/core/lite/src/scope.ts#L42-L115).
+## Source
 
-- `scope.createContext({ tags, parent })` seeds context tags and then scope tags: [pkg/core/lite/src/scope.ts:1814-1842](../pkg/core/lite/src/scope.ts#L1814-L1842).
+- [ExecutionContext types](../pkg/core/lite/src/types.ts)
+- [Context tag lookup](../pkg/core/lite/src/scope.ts)
+- [Hono adapter](../pkg/framework/hono/src/index.ts)
+- [Hono adapter tests](../pkg/framework/hono/tests/hono.test.ts)
 
-- The Hono adapter creates the execution context from the request and stores it in `context.var`: [pkg/framework/hono/src/index.ts:49-71](../pkg/framework/hono/src/index.ts#L49-L71).
+## Next
 
-- The Hono test proves separate request IDs, per-call tag override, JSON input execution, and context close settlement: [pkg/framework/hono/tests/hono.test.ts:22-80](../pkg/framework/hono/tests/hono.test.ts#L22-L80).
-
-AsyncLocalStorage internals are not covered here. The repo-backed claim is the alternative control surface: explicit execution contexts plus declared tag deps.
+- [Adopt one route at a time](adopt-incrementally.md)
+- [Test without mocking modules](test-without-mocks.md)

--- a/docs/request-context-without-als.md
+++ b/docs/request-context-without-als.md
@@ -1,11 +1,5 @@
 # Why is AsyncLocalStorage `getStore()` undefined, and what should I use instead?
 
-Reader question: "My ALS request context disappeared; how do I avoid that class of bug?"
-
-Pillar proven: explicit request context.
-
-Entry arena: ALS long-tail, `AsyncLocalStorage getStore undefined`.
-
 Use an explicit `ExecutionContext`. Middleware creates it, stores it in the framework context, seeds request tags, and closes it after the request.
 
 ```ts
@@ -60,16 +54,16 @@ await scope.dispose()
 if (id !== "test-request") throw new Error("unexpected request id")
 ```
 
-## Claim -> Citation
+## Proven in the source
 
-`ExecutionContext` is a public interface with `input`, `scope`, `parent`, `data`, `resolve`, `release`, `controller`, `exec`, `execStream`, `changes`, `onClose`, `close`, and `fail`: `[pkg/core/lite/src/types.ts:233-254](../pkg/core/lite/src/types.ts#L233-L254)`.
+- `ExecutionContext` is a public interface with `input`, `scope`, `parent`, `data`, `resolve`, `release`, `controller`, `exec`, `execStream`, `changes`, `onClose`, `close`, and `fail`: [pkg/core/lite/src/types.ts:233-254](../pkg/core/lite/src/types.ts#L233-L254).
 
-Context data supports raw keys and tag methods, including parent-chain lookup through `seekTag`: `[pkg/core/lite/src/types.ts:166-218](../pkg/core/lite/src/types.ts#L166-L218)`, `[pkg/core/lite/src/scope.ts:42-115](../pkg/core/lite/src/scope.ts#L42-L115)`.
+- Context data supports raw keys and tag methods, including parent-chain lookup through `seekTag`: [pkg/core/lite/src/types.ts:166-218](../pkg/core/lite/src/types.ts#L166-L218), [pkg/core/lite/src/scope.ts:42-115](../pkg/core/lite/src/scope.ts#L42-L115).
 
-`scope.createContext({ tags, parent })` seeds context tags and then scope tags: `[pkg/core/lite/src/scope.ts:1814-1842](../pkg/core/lite/src/scope.ts#L1814-L1842)`.
+- `scope.createContext({ tags, parent })` seeds context tags and then scope tags: [pkg/core/lite/src/scope.ts:1814-1842](../pkg/core/lite/src/scope.ts#L1814-L1842).
 
-The Hono adapter creates the execution context from the request and stores it in `context.var`: `[pkg/framework/hono/src/index.ts:49-71](../pkg/framework/hono/src/index.ts#L49-L71)`.
+- The Hono adapter creates the execution context from the request and stores it in `context.var`: [pkg/framework/hono/src/index.ts:49-71](../pkg/framework/hono/src/index.ts#L49-L71).
 
-The Hono test proves separate request IDs, per-call tag override, JSON input execution, and context close settlement: `[pkg/framework/hono/tests/hono.test.ts:22-80](../pkg/framework/hono/tests/hono.test.ts#L22-L80)`.
+- The Hono test proves separate request IDs, per-call tag override, JSON input execution, and context close settlement: [pkg/framework/hono/tests/hono.test.ts:22-80](../pkg/framework/hono/tests/hono.test.ts#L22-L80).
 
-Do not use this page to make uncited claims about Node ALS internals. The repo-backed claim is the alternative control surface: explicit execution contexts plus declared tag deps.
+AsyncLocalStorage internals are not covered here. The repo-backed claim is the alternative control surface: explicit execution contexts plus declared tag deps.

--- a/docs/test-without-mocks.md
+++ b/docs/test-without-mocks.md
@@ -1,6 +1,6 @@
 # How do I test TypeScript code without `vi.mock`?
 
-The answer is the scope seam. Replace the graph edge at `createScope`, then execute the same public flow the app uses.
+Replace the graph edge at `createScope`, then execute the same public flow the app uses.
 
 ```ts
 import { atom, createScope, flow, preset, tag, tags, typed } from "@pumped-fn/lite"
@@ -49,7 +49,9 @@ await ctx.close()
 await scope.dispose()
 ```
 
-Real database recipe, from the canonical invoice example:
+The test replaces the `db` atom with `preset(db, fake)` and supplies the clock through a tag. The flow body does not know it is running in a test.
+
+For a real database test, use the same pattern with the canonical invoice example's PGlite database.
 
 ```ts
 const scope = createScope({
@@ -61,7 +63,7 @@ const scope = createScope({
 })
 ```
 
-PGlite support builds a Drizzle database, runs migrations, and returns the same `Database` type as production:
+The helper builds a Drizzle database, runs migrations, and returns the same `Database` type as production.
 
 ```ts
 export async function pgliteDatabase(): Promise<Database> {
@@ -72,20 +74,20 @@ export async function pgliteDatabase(): Promise<Database> {
 }
 ```
 
-## Proven in the source
+`createScope` accepts presets, tags, and extensions. `preset` can replace atoms, flows, and resources. Required tag deps are declared in the `deps` object with `tags.required(tag)`.
 
-- `createScope` accepts `presets`, `tags`, and `extensions`: [pkg/core/lite/src/types.ts:78-83](../pkg/core/lite/src/types.ts#L78-L83).
+> **Note:** External `vi.mock` pain points such as hoisting, type loss, and per-file setup are not covered here. This page shows the pumped-fn seam.
 
-- `preset` can replace atoms, flows, and resources: [pkg/core/lite/src/preset.ts:25-67](../pkg/core/lite/src/preset.ts#L25-L67).
+## Source
 
-- Flow input can be typed with `typed<T>()`: [pkg/core/lite/src/flow.ts:18-20](../pkg/core/lite/src/flow.ts#L18-L20), [pkg/core/lite/src/flow.ts:164-212](../pkg/core/lite/src/flow.ts#L164-L212).
+- [Scope options](../pkg/core/lite/src/types.ts)
+- [Preset API](../pkg/core/lite/src/preset.ts)
+- [Flow typing](../pkg/core/lite/src/flow.ts)
+- [Required tag deps](../pkg/core/lite/src/tag.ts)
+- [Invoice triage tests](../examples/invoice-triage/tests/invoice-triage.test.ts)
+- [PGlite database helper](../examples/invoice-triage/tests/support/database.ts)
 
-- Required tag deps are declared in the deps object with `tags.required(tag)`: [pkg/core/lite/src/tag.ts:253-273](../pkg/core/lite/src/tag.ts#L253-L273).
+## Next
 
-- The invoice tests use `createScope`, `preset(database, await pgliteDatabase())`, model provider tags, and deterministic clock tags: [examples/invoice-triage/tests/invoice-triage.test.ts:337-360](../examples/invoice-triage/tests/invoice-triage.test.ts#L337-L360), [examples/invoice-triage/tests/invoice-triage.test.ts:389-408](../examples/invoice-triage/tests/invoice-triage.test.ts#L389-L408), [examples/invoice-triage/tests/invoice-triage.test.ts:520-555](../examples/invoice-triage/tests/invoice-triage.test.ts#L520-L555).
-
-- The PGlite test database helper returns the production `Database` type after migrations: [examples/invoice-triage/tests/support/database.ts:1-15](../examples/invoice-triage/tests/support/database.ts#L1-L15).
-
-- The lint rule rejects module mocks and points tests to scope presets: [pkg/tool/lint/README.md:23-31](../pkg/tool/lint/README.md#L23-L31), [pkg/tool/lint/src/index.ts:1160-1179](../pkg/tool/lint/src/index.ts#L1160-L1179).
-
-External `vi.mock` pain points such as hoisting, type loss, and per-file setup are not covered here. This repo proves the alternative seam.
+- [Mental model](mental-model.md)
+- [Code review guide](code-review-guide.md)

--- a/docs/test-without-mocks.md
+++ b/docs/test-without-mocks.md
@@ -1,11 +1,5 @@
 # How do I test TypeScript code without `vi.mock`?
 
-Reader question: "How do I test code that hits DB, LLM, clock, or fetch without mocking modules?"
-
-Pillar proven: fully testable.
-
-Entry arena: `test without mocking modules`, `vi.mock alternative`.
-
 The answer is the scope seam. Replace the graph edge at `createScope`, then execute the same public flow the app uses.
 
 ```ts
@@ -78,20 +72,20 @@ export async function pgliteDatabase(): Promise<Database> {
 }
 ```
 
-## Claim -> Citation
+## Proven in the source
 
-`createScope` accepts `presets`, `tags`, and `extensions`: `[pkg/core/lite/src/types.ts:78-83](../pkg/core/lite/src/types.ts#L78-L83)`.
+- `createScope` accepts `presets`, `tags`, and `extensions`: [pkg/core/lite/src/types.ts:78-83](../pkg/core/lite/src/types.ts#L78-L83).
 
-`preset` can replace atoms, flows, and resources: `[pkg/core/lite/src/preset.ts:25-67](../pkg/core/lite/src/preset.ts#L25-L67)`.
+- `preset` can replace atoms, flows, and resources: [pkg/core/lite/src/preset.ts:25-67](../pkg/core/lite/src/preset.ts#L25-L67).
 
-Flow input can be typed with `typed<T>()`: `[pkg/core/lite/src/flow.ts:18-20](../pkg/core/lite/src/flow.ts#L18-L20)`, `[pkg/core/lite/src/flow.ts:164-212](../pkg/core/lite/src/flow.ts#L164-L212)`.
+- Flow input can be typed with `typed<T>()`: [pkg/core/lite/src/flow.ts:18-20](../pkg/core/lite/src/flow.ts#L18-L20), [pkg/core/lite/src/flow.ts:164-212](../pkg/core/lite/src/flow.ts#L164-L212).
 
-Required tag deps are declared in the deps object with `tags.required(tag)`: `[pkg/core/lite/src/tag.ts:253-273](../pkg/core/lite/src/tag.ts#L253-L273)`.
+- Required tag deps are declared in the deps object with `tags.required(tag)`: [pkg/core/lite/src/tag.ts:253-273](../pkg/core/lite/src/tag.ts#L253-L273).
 
-The invoice tests use `createScope`, `preset(database, await pgliteDatabase())`, model provider tags, and deterministic clock tags: `[examples/invoice-triage/tests/invoice-triage.test.ts:337-360](../examples/invoice-triage/tests/invoice-triage.test.ts#L337-L360)`, `[examples/invoice-triage/tests/invoice-triage.test.ts:389-408](../examples/invoice-triage/tests/invoice-triage.test.ts#L389-L408)`, `[examples/invoice-triage/tests/invoice-triage.test.ts:520-555](../examples/invoice-triage/tests/invoice-triage.test.ts#L520-L555)`.
+- The invoice tests use `createScope`, `preset(database, await pgliteDatabase())`, model provider tags, and deterministic clock tags: [examples/invoice-triage/tests/invoice-triage.test.ts:337-360](../examples/invoice-triage/tests/invoice-triage.test.ts#L337-L360), [examples/invoice-triage/tests/invoice-triage.test.ts:389-408](../examples/invoice-triage/tests/invoice-triage.test.ts#L389-L408), [examples/invoice-triage/tests/invoice-triage.test.ts:520-555](../examples/invoice-triage/tests/invoice-triage.test.ts#L520-L555).
 
-The PGlite test database helper returns the production `Database` type after migrations: `[examples/invoice-triage/tests/support/database.ts:1-15](../examples/invoice-triage/tests/support/database.ts#L1-L15)`.
+- The PGlite test database helper returns the production `Database` type after migrations: [examples/invoice-triage/tests/support/database.ts:1-15](../examples/invoice-triage/tests/support/database.ts#L1-L15).
 
-The lint rule rejects module mocks and points tests to scope presets: `[pkg/tool/lint/README.md:23-31](../pkg/tool/lint/README.md#L23-L31)`, `[pkg/tool/lint/src/index.ts:1160-1179](../pkg/tool/lint/src/index.ts#L1160-L1179)`.
+- The lint rule rejects module mocks and points tests to scope presets: [pkg/tool/lint/README.md:23-31](../pkg/tool/lint/README.md#L23-L31), [pkg/tool/lint/src/index.ts:1160-1179](../pkg/tool/lint/src/index.ts#L1160-L1179).
 
-Searcher pain to name on the page: `vi.mock` hoisting, type loss, and per-file setup. This repo proves the alternative seam; external `vi.mock` pain claims need external examples before publication.
+External `vi.mock` pain points such as hoisting, type loss, and per-file setup are not covered here. This repo proves the alternative seam.

--- a/docs/vs-di-containers.md
+++ b/docs/vs-di-containers.md
@@ -1,6 +1,6 @@
 # TypeScript DI without decorators: why use pumped-fn instead of a container?
 
-The repo-backed claim is about pumped-fn's shape: imports define graph units; dependency records define edges; a scope materializes one graph with substitutions.
+pumped-fn's core API is imports, dependency records, and scopes. Imports define graph units, dependency records define edges, and a scope materializes one graph with substitutions.
 
 ```ts
 import { createScope, flow, tag, tags, typed } from "@pumped-fn/lite"
@@ -35,7 +35,11 @@ await ctx.close()
 await scope.dispose()
 ```
 
-## What This Proves
+The root chooses the model by setting a tag. The feature flow depends on the role, not on a decorator container or a global registry. In a request or test, you can rebind the role by creating a context with different tags.
+
+> **Note:** Required tag deps do not fail at scope creation today. Missing required tags throw during dependency resolution before the unit factory runs.
+
+## What You Get
 
 | Need | pumped-fn Shape |
 | --- | --- |
@@ -45,22 +49,18 @@ await scope.dispose()
 | Context override | Context tags can rebind a role for one request or test |
 | Async deps | Atom, flow, and resource factories accept `MaybePromise` values |
 
-## Caveat
+This page does not document tsyringe or InversifyJS internals. The comparison here is limited to pumped-fn's core exports: they expose primitives such as `atom`, `flow`, `tag`, `preset`, `resource`, and `createScope`, not a decorator or registration surface.
 
-Required tag deps do not fail at scope creation today. Current source proves a narrower and still useful claim: missing required tags throw during dependency resolution before the unit factory runs.
+## Source
 
-This page does not document tsyringe or InversifyJS internals. The repo-backed comparison is: pumped-fn's public API does not expose a decorator or registration surface in its core exports.
+- [Core exports](../pkg/core/lite/src/index.ts)
+- [Dependency classification](../pkg/core/lite/src/deps-graph.ts)
+- [Dependency types](../pkg/core/lite/src/types.ts)
+- [Role tag tests](../pkg/core/lite/tests/role-tags.test.ts)
+- [Scope implementation](../pkg/core/lite/src/scope.ts)
+- [Required tag timing](../pkg/core/lite/src/scope.ts)
 
-## Proven in the source
+## Next
 
-- No decorator-shaped public API: [pkg/core/lite/src/index.ts:16-22](../pkg/core/lite/src/index.ts#L16-L22).
-
-- Inference-carried dependency values: [pkg/core/lite/src/deps-graph.ts:16-49](../pkg/core/lite/src/deps-graph.ts#L16-L49), [pkg/core/lite/src/types.ts:530-579](../pkg/core/lite/src/types.ts#L530-L579).
-
-- Role selection: [pkg/core/lite/tests/role-tags.test.ts:10-26](../pkg/core/lite/tests/role-tags.test.ts#L10-L26), [pkg/core/lite/tests/role-tags.test.ts:59-71](../pkg/core/lite/tests/role-tags.test.ts#L59-L71).
-
-- Context override: [pkg/core/lite/tests/role-tags.test.ts:128-142](../pkg/core/lite/tests/role-tags.test.ts#L128-L142), [pkg/core/lite/src/scope.ts:1814-1842](../pkg/core/lite/src/scope.ts#L1814-L1842).
-
-- Async deps: [pkg/core/lite/src/atom.ts:29-44](../pkg/core/lite/src/atom.ts#L29-L44), [pkg/core/lite/src/flow.ts:146-212](../pkg/core/lite/src/flow.ts#L146-L212), [pkg/core/lite/src/resource.ts:25-42](../pkg/core/lite/src/resource.ts#L25-L42).
-
-- Required tag timing: [pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068).
+- [Mental model](mental-model.md)
+- [Test without mocking modules](test-without-mocks.md)

--- a/docs/vs-di-containers.md
+++ b/docs/vs-di-containers.md
@@ -1,12 +1,6 @@
 # TypeScript DI without decorators: why use pumped-fn instead of a container?
 
-Reader question: "Why use this over tsyringe or InversifyJS?"
-
-Pillar proven: graph mechanism.
-
-Entry arena: DI hub and container comparison.
-
-The repo-backed claim is about pumped-fn's shape: imports define graph nodes; dependency records define edges; a scope materializes one graph with substitutions.
+The repo-backed claim is about pumped-fn's shape: imports define graph units; dependency records define edges; a scope materializes one graph with substitutions.
 
 ```ts
 import { createScope, flow, tag, tags, typed } from "@pumped-fn/lite"
@@ -43,16 +37,30 @@ await scope.dispose()
 
 ## What This Proves
 
-| Need | pumped-fn Shape | Citation |
-| --- | --- | --- |
-| No decorator-shaped public API | Public exports are primitives such as `atom`, `flow`, `tag`, `preset`, `resource`, `createScope` | `[pkg/core/lite/src/index.ts:16-22](../pkg/core/lite/src/index.ts#L16-L22)` |
-| Inference-carried dependency values | Dependency records are classified by runtime handle type | `[pkg/core/lite/src/deps-graph.ts:16-49](../pkg/core/lite/src/deps-graph.ts#L16-L49)`, `[pkg/core/lite/src/types.ts:530-579](../pkg/core/lite/src/types.ts#L530-L579)` |
-| Role selection | A tag can carry a flow and project to a context-bound `FlowHandle` in deps | `[pkg/core/lite/tests/role-tags.test.ts:10-26](../pkg/core/lite/tests/role-tags.test.ts#L10-L26)`, `[pkg/core/lite/tests/role-tags.test.ts:59-71](../pkg/core/lite/tests/role-tags.test.ts#L59-L71)` |
-| Context override | Context tags can rebind a role for one request or test | `[pkg/core/lite/tests/role-tags.test.ts:128-142](../pkg/core/lite/tests/role-tags.test.ts#L128-L142)`, `[pkg/core/lite/src/scope.ts:1814-1842](../pkg/core/lite/src/scope.ts#L1814-L1842)` |
-| Async deps | Atom, flow, and resource factories accept `MaybePromise` values | `[pkg/core/lite/src/atom.ts:29-44](../pkg/core/lite/src/atom.ts#L29-L44)`, `[pkg/core/lite/src/flow.ts:146-212](../pkg/core/lite/src/flow.ts#L146-L212)`, `[pkg/core/lite/src/resource.ts:25-42](../pkg/core/lite/src/resource.ts#L25-L42)` |
+| Need | pumped-fn Shape |
+| --- | --- |
+| No decorator-shaped public API | Public exports are primitives such as `atom`, `flow`, `tag`, `preset`, `resource`, `createScope` |
+| Inference-carried dependency values | Dependency records are classified by runtime handle type |
+| Role selection | A tag can carry a flow and project to a context-bound `FlowHandle` in deps |
+| Context override | Context tags can rebind a role for one request or test |
+| Async deps | Atom, flow, and resource factories accept `MaybePromise` values |
 
 ## Caveat
 
-The brief's desired positioning says required tag deps fail at scope creation. Current source proves a narrower and still useful claim: missing required tags throw during dependency resolution before the unit factory runs. Evidence: `[pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068)`.
+Required tag deps do not fail at scope creation today. Current source proves a narrower and still useful claim: missing required tags throw during dependency resolution before the unit factory runs.
 
-Do not publish uncited claims about tsyringe or InversifyJS internals from this file alone. The repo-backed comparison is: pumped-fn's public API does not expose a decorator or registration surface in its core exports.
+This page does not document tsyringe or InversifyJS internals. The repo-backed comparison is: pumped-fn's public API does not expose a decorator or registration surface in its core exports.
+
+## Proven in the source
+
+- No decorator-shaped public API: [pkg/core/lite/src/index.ts:16-22](../pkg/core/lite/src/index.ts#L16-L22).
+
+- Inference-carried dependency values: [pkg/core/lite/src/deps-graph.ts:16-49](../pkg/core/lite/src/deps-graph.ts#L16-L49), [pkg/core/lite/src/types.ts:530-579](../pkg/core/lite/src/types.ts#L530-L579).
+
+- Role selection: [pkg/core/lite/tests/role-tags.test.ts:10-26](../pkg/core/lite/tests/role-tags.test.ts#L10-L26), [pkg/core/lite/tests/role-tags.test.ts:59-71](../pkg/core/lite/tests/role-tags.test.ts#L59-L71).
+
+- Context override: [pkg/core/lite/tests/role-tags.test.ts:128-142](../pkg/core/lite/tests/role-tags.test.ts#L128-L142), [pkg/core/lite/src/scope.ts:1814-1842](../pkg/core/lite/src/scope.ts#L1814-L1842).
+
+- Async deps: [pkg/core/lite/src/atom.ts:29-44](../pkg/core/lite/src/atom.ts#L29-L44), [pkg/core/lite/src/flow.ts:146-212](../pkg/core/lite/src/flow.ts#L146-L212), [pkg/core/lite/src/resource.ts:25-42](../pkg/core/lite/src/resource.ts#L25-L42).
+
+- Required tag timing: [pkg/core/lite/src/scope.ts:1055-1068](../pkg/core/lite/src/scope.ts#L1055-L1068).

--- a/docs/vs-effect.md
+++ b/docs/vs-effect.md
@@ -1,11 +1,5 @@
 # Should I use pumped-fn instead of Effect for DI and typed errors?
 
-Reader question: "Can I get a typed DI/test seam and typed errors without adopting an Effect runtime?"
-
-Pillar proven: readability without giving up the test and trace seam.
-
-Entry arena: first-party comparison, `pumped-fn vs Effect`.
-
 Use pumped-fn when the unit of adoption should stay a plain TypeScript function behind a scope. Scalar flows return `MaybePromise<Output>`; streaming flows use async generators only when the result is a stream.
 
 ```ts
@@ -39,18 +33,18 @@ await scope.dispose()
 | Pick | Cost | When to Pick |
 | --- | --- | --- |
 | pumped-fn | Learn scopes, lifetimes, and dependency kinds | You want graph seams, presets, tags, and extension hooks while product code remains ordinary `async` TypeScript. |
-| Effect | Needs external citation before this page claims details | Pick it when you want Effect's own typed effect combinators, ecosystem, and fiber concurrency model. Do not make repo-uncited claims about Effect here. |
+| Effect | Detailed Effect claims are not covered here | Pick it when you want Effect's own typed effect combinators, ecosystem, and fiber concurrency model. This page does not document Effect internals. |
 
-## Claim -> Citation
+## Proven in the source
 
-Flow factories are normal functions returning `MaybePromise<Output>` or async generators: `[pkg/core/lite/src/flow.ts:146-212](../pkg/core/lite/src/flow.ts#L146-L212)`, `[pkg/core/lite/src/types.ts:586-594](../pkg/core/lite/src/types.ts#L586-L594)`.
+- Flow factories are normal functions returning `MaybePromise<Output>` or async generators: [pkg/core/lite/src/flow.ts:146-212](../pkg/core/lite/src/flow.ts#L146-L212), [pkg/core/lite/src/types.ts:586-594](../pkg/core/lite/src/types.ts#L586-L594).
 
-`typed<T>()` is a type marker for flow input and faults: `[pkg/core/lite/src/flow.ts:4-20](../pkg/core/lite/src/flow.ts#L4-L20)`, `[pkg/core/lite/src/flow.ts:260-284](../pkg/core/lite/src/flow.ts#L260-L284)`.
+- `typed<T>()` is a type marker for flow input and faults: [pkg/core/lite/src/flow.ts:4-20](../pkg/core/lite/src/flow.ts#L4-L20), [pkg/core/lite/src/flow.ts:260-284](../pkg/core/lite/src/flow.ts#L260-L284).
 
-`ctx.fail` throws a `FlowFault` carrying a fault payload: `[pkg/core/lite/src/types.ts:25-35](../pkg/core/lite/src/types.ts#L25-L35)`, `[pkg/core/lite/src/types.ts:233-254](../pkg/core/lite/src/types.ts#L233-L254)`, `[pkg/core/lite/tests/flow-fault.test.ts:8-21](../pkg/core/lite/tests/flow-fault.test.ts#L8-L21)`.
+- `ctx.fail` throws a `FlowFault` carrying a fault payload: [pkg/core/lite/src/types.ts:25-35](../pkg/core/lite/src/types.ts#L25-L35), [pkg/core/lite/src/types.ts:233-254](../pkg/core/lite/src/types.ts#L233-L254), [pkg/core/lite/tests/flow-fault.test.ts:8-21](../pkg/core/lite/tests/flow-fault.test.ts#L8-L21).
 
-`isFault` narrows by `FlowFault` plus flow name. It does not prove exact flow-instance identity: `[pkg/core/lite/src/flow.ts:260-290](../pkg/core/lite/src/flow.ts#L260-L290)`.
+- `isFault` narrows by `FlowFault` plus flow name. It does not prove exact flow-instance identity: [pkg/core/lite/src/flow.ts:260-290](../pkg/core/lite/src/flow.ts#L260-L290).
 
-The scope seam is still available with typed faults because `ctx.exec({ flow, input })` runs the same flow object through the execution context: `[pkg/core/lite/src/types.ts:233-245](../pkg/core/lite/src/types.ts#L233-L245)`, `[pkg/core/lite/src/scope.ts:2084-2131](../pkg/core/lite/src/scope.ts#L2084-L2131)`.
+- The scope seam is still available with typed faults because `ctx.exec({ flow, input })` runs the same flow object through the execution context: [pkg/core/lite/src/types.ts:233-245](../pkg/core/lite/src/types.ts#L233-L245), [pkg/core/lite/src/scope.ts:2084-2131](../pkg/core/lite/src/scope.ts#L2084-L2131).
 
-No performance or bundle-size claim belongs on this page.
+This page makes no performance or bundle-size claim.

--- a/docs/vs-effect.md
+++ b/docs/vs-effect.md
@@ -1,6 +1,6 @@
 # Should I use pumped-fn instead of Effect for DI and typed errors?
 
-Use pumped-fn when the unit of adoption should stay a plain TypeScript function behind a scope. Scalar flows return `MaybePromise<Output>`; streaming flows use async generators only when the result is a stream.
+Use pumped-fn when the unit of adoption should stay a plain TypeScript function behind a scope.
 
 ```ts
 import { createScope, flow, isFault, typed } from "@pumped-fn/lite"
@@ -28,23 +28,28 @@ await ctx.close()
 await scope.dispose()
 ```
 
+The flow returns through normal `await`, and typed faults move through `ctx.fail`. Scalar flows return `MaybePromise<Output>`; streaming flows use async generators only when the result is a stream.
+
+> **Note:** `isFault` narrows by `FlowFault` plus flow name. It does not check exact flow-instance identity.
+
 ## Decision Table
 
 | Pick | Cost | When to Pick |
 | --- | --- | --- |
 | pumped-fn | Learn scopes, lifetimes, and dependency kinds | You want graph seams, presets, tags, and extension hooks while product code remains ordinary `async` TypeScript. |
-| Effect | Detailed Effect claims are not covered here | Pick it when you want Effect's own typed effect combinators, ecosystem, and fiber concurrency model. This page does not document Effect internals. |
+| Effect | Adopt the Effect runtime and combinator style throughout your codebase | Pick it when you want Effect's own typed effect combinators, ecosystem, and fiber concurrency model. |
 
-## Proven in the source
+The scope seam is still there when you use typed faults: `ctx.exec({ flow, input })` runs the same flow object through the execution context.
 
-- Flow factories are normal functions returning `MaybePromise<Output>` or async generators: [pkg/core/lite/src/flow.ts:146-212](../pkg/core/lite/src/flow.ts#L146-L212), [pkg/core/lite/src/types.ts:586-594](../pkg/core/lite/src/types.ts#L586-L594).
 
-- `typed<T>()` is a type marker for flow input and faults: [pkg/core/lite/src/flow.ts:4-20](../pkg/core/lite/src/flow.ts#L4-L20), [pkg/core/lite/src/flow.ts:260-284](../pkg/core/lite/src/flow.ts#L260-L284).
+## Source
 
-- `ctx.fail` throws a `FlowFault` carrying a fault payload: [pkg/core/lite/src/types.ts:25-35](../pkg/core/lite/src/types.ts#L25-L35), [pkg/core/lite/src/types.ts:233-254](../pkg/core/lite/src/types.ts#L233-L254), [pkg/core/lite/tests/flow-fault.test.ts:8-21](../pkg/core/lite/tests/flow-fault.test.ts#L8-L21).
+- [Flow implementation](../pkg/core/lite/src/flow.ts)
+- [Flow and context types](../pkg/core/lite/src/types.ts)
+- [Flow fault tests](../pkg/core/lite/tests/flow-fault.test.ts)
+- [Scope execution](../pkg/core/lite/src/scope.ts)
 
-- `isFault` narrows by `FlowFault` plus flow name. It does not prove exact flow-instance identity: [pkg/core/lite/src/flow.ts:260-290](../pkg/core/lite/src/flow.ts#L260-L290).
+## Next
 
-- The scope seam is still available with typed faults because `ctx.exec({ flow, input })` runs the same flow object through the execution context: [pkg/core/lite/src/types.ts:233-245](../pkg/core/lite/src/types.ts#L233-L245), [pkg/core/lite/src/scope.ts:2084-2131](../pkg/core/lite/src/scope.ts#L2084-L2131).
-
-This page makes no performance or bundle-size claim.
+- [TypeScript DI without decorators](vs-di-containers.md)
+- [Mental model](mental-model.md)


### PR DESCRIPTION
## What

The merged docs pages read like proof documents (claim → evidence → caveat) — the register the content pipeline bred them in. This PR rewrites all 9 `docs/` pages in teaching register:

- Each page: problem → working code in the first screen → short you-voice explanation → `> Note:` callouts in context → **Source** / **Next** footers.
- Citation links unwrapped (they were backtick-wrapped and rendered as dead text) and de-noised into Source sections.
- Internal scaffolding removed ("Reader question / Pillar proven / Entry arena" headers, writer-directed caveat commandments).
- `docs/README.md` is now a short warm index with an honest-limits bullet list.

## What did NOT change

Code snippets (byte-for-byte), every verified claim and caveat (isFault name-matching, tag failure timing, suspense streaming limit, at-least-once note, experimental package labels), the H1s, and the README first screen.

## Verification

- Independent frozen-fact audit: all 6 fact classes intact, no overclaims introduced.
- 33/33 links resolve.
- `pumped-lite-lint README.md docs`: 0 diagnostics (docs are in the root lint gate).
- Per-page readability review: reads-well across the set after final voice polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)