### PR TITLE
docs: ring-2 register rewrites — the deep pages read like docs too

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,38 +148,38 @@ Read the checklist: [How to review pumped-fn code](docs/code-review-guide.md).
 
 | Path | What it shows |
 | --- | --- |
-| [examples](examples/README.md) | Examples index. |
-| [examples/invoice-triage](examples/invoice-triage/README.md) | Canonical Postgres-backed invoice import and triage with traced store, model, review, and reminder edges. |
+| `examples` | [Examples index](examples/README.md). |
+| `examples/invoice-triage` | [Canonical Postgres-backed invoice import and triage with traced store, model, review, and reminder edges.](examples/invoice-triage/README.md) |
 
 ## Package inventory
 
-| Path | Package |
-| --- | --- |
-| [pkg/core/lite](pkg/core/lite/README.md) | `@pumped-fn/lite` |
-| [pkg/ext/hmr](pkg/ext/hmr/README.md) | `@pumped-fn/lite-hmr` |
-| [pkg/ext/logging](pkg/ext/logging/README.md) | `@pumped-fn/lite-extension-logging` |
-| [pkg/ext/logging-pino](pkg/ext/logging-pino/README.md) | `@pumped-fn/lite-extension-logging-pino` |
-| [pkg/ext/observable](pkg/ext/observable/README.md) | `@pumped-fn/lite-extension-observable` |
-| [pkg/ext/observable-otel](pkg/ext/observable-otel/README.md) | `@pumped-fn/lite-extension-observable-otel` |
-| [pkg/ext/scheduler](pkg/ext/scheduler/README.md) | `@pumped-fn/lite-extension-scheduler` |
-| [pkg/ext/scheduler-nats](pkg/ext/scheduler-nats/README.md) | `@pumped-fn/lite-extension-scheduler-nats` |
-| [pkg/ext/suspense](pkg/ext/suspense/README.md) | `@pumped-fn/lite-extension-suspense` |
-| [pkg/ext/sync](pkg/ext/sync/README.md) | `@pumped-fn/lite-extension-sync` |
-| [pkg/ext/sync-nats](pkg/ext/sync-nats/README.md) | `@pumped-fn/lite-extension-sync-nats` |
-| [pkg/framework/hono](pkg/framework/hono/README.md) | `@pumped-fn/lite-hono` |
-| [pkg/framework/pumped](pkg/framework/pumped/README.md) | `@pumped-fn/pumped` |
-| [pkg/framework/tanstack-start](pkg/framework/tanstack-start/README.md) | `@pumped-fn/lite-tanstack-start` |
-| [pkg/react/json](pkg/react/json/README.md) | `@pumped-fn/lite-react-json-render` |
-| [pkg/react/lite-react](pkg/react/lite-react/README.md) | `@pumped-fn/lite-react` |
-| [pkg/render/core](pkg/render/core/README.md) | `@pumped-fn/lite-render-core` |
-| [pkg/render/react](pkg/render/react/README.md) | `@pumped-fn/lite-render-react` |
-| [pkg/sdk/bash](pkg/sdk/bash/README.md) | `@pumped-fn/sdk-just-bash` |
-| [pkg/sdk/claude](pkg/sdk/claude/README.md) | `@pumped-fn/sdk-claude` |
-| [pkg/sdk/codex](pkg/sdk/codex/README.md) | `@pumped-fn/sdk-codex` |
-| [pkg/sdk/core](pkg/sdk/core/README.md) | `@pumped-fn/sdk` |
-| [pkg/sdk/test](pkg/sdk/test/README.md) | `@pumped-fn/sdk-test` |
-| [pkg/tool/codemod](pkg/tool/codemod/README.md) | `@pumped-fn/codemod` |
-| [pkg/tool/lint](pkg/tool/lint/README.md) | `@pumped-fn/lite-lint` |
+| Path | Package | Docs |
+| --- | --- | --- |
+| `pkg/core/lite` | `@pumped-fn/lite` | [README](pkg/core/lite/README.md) |
+| `pkg/ext/hmr` | `@pumped-fn/lite-hmr` | [README](pkg/ext/hmr/README.md) |
+| `pkg/ext/logging` | `@pumped-fn/lite-extension-logging` | [README](pkg/ext/logging/README.md) |
+| `pkg/ext/logging-pino` | `@pumped-fn/lite-extension-logging-pino` | [README](pkg/ext/logging-pino/README.md) |
+| `pkg/ext/observable` | `@pumped-fn/lite-extension-observable` | [README](pkg/ext/observable/README.md) |
+| `pkg/ext/observable-otel` | `@pumped-fn/lite-extension-observable-otel` | [README](pkg/ext/observable-otel/README.md) |
+| `pkg/ext/scheduler` | `@pumped-fn/lite-extension-scheduler` | [README](pkg/ext/scheduler/README.md) |
+| `pkg/ext/scheduler-nats` | `@pumped-fn/lite-extension-scheduler-nats` | [README](pkg/ext/scheduler-nats/README.md) |
+| `pkg/ext/suspense` | `@pumped-fn/lite-extension-suspense` | [README](pkg/ext/suspense/README.md) |
+| `pkg/ext/sync` | `@pumped-fn/lite-extension-sync` | [README](pkg/ext/sync/README.md) |
+| `pkg/ext/sync-nats` | `@pumped-fn/lite-extension-sync-nats` | [README](pkg/ext/sync-nats/README.md) |
+| `pkg/framework/hono` | `@pumped-fn/lite-hono` | [README](pkg/framework/hono/README.md) |
+| `pkg/framework/pumped` | `@pumped-fn/pumped` | [README](pkg/framework/pumped/README.md) |
+| `pkg/framework/tanstack-start` | `@pumped-fn/lite-tanstack-start` | [README](pkg/framework/tanstack-start/README.md) |
+| `pkg/react/json` | `@pumped-fn/lite-react-json-render` | [README](pkg/react/json/README.md) |
+| `pkg/react/lite-react` | `@pumped-fn/lite-react` | [README](pkg/react/lite-react/README.md) |
+| `pkg/render/core` | `@pumped-fn/lite-render-core` | [README](pkg/render/core/README.md) |
+| `pkg/render/react` | `@pumped-fn/lite-render-react` | [README](pkg/render/react/README.md) |
+| `pkg/sdk/bash` | `@pumped-fn/sdk-just-bash` | [README](pkg/sdk/bash/README.md) |
+| `pkg/sdk/claude` | `@pumped-fn/sdk-claude` | [README](pkg/sdk/claude/README.md) |
+| `pkg/sdk/codex` | `@pumped-fn/sdk-codex` | [README](pkg/sdk/codex/README.md) |
+| `pkg/sdk/core` | `@pumped-fn/sdk` | [README](pkg/sdk/core/README.md) |
+| `pkg/sdk/test` | `@pumped-fn/sdk-test` | [README](pkg/sdk/test/README.md) |
+| `pkg/tool/codemod` | `@pumped-fn/codemod` | [README](pkg/tool/codemod/README.md) |
+| `pkg/tool/lint` | `@pumped-fn/lite-lint` | [README](pkg/tool/lint/README.md) |
 
 ## Documentation
 

--- a/examples/CONTRIBUTING.md
+++ b/examples/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing Examples
+
+Use this when you add or change an example. `examples/` is a proof surface for documented patterns, not a publishing target or scratch space.
+
+## Structure
+
+| Directory | Package | Role |
+| --- | --- | --- |
+| `invoice-triage/` | `@pumped-fn/invoice-triage` | Postgres-backed invoice import, LLM triage, database capabilities, daemon/server/CLI entrypoints, and scheduler cron. |
+
+## Naming
+
+Name an example after what the application is, not the lesson it teaches. Keep a tech suffix such as `-hono`, `-cli`, or `-web` only when it distinguishes variants of the same domain. Pure API tours with no domain get an honest `<library>-tour` name. Domain capstones use `<domain>-<surface>` with a shared domain package when multiple entrypoints prove the same behavior.
+
+## Canonical Usage
+
+The canonical example teaches one library shape:
+
+- Composition roots create scopes with the presets, tags, and extensions they need.
+- Tests use the scope seam and public API instead of module mocks or internal reaches.
+- Entrypoints translate transport input into flow input and tags; shared packages own the flows.
+- React examples observe graph state and dispatch with Lite React hooks.
+- Runtime backend variation is passed with tags, presets, or extensions at the composition root.
+
+If an example needs a different shape, document the reason in that example README and make it lint food when the difference is repeatable.
+
+## Inconsistency Guardrails
+
+Inconsistency means one of these measurable failures:
+
+| Guardrail | Failure shape |
+| --- | --- |
+| Example inventory | A package under `examples/*` is missing from this index or the root practical examples table. |
+| Canonical shape | An example README lacks `## Canonical Shape` or describes a shape that differs from the code. |
+| Lint coverage | A current example or guidance README is absent from the root lint script. |
+| Stale references | Markdown points at an example or package path that no longer exists. |
+| Dependency policy | External dependencies bypass `catalog:` or peer dependencies use non-explicit ranges. |
+| Package map | README package tables disagree with current `pkg/*/*/package.json` package names. |
+| Pattern contract | A pattern lacks its bad specimen, canonical rewrite, tests, or explanation sections. |
+| Script surface | `package.json`, workflows, or `scripts/README.md` name a script file that does not exist. |
+
+`pnpm examples:check` measures these guardrails and prints the drift counters.
+
+`before.*` files are the exception by design: they are anti-pattern specimens for lint and pattern work. Every specimen needs a paired canonical rewrite and tests, and the root lint path scans the canonical side.
+
+## Content Rules
+
+Examples should be runnable, tested, and tied to real package behavior. Keep the canonical example deep enough to carry product-shaped requirements instead of spreading shallow demos across domains.
+
+## Boundaries
+
+Do not use examples as hidden package tests. Research notes belong in `research/`; reusable test fixtures belong in package tests or `tests/`.
+
+## Next
+
+- [Examples index](./README.md)
+- [Root README](../README.md)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,63 +1,14 @@
 # Examples
 
-## Purpose
+`examples/` holds runnable applications that show pumped-fn in real code. Start with invoice triage when you want a full app shape instead of a tiny API tour. For package and API docs, start from the [root README](../README.md).
 
-`examples/` holds the private workspace package that shows practical pumped-fn usage. It is a proof
-surface for documented patterns, not a publishing target.
+| Directory | Package | What it shows | Run |
+| --- | --- | --- | --- |
+| `invoice-triage/` | `@pumped-fn/invoice-triage` | [Invoice triage](./invoice-triage/README.md) imports invoices into Postgres and triages them with a model provider across daemon, server, CLI, cron, and tests. | `docker compose -f examples/invoice-triage/compose.yaml up -d postgres`<br>`pnpm -F @pumped-fn/invoice-triage start < examples/invoice-triage/fixtures/demo.ndjson`<br>`PORT=3000 pnpm -F @pumped-fn/invoice-triage server`<br>`pnpm -F @pumped-fn/invoice-triage test` |
 
-## Structure
+Adding an example? See [CONTRIBUTING.md](./CONTRIBUTING.md).
 
-| Directory | Package | Role |
-| --- | --- | --- |
-| `invoice-triage/` | `@pumped-fn/invoice-triage` | Postgres-backed invoice import, LLM triage, database capabilities, daemon/server/CLI entrypoints, and scheduler cron. |
+## Next
 
-## Naming
-
-Examples are named after what the application is, not the lesson it teaches. A tech suffix (e.g.
-`-hono`, `-cli`, `-web`) is kept only where it distinguishes variants of the same domain. Pure API
-tours with no domain get an honest `<library>-tour` name. Domain capstones use `<domain>-<surface>`
-with a shared domain package when multiple entrypoints prove the same behavior.
-
-## Canonical Usage
-
-The canonical example teaches one library shape:
-
-- Composition roots create scopes with the presets, tags, and extensions they need.
-- Tests use the scope seam and public API instead of module mocks or internal reaches.
-- Entrypoints translate transport input into flow input and tags; shared packages own the flows.
-- React examples observe graph state and dispatch with Lite React hooks.
-- Runtime backend variation is passed with tags, presets, or extensions at the composition root.
-
-If an example needs a different shape, document the reason in that example README and make it lint
-food when the difference is repeatable.
-
-## Inconsistency Guardrails
-
-Inconsistency means one of these measurable failures:
-
-| Guardrail | Failure shape |
-| --- | --- |
-| Example inventory | A package under `examples/*` is missing from this index or the root practical examples table. |
-| Canonical shape | An example README lacks `## Canonical Shape` or describes a shape that differs from the code. |
-| Lint coverage | A current example or guidance README is absent from the root lint script. |
-| Stale references | Markdown points at an example or package path that no longer exists. |
-| Dependency policy | External dependencies bypass `catalog:` or peer dependencies use non-explicit ranges. |
-| Package map | README package tables disagree with current `pkg/*/*/package.json` package names. |
-| Pattern contract | A pattern lacks its bad specimen, canonical rewrite, tests, or explanation sections. |
-| Script surface | `package.json`, workflows, or `scripts/README.md` name a script file that does not exist. |
-
-`pnpm examples:check` measures these guardrails and prints the drift counters.
-
-`before.*` files are the exception by design: they are anti-pattern specimens for lint and pattern
-work. Every specimen needs a paired canonical rewrite and tests, and the root lint path scans the
-canonical side.
-
-## Content Rules
-
-Examples should be runnable, tested, and tied to real package behavior. Keep the canonical example
-deep enough to carry product-shaped requirements instead of spreading shallow demos across domains.
-
-## Boundaries
-
-Do not use examples as scratch space or as hidden package tests. Research notes belong in
-`research/`; reusable test fixtures belong in package tests or `tests/`.
+- [Root README](../README.md)
+- [Invoice triage](./invoice-triage/README.md)

--- a/examples/invoice-triage/README.md
+++ b/examples/invoice-triage/README.md
@@ -1,21 +1,30 @@
 # Invoice Triage
 
-Runnable `@pumped-fn/sdk` example for Postgres-backed invoice import, LLM classification, cron reports, reminder delivery, and request routes over the same graph.
+This example imports invoices into Postgres and classifies them with an LLM provider. It runs the same graph from a daemon, HTTP server, and CLI. Durable store steps, cron jobs, and tests show how the pieces recover and stay observable.
 
-It proves:
+## Run
 
-- generator flows with `execStream` progress and `exec` summary consumption
-- `yield*` progress composition from nested generator flows
-- direct data-access flows: each store operation is a plain flow that deps the `database` atom and runs its SQL inline, wrapping multi-write operations in `db.transaction` for per-operation atomicity
-- foreign integration and graph projection side by side: a `notifier` client (an adapter behind a tag) instrumented at its call site with `ctx.exec({ fn: () => notifier.send(msg), name: "notifier.send", tags })`, and role-tag flow projection for the classification model
-- a Postgres-backed ingest queue with Drizzle migrations from the `database` atom and PGlite preset in tests
-- signal-driven ingest using `queueSignal`, `storedSignal`, `outstanding`, `importing`, `drained`, and `stopping`
-- `scope.resolveStream(...)` fan-out feeds plus `scope.drain(..., { take })` shown in tests with a local status feed
-- signal-backed ops views for review queue count from a Postgres jsonb query
-- scheduler-backed cron registration with deterministic manual ticks in tests
-- idempotent reminders through ledger state
-- Hono server, daemon, and CLI entrypoints over the same graph
-- OpenTelemetry spans for flow exec edges when an OTel SDK or test tracer is registered
+```sh
+docker compose -f examples/invoice-triage/compose.yaml up -d postgres
+```
+
+```sh
+pnpm -F @pumped-fn/invoice-triage start < examples/invoice-triage/fixtures/demo.ndjson
+```
+
+```sh
+PORT=3000 pnpm -F @pumped-fn/invoice-triage server
+```
+
+```sh
+pnpm -F @pumped-fn/invoice-triage cli report
+```
+
+```sh
+pnpm -F @pumped-fn/invoice-triage test
+pnpm -F @pumped-fn/invoice-triage typecheck
+pnpm -F @pumped-fn/invoice-triage lint
+```
 
 ## Architecture
 
@@ -76,9 +85,18 @@ flowchart TD
   Deliver -.-> OTel
 ```
 
+## What it shows
+
+- Streaming invoice import with generator flows, `execStream` progress, nested `yield*`, and final `exec` summaries.
+- Postgres-backed ingest through Drizzle migrations, store flows, and PGlite presets in tests.
+- Signal-driven workers and ops views using `queueSignal`, `storedSignal`, `outstanding`, `importing`, `drained`, and `stopping`.
+- Provider seams for the model tag, notifier client, clock, request id, reminder policy, and database URL.
+- Scheduler-backed cron registration, idempotent reminder claims, release-on-failure SQL, and deterministic manual ticks in tests.
+- Hono server, daemon, CLI, and OpenTelemetry spans over the same graph.
+
 ## Canonical Shape
 
-`triage` and `importBatch` are streaming orchestration flows. They are not tagged with replay, suspend, or workflow policy. The SDK workflow and suspense extensions reject streaming targets through `isStreamingExec`, so durable policy belongs below them.
+Keep durable policy below `triage` and `importBatch`. They are streaming orchestration flows, while the scalar store/model/delivery steps carry replay, suspend, or workflow policy. The SDK workflow and suspense extensions reject streaming targets through `isStreamingExec`.
 
 Business features are flows/resources; free functions are pure calculations; ctx/scope/handles never travel into helpers.
 
@@ -108,7 +126,7 @@ Long-lived loop flows such as `ingest` or `watchReviewQueue` never hold a transa
 - `sendReminder` runs the release-on-failure SQL inline: when delivery rejects, it clears `reminded_at` and writes `reminder_failed` in one transaction, then rethrows.
 - `deliver` owns mail delivery through the `notifier` client, wrapping the foreign call in `ctx.exec({ fn: () => notifier.send(message), name: "notifier.send" })` so the foreign transport becomes a named `notifier.send` edge.
 
-`triage`, `importBatch`, `ingest`, `intake`, and `sendReminders` declare the child flows they compose with `controller(childFlow)` deps, then call `child.exec(...)` or `child.execStream(...)` from the injected handle. Those scalar flows use `step({ workflow: true, kind })`, so a production composition can add `workflowExtension({ log })` and replay completed scalar work without journaling streaming generators. `classify` no longer carries its own `kind: "llm"` step tag - the SDK `complete` port flow owns that span. A completed workflow run shows the model implementor's step followed by `model.complete`; `invoice.classify` itself is untracked plumbing around that call. Do not put `step({ workflow: true })`, replay, suspend, or durable tags on `triage` or `importBatch`.
+`triage`, `importBatch`, `ingest`, `intake`, and `sendReminders` declare the child flows they compose with `controller(childFlow)` deps, then call `child.exec(...)` or `child.execStream(...)` from the injected handle. Those scalar flows use `step({ workflow: true, kind })`, so a production composition can add `workflowExtension({ log })` and replay completed scalar work without journaling streaming generators. `classify` no longer carries its own `kind: "llm"` step tag - the SDK `complete` port flow owns that span. A completed workflow run shows the model implementor's step followed by `model.complete`; `invoice.classify` itself is untracked plumbing around that call. When you build similar flows, put `step({ workflow: true })`, replay, suspend, and durable tags on the scalar child steps, not on streaming orchestration flows like `triage` or `importBatch`.
 
 The example uses `yield* stream` to pass nested triage progress through `importBatch`, then reads `stream.result` for the typed classification. The current `FlowStream` type preserves output through `.result`; the `yield*` expression itself does not recover the output type from `AsyncIterable`.
 
@@ -186,26 +204,15 @@ Settlement is atomic per invoice: `settleInvoice` claims, upserts, and audits in
 
 Reminder idempotency is SQL-backed: `sendReminder` claims an invoice through `markReminderSent`, which updates `reminded_at` only when it is still null, then calls `deliver`. If `deliver` rejects, `sendReminder` runs the release SQL inline — clearing `reminded_at` and writing `reminder_failed` in one transaction — then rethrows so the invoice appears in a later `sendReminders` run. A process crash between the SQL claim and delivery completion can still leave the claim set without a sent message; that window is intentionally at-most-once. In production, bind `notifier` to a real transport client (SES/SendGrid/Twilio wrapped as a plain-object record), set `clock` for deterministic tests, and wire a durable workflow event log for scalar steps.
 
-## Run
+## Source
 
-```sh
-docker compose -f examples/invoice-triage/compose.yaml up -d postgres
-```
+- [flows.ts](./src/flows.ts)
+- [store.ts](./src/store.ts)
+- [database.ts](./src/database.ts)
+- [server.ts](./bin/server.ts)
+- [invoice-triage.test.ts](./tests/invoice-triage.test.ts)
 
-```sh
-pnpm -F @pumped-fn/invoice-triage start < examples/invoice-triage/fixtures/demo.ndjson
-```
+## Next
 
-```sh
-PORT=3000 pnpm -F @pumped-fn/invoice-triage server
-```
-
-```sh
-pnpm -F @pumped-fn/invoice-triage cli report
-```
-
-```sh
-pnpm -F @pumped-fn/invoice-triage test
-pnpm -F @pumped-fn/invoice-triage typecheck
-pnpm -F @pumped-fn/invoice-triage lint
-```
+- [Examples index](../README.md)
+- [Lite patterns](../../pkg/core/lite/PATTERNS.md)

--- a/pkg/core/lite/PATTERNS.md
+++ b/pkg/core/lite/PATTERNS.md
@@ -1,20 +1,16 @@
 # Patterns
 
-Usage patterns as sequences. For API details, see `pkg/core/lite/dist/index.d.mts`.
+This is a sequence-diagram tour of Lite runtime behavior. Use it when you want to see how scopes,
+contexts, resources, controllers, tags, service calls, and extensions move at runtime. For API details,
+see `pkg/core/lite/dist/index.d.mts`.
 
-## Boundary Ownership Checklist
+## Boundary Ownership
 
-Use this checklist before adding helpers around the graph.
-
-| Boundary | Owns | Guard |
-|----------|------|-------|
-| Scope seam | `createScope({ presets, tags, extensions })` at composition and test boundaries | Product helpers should not accept `scope`; graph work enters through atoms, flows, resources, tags, atom controllers when reactivity is intentional, flow handles for child flow composition, and `ctx.exec` at execution boundaries |
-| Test radius | inside-out tests preset a unit's direct deps; outside-in tests preset only edge adapters | No module mocks, no global stubs above raw transport wrappers, no internal reaches, no test-only product branches |
-| transport atom | Raw ambient IO such as network, clock, storage, random, and process APIs | Transport-owned tests may fake the platform API below the seam |
-| capability atom | Domain/application operations built on transport atom deps | Capability atoms stay ambient-free and are presettable at a wider radius |
-| feature atom | User-facing state, derived data, and application decisions | Feature atoms depend on capability atom ports, not raw transports plus auth/session/token plumbing |
-| composition root | Scope, root execution context, providers, route/job mounting, and disposal | Keep it thin and tested; do not hide flows behind facade objects or shared preconfigured scope factories |
-| public docs | Architectural claims, inventories, run commands, and implemented slices | Strong claims need structural guards, and counts must be derived or explicitly scoped |
+Before adding helpers around the graph, keep ownership at the real boundary: composition roots and tests
+own `createScope({ presets, tags, extensions })`; product work enters through atoms, flows, resources,
+tags, controllers, flow handles, or `ctx.exec`; transport atoms wrap raw ambient IO; capability atoms
+depend on transports; feature nodes depend on capabilities. For review rules, see the
+[code review guide](../../../docs/code-review-guide.md).
 
 For foreign integration, wrap the client in an adapter atom (the substitution seam) and instrument each call with `ctx.exec({ fn: () => client.method(args), name: "client.method", tags })` — one named, tag-able edge per call. `fn`-exec is the one way to trace a specific call; a flow is the one way for a capability that is a graph node.
 
@@ -128,9 +124,7 @@ const settlePayment = flow({
 })
 ```
 
-Use `controller(flow, { name, tags, key })` only to preconfigure child-flow execution defaults. Do not mix
-flow controller options with atom/resource controller options: flows never accept `resolve`, `watch`, or
-`eq`; atoms and resources never accept flow execution defaults.
+> **Note:** Use `controller(flow, { name, tags, key })` only to preconfigure child-flow execution defaults. Do not mix flow controller options with atom/resource controller options: flows never accept `resolve`, `watch`, or `eq`; atoms and resources never accept flow execution defaults.
 
 `prepare()` creates an invocation object for resumability, loops, fanout, policy checks, or retries.
 `step.ready` is an optional prep point; `step.exec()` awaits readiness internally, then delegates to the
@@ -156,9 +150,7 @@ sequenceDiagram
     Flow-->>Parent: output
 ```
 
-Extension authors should not need a second hook or wrapper-specific span logic. Normal `wrapExec` must
-still see one child execution per child-flow `exec()` call; sequential and parallel child flow work should
-remain visible through ordinary child span parentage and timing.
+> **Note:** Extension authors should not need a second hook or wrapper-specific span logic. Normal `wrapExec` must still see one child execution per child-flow `exec()` call; sequential and parallel child flow work should remain visible through ordinary child span parentage and timing.
 
 ### Scoped Isolation + Testing
 
@@ -370,7 +362,9 @@ sequenceDiagram
 
 ### Service Pattern
 
-Constrain atom methods to ExecutionContext-first signature. Always invoke via `ctx.exec` so a child context is created — extensions can observe the call, and cleanup is scoped.
+Constrain atom methods to ExecutionContext-first signature.
+
+> **Note:** Invoke service methods through `ctx.exec` so a child context is created — extensions can observe the call, and cleanup is scoped.
 
 ```mermaid
 sequenceDiagram
@@ -480,44 +474,16 @@ sequenceDiagram
     Note over Scope: await invalidation chain only
 ```
 
-## Practical Examples
+## Practical Example
 
-The runnable practical example under `examples/` is `invoice-triage`. It carries the canonical app
-surface for generator flows, `execStream`, child-flow composition, state-backed ingest queues,
-scheduler cron, provider tags, and test substitution through the scope seam.
-
-The practical example uses the same boundary vocabulary as the package docs. Entry points keep
-transport work at the composition root, graph work behind flows or `ctx.exec`, root execution lifecycle
-owned by the root, and scope disposal explicit. Raw IO is kept in transport atoms or composition-root
-adapters; capability atoms depend on transports and remain presettable; feature flows depend on
-capabilities. Public example claims are guarded by structural tests for provider wiring, state queues,
-streaming progress, cron registration, and idempotent side effects.
+The runnable practical example is [invoice-triage](../../../examples/invoice-triage/README.md). It carries
+the canonical app surface for generator flows, `execStream`, child-flow composition, state-backed ingest
+queues, scheduler cron, provider tags, and test substitution through the scope seam.
 
 `@pumped-fn/lite-lint` turns those boundary rules into a lint-like scanner. It catches module mocks,
 test-only product branches, definition-handle suffixes, product helpers that accept `scope`, raw ambient IO
 outside transport/root declarations, stale example vocabulary, and React observer violations from
 `@pumped-fn/lite-react`.
-
-Backend practical examples:
-
-```bash
-pnpm test
-pnpm typecheck
-```
-
-React practical examples:
-
-```bash
-pnpm test
-pnpm typecheck
-```
-
-BFF practical examples:
-
-```bash
-pnpm test
-pnpm typecheck
-```
 
 ## Next
 

--- a/pkg/core/lite/README.md
+++ b/pkg/core/lite/README.md
@@ -32,28 +32,19 @@ Lite owns the application boundary below framework adapters:
 - `tag()` carries typed ambient values such as tenant, trace id, locale, config, and equality-aware boundary identity.
 - `preset()` swaps atoms, flows, and resources at the scope seam for tests or composition.
 - Extensions wrap resolve and exec for logging, tracing, auth, metrics, and transactional policy.
-- Controllers and selects add reactivity where it is intentional. `controller(flow, defaults)` only
-  preconfigures child-flow execution; it is not reactive.
+- Controllers and selects add reactivity where it is intentional.
+
+> **Note:** `controller(flow, defaults)` only preconfigures child-flow execution; it is not reactive.
 
 ## Boundary Ownership
 
 Scope is the composition and test seam. Composition roots, tests, and boundary adapters call
-`createScope({ presets, tags, extensions })`.
+`createScope({ presets, tags, extensions })`; product helpers do not accept `scope`.
+Tests use the same seam: preset direct deps for an inside-out radius, or only edge adapters for
+outside-in coverage. Raw ambient IO belongs in transport atoms or composition-root adapters; capability
+atoms depend on transports, and feature nodes depend on capabilities.
 
-Composition roots are thin, tested adapters. They create scopes, root contexts, providers, route/job
-mounts, and disposal. `scope` is not a product helper argument; that turns the graph into a service
-locator. Make the behavior an atom, flow, resource, pure helper called by a graph node, or route it
-through flows, `ctx.exec`, resources, or providers.
-
-Tests use the same seam. Inside-out tests preset direct dependencies. Outside-in tests preset only edge
-adapters. A test that needs module mocks, global patches above raw transport wrappers, internal reaches,
-or test-only product branches means the boundary leaked.
-
-Raw ambient IO belongs in transport atoms or composition-root adapters. Capability atoms depend on transports.
-Feature atoms depend on capabilities.
-
-Public examples with strong architectural claims need structural guards, and inventories or implemented
-slice claims should be derived or explicitly scoped.
+See [Mental model](../../../docs/mental-model.md) and [Test without mocks](../../../docs/test-without-mocks.md).
 
 ## Shape
 
@@ -84,7 +75,7 @@ The usual layering is:
 | Feature atom or flow | User-facing state, decisions, derived data, and use-case execution |
 | Composition root | Scope creation, root execution context, providers, route/job mounting, disposal |
 
-Feature nodes should depend on capabilities, not raw transports plus auth/session/token plumbing.
+> **Note:** Feature nodes should depend on capabilities, not raw transports plus auth/session/token plumbing.
 
 ## First Graph
 
@@ -237,9 +228,7 @@ await scope.dispose()
 if (events.join(",") !== "commit,release") throw new Error("unexpected lifecycle")
 ```
 
-`ctx.release(resource)` is an owner-local reset. It runs the resource cleanup for that owner, but `onClose`
-handlers registered by that resource still belong to the execution context. Use it when you intentionally
-need a fresh resource instance inside an open context.
+> **Note:** `ctx.release(resource)` is an owner-local reset. It runs the resource cleanup for that owner, but `onClose` handlers registered by that resource still belong to the execution context. Use it when you intentionally need a fresh resource instance inside an open context.
 
 Resource controllers are infrastructure handles for observing a resource visible from one execution
 context. Prefer direct resource dependencies, flows, or domain actions in product APIs. `watch: true` for
@@ -317,9 +306,7 @@ selected.dispose()
 await scope.dispose()
 ```
 
-Use `controller(dep, { resolve: true, watch: true, eq })` in atom dependencies for derived atoms that
-should invalidate when a dependency changes. That replaces manual subscription wiring and automatically
-cleans up on re-resolve, release, and dispose.
+> **Note:** Use `controller(dep, { resolve: true, watch: true, eq })` in atom dependencies for derived atoms that should invalidate when a dependency changes. That replaces manual subscription wiring and automatically cleans up on re-resolve, release, and dispose.
 
 ### Async Iteration
 
@@ -379,19 +366,14 @@ for await (const order of scope.resolveStream(orders)) {
 ```
 
 `scope.drain(atom, { take })` collects a fresh view into an array — until the producer completes, or after
-`take` elements. Without `take` it only returns when the producer ends, so do not drain an infinite feed
-unbounded. One producer-side caveat: `scope.dispose()` awaits `iterator.return()`, and JavaScript queues
-that behind a pending `await` inside the generator, so a producer blocked on IO without yielding delays
-disposal until that await settles.
+`take` elements.
+
+> **Note:** Without `take`, `scope.drain` only returns when the producer ends, so do not drain an infinite feed unbounded. `scope.dispose()` awaits `iterator.return()`, and JavaScript queues that behind a pending `await` inside the generator, so a producer blocked on IO without yielding delays disposal until that await settles.
 
 Presets compose with all of it: `preset(orders, fakeFeed)` swaps the producer for a test, and
 `await scope.drain(orders, { take: 3 })` asserts the consumed elements through the same seam.
 
-`resolveStream` views conflate — they are state views, not lossless transports. Elements produced
-while a consumer is busy are superseded, not queued, so a stream must never be the only carrier of
-must-not-drop work. Put such work in state instead: producers append to an atom, and a processor
-loop wakes on `changes(select(...))` and drains everything pending from state. Conflated wakeups
-lose nothing because the state carries the work; conflated data would.
+> **Note:** `resolveStream` views conflate — they are state views, not lossless transports. Elements produced while a consumer is busy are superseded, not queued, so a stream must never be the only carrier of must-not-drop work. Put such work in state instead: producers append to an atom, and a processor loop wakes on `changes(select(...))` and drains everything pending from state. Conflated wakeups lose nothing because the state carries the work; conflated data would.
 
 ### Generator Flows
 
@@ -432,15 +414,12 @@ await scope.dispose()
 
 The consumer pulls the generator directly: the flow body does not advance past a `yield` until the
 caller asks, so backpressure is inherent and no element is dropped. Each invocation is consumed once.
-Breaking out of the loop cancels the invocation — the generator's `finally` runs, resources clean up,
-and `onClose` observes `{ ok: false, aborted: true }`, distinguishable from success and failure; a
-transaction resource should roll back on both error and abandonment. Reading `stream.result` before
-iterating throws — a caller that only wants the final output uses `exec`. A non-generator factory
-whose output is an async iterable fails the execution: returned iterables would outlive their context;
-yield from a generator flow or use an iterable atom with `resolveStream` instead.
 
-Streaming invocations are visible to extensions as `streaming` on the exec target. The suspense
-extension refuses to journal them (`replay` throws) until stream replay semantics exist.
+> **Note:** Breaking out of the loop cancels the invocation — the generator's `finally` runs, resources clean up, and `onClose` observes `{ ok: false, aborted: true }`, distinguishable from success and failure. A transaction resource should roll back on both error and abandonment.
+
+> **Note:** Reading `stream.result` before iterating throws — a caller that only wants the final output uses `exec`. A non-generator factory whose output is an async iterable fails the execution: returned iterables would outlive their context; yield from a generator flow or use an iterable atom with `resolveStream` instead.
+
+> **Note:** Streaming invocations are visible to extensions as `streaming` on the exec target. The suspense extension refuses to journal them (`replay` throws) until stream replay semantics exist.
 
 ## Presets And Tests
 
@@ -473,11 +452,9 @@ spies, or test-only branches.
 
 ## Extensions
 
-Extensions wrap atom/resource resolution and flow/function execution. Use them for cross-cutting behavior
-that should be complete and auditable: logging, metrics, auth checks, trace spans, transactions, and
-runtime tag injection.
-
-Extension hooks run around graph work, so they see the same seams as tests and composition roots.
+Extensions wrap atom/resource resolution and flow/function execution for logging, metrics, auth checks,
+trace spans, transactions, and runtime tag injection. Extension hooks see the same seams as tests and
+composition roots. See [Observability](../../../docs/observability.md).
 
 ## API Summary
 
@@ -500,13 +477,19 @@ Extension hooks run around graph work, so they see the same seams as tests and c
 
 Complete type reference: [`dist/index.d.mts`](./dist/index.d.mts)
 
-Patterns and guardrails: [`PATTERNS.md`](./PATTERNS.md)
+Patterns: [`PATTERNS.md`](./PATTERNS.md)
 
 React integration: [`@pumped-fn/lite-react`](../../react/lite-react/README.md)
 
 ## License
 
 MIT
+
+## Next
+
+- [Docs index](../../../docs/README.md)
+- [Patterns](./PATTERNS.md)
+- [Invoice triage example](../../../examples/invoice-triage/README.md)
 
 ---
 Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/ext/scheduler-nats/README.md
+++ b/pkg/ext/scheduler-nats/README.md
@@ -5,6 +5,35 @@ KV. Multiple process instances can register the same schedule and coordinate thr
 bucket: only one instance runs any given scheduled tick, and a `last:` key lets late-joining or
 restarted instances catch up on what they missed.
 
+## Install
+
+Install the NATS backend next to Lite, the scheduler extension, and the NATS client packages: `pnpm add @pumped-fn/lite @pumped-fn/lite-extension-scheduler @pumped-fn/lite-extension-scheduler-nats @nats-io/kv @nats-io/transport-node`.
+
+## Usage
+
+```ts
+import { connect } from "@nats-io/transport-node"
+import { createScope } from "@pumped-fn/lite"
+import { scheduler } from "@pumped-fn/lite-extension-scheduler"
+import { nats } from "@pumped-fn/lite-extension-scheduler-nats"
+import { sweepExpired } from "./flows"
+
+const connection = await connect({ servers: "nats://localhost:4222" })
+
+const nightlySweep = scheduler.schedule({
+  name: "nightly-sweep",
+  cadence: { cron: "0 2 * * *" },
+  catchUp: "last",
+  flow: sweepExpired,
+  input: () => undefined,
+})
+
+const scope = createScope({
+  tags: [scheduler.backend(nats({ connection, bucket: "scheduler", history: { ttlMs: 7 * 24 * 60 * 60 * 1000 } }))],
+})
+await scope.resolve(nightlySweep)
+```
+
 ## Semantics
 
 | What NATS gives | What stays local |
@@ -53,31 +82,6 @@ run key only while the holder completes within `lockTtlMs`**; across a lease exp
 in practice. There is no heartbeat/lease-renewal mechanism today — a holder cannot extend its lock by
 signaling it is still alive; adding one (so a live holder renews before `lockTtlMs` elapses and a
 takeover only ever targets a truly dead holder) is possible future work.
-
-## Usage
-
-```ts
-import { connect } from "@nats-io/transport-node"
-import { createScope } from "@pumped-fn/lite"
-import { scheduler } from "@pumped-fn/lite-extension-scheduler"
-import { nats } from "@pumped-fn/lite-extension-scheduler-nats"
-import { sweepExpired } from "./flows"
-
-const connection = await connect({ servers: "nats://localhost:4222" })
-
-const nightlySweep = scheduler.schedule({
-  name: "nightly-sweep",
-  cadence: { cron: "0 2 * * *" },
-  catchUp: "last",
-  flow: sweepExpired,
-  input: () => undefined,
-})
-
-const scope = createScope({
-  tags: [scheduler.backend(nats({ connection, bucket: "scheduler", history: { ttlMs: 7 * 24 * 60 * 60 * 1000 } }))],
-})
-await scope.resolve(nightlySweep)
-```
 
 ## `nats(options)`
 

--- a/pkg/tool/lint/README.md
+++ b/pkg/tool/lint/README.md
@@ -5,6 +5,8 @@ Static anti-pattern scanner for `@pumped-fn/lite` and `@pumped-fn/lite-react` co
 It is lint-like, but intentionally small: it uses the TypeScript parser directly and checks the boundary
 rules that the lite and lite-react docs teach. The CLI exits nonzero when diagnostics are found.
 
+The rules encode the [code review guide](../../../docs/code-review-guide.md).
+
 ## Usage
 
 ```sh
@@ -12,11 +14,7 @@ pumped-lite-lint src tests
 pumped-lite-lint --json src tests
 ```
 
-In this monorepo, root `pnpm lint` builds the tool and scans the public docs plus practical examples:
-
-```sh
-pnpm lint
-```
+> **Note:** In this repo, root `pnpm lint` builds the tool and scans the public docs plus practical examples.
 
 ## Rules
 
@@ -52,15 +50,9 @@ directories where examples intentionally contain bad shapes or third-party code.
 
 ## Severity
 
-Every diagnostic carries a `severity` of `"error"` or `"warn"`. The CLI exits nonzero only when at
-least one `"error"` diagnostic is found; `"warn"` diagnostics still print (and show up in `--json`
-output) but never fail the process. `pumped/no-implicit-tag-read`, `pumped/no-naked-globals`,
-`pumped/no-module-state`, `pumped/prefer-destructured-deps`, `pumped/no-untyped-throw`,
-`pumped/no-swallowed-error`, and `pumped/no-handle-spread` default to `"warn"` because root `pnpm lint` only scans docs and the
-practical example packages today (not the whole monorepo), and turning them into hard failures for
-every existing example in one pass isn't the goal of adding them — treat their output as an
-inventory to clean up incrementally. All other rules default to `"error"`, matching current
-behavior.
+Every diagnostic carries a `severity` of `"error"` or `"warn"`.
+
+> **Note:** The CLI exits nonzero only when at least one `"error"` diagnostic is found. `"warn"` diagnostics still print and appear in `--json`, but they do not fail the process; `pumped/no-implicit-tag-read`, `pumped/no-naked-globals`, `pumped/no-module-state`, `pumped/prefer-destructured-deps`, `pumped/no-untyped-throw`, `pumped/no-swallowed-error`, and `pumped/no-handle-spread` default to `"warn"` as an incremental cleanup inventory, while all other rules default to `"error"`.
 
 ## Config
 


### PR DESCRIPTION
PR-C (final) of the docs-surface review.

- **examples/README.md**: maintainer policy page → visitor index; guardrails/naming/boundaries moved intact to `examples/CONTRIBUTING.md`.
- **invoice-triage README**: 3-sentence plain opening, **Run first**, 13 jargon bullets → 6 plain ones, diagram after Run; Canonical Shape/Providers/Ops Notes kept.
- **pkg/core/lite/README.md**: governance sentences excised, duplicated Boundary-Ownership/Extensions sections shrunk to docs/ pointers, rule-voice → notes, Next section added.
- **PATTERNS.md**: all 12 sequence diagrams kept (verified 12v12); maintainer checklist → short paragraph + review-guide link; vestigial pnpm sections removed.
- **lint README**: internal decision log trimmed; links the code-review guide.
- **scheduler-nats**: usage before lock theory; semantics text verbatim-unchanged.

Verification: independent pass confirms code blocks/mermaid unchanged (verbatim moves only), frozen facts intact (at-most-once, suspense limit, lockTtlMs caveats), all links resolve, full `pnpm lint` (incl. example-alignment, adapted table formats) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)