### PR TITLE
docs: navigation edges — no more dead ends on GitHub or npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,37 +148,38 @@ Read the checklist: [How to review pumped-fn code](docs/code-review-guide.md).
 
 | Path | What it shows |
 | --- | --- |
-| `examples/invoice-triage` | Canonical Postgres-backed invoice import and triage with traced store, model, review, and reminder edges. |
+| [examples](examples/README.md) | Examples index. |
+| [examples/invoice-triage](examples/invoice-triage/README.md) | Canonical Postgres-backed invoice import and triage with traced store, model, review, and reminder edges. |
 
 ## Package inventory
 
 | Path | Package |
 | --- | --- |
-| `pkg/core/lite` | `@pumped-fn/lite` |
-| `pkg/ext/hmr` | `@pumped-fn/lite-hmr` |
-| `pkg/ext/logging` | `@pumped-fn/lite-extension-logging` |
-| `pkg/ext/logging-pino` | `@pumped-fn/lite-extension-logging-pino` |
-| `pkg/ext/observable` | `@pumped-fn/lite-extension-observable` |
-| `pkg/ext/observable-otel` | `@pumped-fn/lite-extension-observable-otel` |
-| `pkg/ext/scheduler` | `@pumped-fn/lite-extension-scheduler` |
-| `pkg/ext/scheduler-nats` | `@pumped-fn/lite-extension-scheduler-nats` |
-| `pkg/ext/suspense` | `@pumped-fn/lite-extension-suspense` |
-| `pkg/ext/sync` | `@pumped-fn/lite-extension-sync` |
-| `pkg/ext/sync-nats` | `@pumped-fn/lite-extension-sync-nats` |
-| `pkg/framework/hono` | `@pumped-fn/lite-hono` |
-| `pkg/framework/pumped` | `@pumped-fn/pumped` |
-| `pkg/framework/tanstack-start` | `@pumped-fn/lite-tanstack-start` |
-| `pkg/react/json` | `@pumped-fn/lite-react-json-render` |
-| `pkg/react/lite-react` | `@pumped-fn/lite-react` |
-| `pkg/render/core` | `@pumped-fn/lite-render-core` |
-| `pkg/render/react` | `@pumped-fn/lite-render-react` |
-| `pkg/sdk/bash` | `@pumped-fn/sdk-just-bash` |
-| `pkg/sdk/claude` | `@pumped-fn/sdk-claude` |
-| `pkg/sdk/codex` | `@pumped-fn/sdk-codex` |
-| `pkg/sdk/core` | `@pumped-fn/sdk` |
-| `pkg/sdk/test` | `@pumped-fn/sdk-test` |
-| `pkg/tool/codemod` | `@pumped-fn/codemod` |
-| `pkg/tool/lint` | `@pumped-fn/lite-lint` |
+| [pkg/core/lite](pkg/core/lite/README.md) | `@pumped-fn/lite` |
+| [pkg/ext/hmr](pkg/ext/hmr/README.md) | `@pumped-fn/lite-hmr` |
+| [pkg/ext/logging](pkg/ext/logging/README.md) | `@pumped-fn/lite-extension-logging` |
+| [pkg/ext/logging-pino](pkg/ext/logging-pino/README.md) | `@pumped-fn/lite-extension-logging-pino` |
+| [pkg/ext/observable](pkg/ext/observable/README.md) | `@pumped-fn/lite-extension-observable` |
+| [pkg/ext/observable-otel](pkg/ext/observable-otel/README.md) | `@pumped-fn/lite-extension-observable-otel` |
+| [pkg/ext/scheduler](pkg/ext/scheduler/README.md) | `@pumped-fn/lite-extension-scheduler` |
+| [pkg/ext/scheduler-nats](pkg/ext/scheduler-nats/README.md) | `@pumped-fn/lite-extension-scheduler-nats` |
+| [pkg/ext/suspense](pkg/ext/suspense/README.md) | `@pumped-fn/lite-extension-suspense` |
+| [pkg/ext/sync](pkg/ext/sync/README.md) | `@pumped-fn/lite-extension-sync` |
+| [pkg/ext/sync-nats](pkg/ext/sync-nats/README.md) | `@pumped-fn/lite-extension-sync-nats` |
+| [pkg/framework/hono](pkg/framework/hono/README.md) | `@pumped-fn/lite-hono` |
+| [pkg/framework/pumped](pkg/framework/pumped/README.md) | `@pumped-fn/pumped` |
+| [pkg/framework/tanstack-start](pkg/framework/tanstack-start/README.md) | `@pumped-fn/lite-tanstack-start` |
+| [pkg/react/json](pkg/react/json/README.md) | `@pumped-fn/lite-react-json-render` |
+| [pkg/react/lite-react](pkg/react/lite-react/README.md) | `@pumped-fn/lite-react` |
+| [pkg/render/core](pkg/render/core/README.md) | `@pumped-fn/lite-render-core` |
+| [pkg/render/react](pkg/render/react/README.md) | `@pumped-fn/lite-render-react` |
+| [pkg/sdk/bash](pkg/sdk/bash/README.md) | `@pumped-fn/sdk-just-bash` |
+| [pkg/sdk/claude](pkg/sdk/claude/README.md) | `@pumped-fn/sdk-claude` |
+| [pkg/sdk/codex](pkg/sdk/codex/README.md) | `@pumped-fn/sdk-codex` |
+| [pkg/sdk/core](pkg/sdk/core/README.md) | `@pumped-fn/sdk` |
+| [pkg/sdk/test](pkg/sdk/test/README.md) | `@pumped-fn/sdk-test` |
+| [pkg/tool/codemod](pkg/tool/codemod/README.md) | `@pumped-fn/codemod` |
+| [pkg/tool/lint](pkg/tool/lint/README.md) | `@pumped-fn/lite-lint` |
 
 ## Documentation
 

--- a/pkg/core/lite/PATTERNS.md
+++ b/pkg/core/lite/PATTERNS.md
@@ -518,3 +518,9 @@ BFF practical examples:
 pnpm test
 pnpm typecheck
 ```
+
+## Next
+
+- [Lite README](./README.md)
+- [Mental model](../../../docs/mental-model.md)
+- [Invoice triage example](../../../examples/invoice-triage/README.md)

--- a/pkg/core/lite/README.md
+++ b/pkg/core/lite/README.md
@@ -12,6 +12,8 @@ BFF routes, workers, CLIs, React roots, and tests.
 npm install @pumped-fn/lite
 ```
 
+Upgrading from older versions: see [`MIGRATION.md`](./MIGRATION.md).
+
 ```bash
 npx @pumped-fn/lite
 npx @pumped-fn/lite primitives
@@ -505,3 +507,6 @@ React integration: [`@pumped-fn/lite-react`](../../react/lite-react/README.md)
 ## License
 
 MIT
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/hmr/README.md
+++ b/pkg/ext/hmr/README.md
@@ -91,3 +91,6 @@ The plugin is automatically disabled in production builds (`NODE_ENV=production`
 ## License
 
 MIT
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/logging-pino/README.md
+++ b/pkg/ext/logging-pino/README.md
@@ -23,3 +23,6 @@ const scope = createScope({
 
 Use `map` when a Pino schema needs different field names. Use `flush` or `close` when the selected
 Pino destination needs explicit lifecycle handling.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/logging/README.md
+++ b/pkg/ext/logging/README.md
@@ -54,3 +54,6 @@ The `logging.logger` resource is execution-owned and flushes sinks on context cl
 OpenTelemetry logs and OTLP collectors are adapter targets for `Logging.Sink`; this package does not
 import or ship those backends. Use `@pumped-fn/lite-extension-logging-pino` when the runtime sink
 should write records to Pino.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/observable-otel/README.md
+++ b/pkg/ext/observable-otel/README.md
@@ -38,3 +38,6 @@ observable.runtime -> otel.sink -> OpenTelemetry SDK -> OTLP exporter -> Collect
 Use the same `otel.sink()` in application code, then configure the OpenTelemetry SDK or Collector
 for the backend endpoint. Grafana Tempo, VictoriaTraces, and Jaeger are compatible examples when
 their OTLP receiver or Collector export path is enabled.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/observable/README.md
+++ b/pkg/ext/observable/README.md
@@ -56,3 +56,6 @@ import or ship those backends. Use
 `@pumped-fn/lite-extension-observable-otel` when the runtime sink should map events to
 OpenTelemetry spans. The OTEL adapter stays backend-generic: Grafana, Victoria, and Jaeger
 compatibility comes from standard OTLP configuration.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/scheduler-nats/README.md
+++ b/pkg/ext/scheduler-nats/README.md
@@ -113,3 +113,6 @@ await scope.resolve(nightlySweep)
 
 `catchUp: "skip"` never reads `last.<name>` at all. With no `last.<name>` key present (first
 deployment), `catchUp: "last"`/`"all"` run nothing — there is nothing to catch up from.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/scheduler/README.md
+++ b/pkg/ext/scheduler/README.md
@@ -89,3 +89,6 @@ registration.next() // next scheduled Date, or undefined
 await registration.trigger() // run one tick immediately, awaiting it
 await scope.dispose() // stops the registration
 ```
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/suspense/README.md
+++ b/pkg/ext/suspense/README.md
@@ -30,3 +30,6 @@ await ctx.exec({ flow: waitForCommit })
 ```
 
 Marked steps get key `(taskId, runId, step)`. Completed steps replay from the log. Suspended steps write pending entries and throw `SuspendSignal` until a resolver stores a value.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/sync-nats/README.md
+++ b/pkg/ext/sync-nats/README.md
@@ -31,3 +31,6 @@ Watch failures resubscribe from the last delivered KV revision by default. Use
 `nats.kv(kv, { prefix, onError, retry })` to customize the KV subject prefix, receive watch-loop
 failures from the adapter boundary with retry metadata, or disable adapter-level retry with
 `retry: false`.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/sync/README.md
+++ b/pkg/ext/sync/README.md
@@ -26,3 +26,6 @@ const right = createScope({
 
 `sync(...)` returns an atom-like value. Plain JSON-safe state is inferred. Non-JSON state must use a
 codec, and every inbound value is decoded before it can be applied.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/framework/hono/README.md
+++ b/pkg/framework/hono/README.md
@@ -49,3 +49,6 @@ handlers seed tags at the framework boundary and then execute public Lite units.
 
 Pass `key` to use another Hono variable name. Pass `close: false` if an outer framework boundary owns
 `ctx.close(...)`.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/framework/pumped/README.md
+++ b/pkg/framework/pumped/README.md
@@ -287,3 +287,6 @@ same flows the app serves.
 Deps are declared, never dynamically registered. A flow's `deps` and a resource's shape are static
 and readable without running anything. That's what keeps the graph compilable ahead of time instead
 of only inspectable at runtime.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/framework/tanstack-start/README.md
+++ b/pkg/framework/tanstack-start/README.md
@@ -52,3 +52,6 @@ middleware seeds tags at the framework boundary and handlers execute public Lite
 
 Pass `key` to use another context property. Pass `close: false` when another boundary owns
 `ctx.close(...)`.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/react/json/README.md
+++ b/pkg/react/json/README.md
@@ -161,3 +161,6 @@ provider under `ScopeProvider` and `ExecutionContextProvider`.
 ## License
 
 MIT
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/react/lite-react/README.md
+++ b/pkg/react/lite-react/README.md
@@ -434,12 +434,15 @@ It also exports:
 - `useResource`
 - `useScopedValue`
 
-Complete type reference: [`dist/index.d.mts`](./dist/index.d.mts)
+Complete type reference: [`dist/index.d.mts`](https://github.com/pumped-fn/pumped-fn/blob/main/pkg/react/lite-react/dist/index.d.mts)
 
-Patterns and guardrails: [`PATTERNS.md`](./PATTERNS.md)
+Patterns and guardrails: [`PATTERNS.md`](https://github.com/pumped-fn/pumped-fn/blob/main/pkg/react/lite-react/PATTERNS.md)
 
-Core runtime: [`@pumped-fn/lite`](../../core/lite/README.md)
+Core runtime: [`@pumped-fn/lite`](https://github.com/pumped-fn/pumped-fn/blob/main/pkg/core/lite/README.md)
 
 ## License
 
 MIT
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/render/core/README.md
+++ b/pkg/render/core/README.md
@@ -115,3 +115,6 @@ The contract is plain data and synchronous functions: build a `defineRender(...)
 ## License
 
 MIT
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/render/react/README.md
+++ b/pkg/render/react/README.md
@@ -108,3 +108,6 @@ without React.
 ## License
 
 MIT
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/sdk/bash/README.md
+++ b/pkg/sdk/bash/README.md
@@ -19,3 +19,6 @@ const scope = createScope({
 ```
 
 `sandbox()` returns a lazy `agent.sandbox` tag. The `Bash` runtime is created only when a sandbox capability is first used, and the flow can be run with any other `sdk` sandbox tag instead.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/sdk/claude/README.md
+++ b/pkg/sdk/claude/README.md
@@ -15,3 +15,6 @@ await ctx.exec({ flow: triage.turn, input: { prompt: "Triage this ticket." } })
 ```
 
 `claude()` returns a lazy `model` tag. The Claude harness is created only when the model is first used, and the agent can be run with `codex()` or `model(fake)` instead without changing the graph.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/sdk/codex/README.md
+++ b/pkg/sdk/codex/README.md
@@ -15,3 +15,6 @@ await ctx.exec({ flow: triage.turn, input: { prompt: "Triage this ticket." } })
 ```
 
 `codex()` returns a lazy `model` tag. The Codex harness is created only when the model is first used, and the agent can be run with `claude()` or `model(fake)` instead without changing the graph.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/sdk/core/README.md
+++ b/pkg/sdk/core/README.md
@@ -542,3 +542,6 @@ const { extensions, log } = kit({
 ```
 
 Use `extensions` in `createScope({ extensions })`. This keeps tests fast and proves the same extension contract a NATS-backed runtime will use.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/sdk/test/README.md
+++ b/pkg/sdk/test/README.md
@@ -14,3 +14,6 @@ const ctx = scope.createContext()
 ```
 
 `localRemoteRunner` executes remote-tagged steps in process for tests. `MemoryWorkflowLog` implements the same `RunLog` contract used by `inspect()`.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/tool/codemod/README.md
+++ b/pkg/tool/codemod/README.md
@@ -145,3 +145,6 @@ const fetchUser = controller(async (ctx, id: string) => {
 ```bash
 git checkout .
 ```
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/tool/lint/README.md
+++ b/pkg/tool/lint/README.md
@@ -93,3 +93,11 @@ import { scanPaths, scanText } from "@pumped-fn/lite-lint"
 const result = await scanPaths(["src", "tests"])
 const diagnostics = scanText(source, "src/file.ts")
 ```
+
+## Next
+
+- [Code review guide](../../../docs/code-review-guide.md)
+- [pumped-fn README](../../../README.md)
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).


### PR DESCRIPTION
PR-A of the docs-surface review (audit: 3 parallel read-only auditors over the full click-reachable markdown surface).

## Findings this fixes

- **0 of 24 package READMEs linked back** to the repo/docs — every npmjs.com package page was a dead end. Now all carry an absolute-URL uplink footer (npm-safe).
- README's package inventory was **plain text, not links** — the package surface was invisible. Now every path links.
- `lite-react` had 3 repo-relative links that 404 on npm — now absolute.
- Deep dead-end pages (`pkg/core/lite/PATTERNS.md`, lint README) got onward navigation; `MIGRATION.md` and `examples/` are reachable by clicking now.

## Verification

- 25/25 uplink footers present; 0 broken relative links in all 27 changed files; lint gate 0 diagnostics.
- Edges only — no prose rewrites, no claim changes.

Next: PR-B (experimental banners + claim caveats), PR-C (ring-2 register rewrites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)