### PR TITLE
docs: README H1 names the library, not just the test angle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Test without mocking modules
+# pumped-fn
 
 [![npm version](https://img.shields.io/npm/v/@pumped-fn/lite)](https://www.npmjs.com/package/@pumped-fn/lite)
 [![npm downloads](https://img.shields.io/npm/dm/@pumped-fn/lite)](https://www.npmjs.com/package/@pumped-fn/lite)
 [![license](https://img.shields.io/npm/l/@pumped-fn/lite)](LICENSE)
 [![minzip](https://img.shields.io/bundlephobia/minzip/@pumped-fn/lite)](https://bundlephobia.com/package/@pumped-fn/lite)
 
-pumped-fn puts your app behind the scope: fully testable, fully traceable, without compromising readability.
+Put your app behind a scope, and it becomes fully testable, fully traceable, without compromising readability. One graph carries your backend handlers, scheduled jobs, workflows, and React components — the same nodes swap for fakes in tests and light up as spans in production.
 
 ```text
 createScope({ presets, tags, extensions })
@@ -14,7 +14,9 @@ createScope({ presets, tags, extensions })
   -> flows, resources, tags, and wrapped execution edges
 ```
 
-Production code declares graph edges. Tests replace those edges at `createScope`, then execute the same public flow the app uses.
+## Test without mocking modules
+
+The clearest place to start is testing. Production code declares graph edges; tests replace those edges at `createScope`, then execute the same public flow the app uses — no `vi.mock`, no module interception.
 
 ```ts
 import { atom, createScope, flow, preset, tag, tags, typed } from "@pumped-fn/lite"


### PR DESCRIPTION
## Why

The merged README opened with `# Test without mocking modules` — the flagship SEO phrase doubling as the project title. A visitor landing on the repo reads it as a testing utility, not the application-structure library that carries backend handlers, scheduled jobs, workflows, and React on one graph.

## What changed

- **H1 → `pumped-fn`**, with a lead sentence naming the real span (one graph across backend/jobs/workflows/React; same nodes swap in tests and trace in production).
- The **vi.mock hook survives as an `## Test without mocking modules` H2** above the seam example — the winnable query keeps a heading, so SEO/AI-citation value is preserved.

## Walls

- Only verified size claim (zero deps, ~12 kB); no new claims (the span was already documented across `docs/`, just not surfaced in the README's first line).
- `pumped-lite-lint README.md docs`: 0 diagnostics. Code unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)