### PR TITLE
docs: status banners + source-verified claim caveats

### DIFF
--- a/pkg/ext/hmr/README.md
+++ b/pkg/ext/hmr/README.md
@@ -2,7 +2,7 @@
 
 Vite HMR plugin for `@pumped-fn/lite` that preserves atom state across hot module reloads.
 
-**Dev only** · **Zero overhead in production** · **Vite plugin**
+**Dev only** · **Production transform returns `null`** · **Vite plugin**
 
 ## How It Works
 
@@ -86,7 +86,7 @@ pumpedHmr({
 
 ## Production
 
-The plugin is automatically disabled in production builds (`NODE_ENV=production`).
+When `NODE_ENV=production`, the plugin transform returns `null` and does not inject the HMR helper.
 
 ## License
 

--- a/pkg/ext/sync/README.md
+++ b/pkg/ext/sync/README.md
@@ -2,6 +2,14 @@
 
 Strict replicated state for Lite scopes.
 
+## Install
+
+```bash
+npm install @pumped-fn/lite @pumped-fn/lite-extension-sync
+```
+
+## Usage
+
 ```ts
 import { createScope } from "@pumped-fn/lite"
 import { sync } from "@pumped-fn/lite-extension-sync"
@@ -26,6 +34,10 @@ const right = createScope({
 
 `sync(...)` returns an atom-like value. Plain JSON-safe state is inferred. Non-JSON state must use a
 codec, and every inbound value is decoded before it can be applied.
+
+## Semantics
+
+The core extension is transport-driven: a local controller change is encoded, written as a per-key `Sync.Message`, and remote peers apply subscribed messages from other peers; without a `conflict` policy, an inbound value replaces the local value. Conflict handling is opt-in per atom: `sync.revision(...)` accepts only higher app-level revisions and reports equal-version conflicts, while `sync.lww(...)` keeps the value with the greater-or-equal app-level timestamp/version. The NATS KV transport stores one KV entry per sync key with backend revision acks, maps stale revision writes to `WriteConflict`, and resumes watches from the last delivered KV revision; it does not introduce a leader or cross-key ordering.
 
 ---
 Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/framework/pumped/README.md
+++ b/pkg/framework/pumped/README.md
@@ -1,5 +1,7 @@
 # @pumped-fn/pumped
 
+> **Status: experimental.** APIs change without notice; not recommended for production yet.
+
 A scope compiler, not a runtime. `pumped` discovers flows on disk, assembles them into one
 `@pumped-fn/lite` scope, and drives that scope under a run mode — dev server, test, or production
 build. One graph, three projections:

--- a/pkg/render/core/README.md
+++ b/pkg/render/core/README.md
@@ -1,5 +1,7 @@
 # @pumped-fn/lite-render-core
 
+> **Status: experimental.** APIs change without notice; not recommended for production yet.
+
 Platform-neutral strict spec/catalog render contract for `@pumped-fn/lite`.
 
 This is the **core** half of a core/react split (mirroring json-render): it owns the portable spec types, the

--- a/pkg/render/react/README.md
+++ b/pkg/render/react/README.md
@@ -1,5 +1,7 @@
 # @pumped-fn/lite-render-react
 
+> **Status: experimental.** APIs change without notice; not recommended for production yet.
+
 React adapter for the `@pumped-fn/lite-render-core` render contract.
 
 This is the **react** half of a core/react split (mirroring json-render): core owns the portable spec, the

--- a/pkg/sdk/bash/README.md
+++ b/pkg/sdk/bash/README.md
@@ -1,5 +1,7 @@
 # @pumped-fn/sdk-just-bash
 
+> **Status: early.** Small surface, expect changes.
+
 `just-bash` sandbox provider for `@pumped-fn/sdk`.
 
 ```ts

--- a/pkg/sdk/claude/README.md
+++ b/pkg/sdk/claude/README.md
@@ -1,5 +1,7 @@
 # @pumped-fn/sdk-claude
 
+> **Status: experimental.** APIs change without notice; not recommended for production yet.
+
 Claude CLI model provider for `@pumped-fn/sdk`.
 
 ```ts

--- a/pkg/sdk/codex/README.md
+++ b/pkg/sdk/codex/README.md
@@ -1,5 +1,7 @@
 # @pumped-fn/sdk-codex
 
+> **Status: experimental.** APIs change without notice; not recommended for production yet.
+
 Codex CLI model provider for `@pumped-fn/sdk`.
 
 ```ts

--- a/pkg/sdk/core/README.md
+++ b/pkg/sdk/core/README.md
@@ -4,6 +4,8 @@ Generic runtime primitives on top of `@pumped-fn/lite`: durable workflow steps, 
 materials, event buffers, guards, sandboxes, CLI workers, and an eval harness. Agents and models
 are one primitive family built on the same seam, not the headline.
 
+> **Note:** Durability is delegated to the `WorkflowEventLog` backend you provide. The in-repo `MemoryWorkflowLog` is in-memory and for tests; bring a persistent backend for real durability.
+
 `@pumped-fn/sdk` is the counterpart to `@pumped-fn/pumped`: this package provides the primitives —
 `pumped` discovers, assembles, and runs them as an application.
 


### PR DESCRIPTION
PR-B of the docs-surface review.

- **Experimental banners** under the H1 of `pumped`, `render-core`, `render-react`, `sdk-claude`, `sdk-codex` (+ an *early* banner on `sdk-bash`) — these read as shipped product before.
- **`sdk-core` durability caveat** in the first screen, worded against the actual source: durability is delegated to the `WorkflowEventLog` backend you provide; the in-repo `MemoryWorkflowLog` is test-only.
- **`ext/sync` gets a Semantics section** derived from source: transport-driven replace by default, opt-in `sync.revision` / `sync.lww` conflict policies, NATS KV per-key revisions, no leader, no cross-key ordering.
- **`hmr`**: unverified "zero overhead in production" claim removed.
- Verified non-drift: scheduler-nats exactly-once phrasing stays exactly as caveated; PATTERNS' `ctx.close({ok})` and Service Pattern checked against current API — both current, no changes needed.
- Lint gate: 0 diagnostics.

Next: PR-C (ring-2 register rewrites: examples index, invoice-triage ordering, core README/PATTERNS teaching pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)