### PR TITLE
feat: make comparison the Pages homepage

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -2,6 +2,15 @@ name: Deploy Pages
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Pages artifact to publish
+        required: true
+        default: homepage
+        type: choice
+        options:
+          - homepage
+          - baseline-rollback
 
 concurrency:
   group: pages
@@ -30,10 +39,16 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Chromium
+        if: inputs.mode == 'homepage'
         run: pnpm -F @pumped-fn/compare exec playwright install --with-deps chromium
 
-      - name: Stage and verify Pages artifact
+      - name: Stage and verify homepage artifact
+        if: inputs.mode == 'homepage'
         run: pnpm pages:dry-run
+
+      - name: Stage and verify baseline rollback artifact
+        if: inputs.mode == 'baseline-rollback'
+        run: pnpm pages:rollback:dry-run
 
       - name: Configure Pages
         uses: actions/configure-pages@v5
@@ -87,7 +102,13 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Chromium
+        if: inputs.mode == 'homepage'
         run: pnpm -F @pumped-fn/compare exec playwright install --with-deps chromium
 
-      - name: Verify deployed Pages
+      - name: Verify deployed homepage
+        if: inputs.mode == 'homepage'
         run: pnpm pages:verify:public
+
+      - name: Verify deployed baseline rollback
+        if: inputs.mode == 'baseline-rollback'
+        run: pnpm pages:verify:public:rollback

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "test:release": "pnpm act -W .github/workflows/release.yml -j release --secret-file .secrets",
     "compare:verify": "pnpm -F @pumped-fn/compare verify",
     "pages:dry-run": "pnpm -F @pumped-fn/compare pages:dry-run",
-    "pages:verify:public": "pnpm -F @pumped-fn/compare pages:verify:public"
+    "pages:verify:public": "pnpm -F @pumped-fn/compare pages:verify:public",
+    "pages:rollback:dry-run": "pnpm -F @pumped-fn/compare pages:rollback:dry-run",
+    "pages:verify:public:rollback": "pnpm -F @pumped-fn/compare pages:verify:public:rollback"
   },
   "devDependencies": {
     "@changesets/changelog-github": "catalog:",

--- a/playground/compare/README.md
+++ b/playground/compare/README.md
@@ -1,8 +1,8 @@
-# Comparison lab
+# Build, test, and operate comparison
 
-This private package owns the guided comparison and its executable proof. One account-onboarding contract runs through pumped-fn, Effect, Awilix, Inversify, and plain TypeScript. Each lane owns dependency composition, request facts, typed duplicate handling, and database cleanup in its native style.
+One account-onboarding contract runs through pumped-fn, Effect, Awilix, Inversify, and plain TypeScript. The homepage exposes the exact Build source, native substitution test, and operations proof for each lane.
 
-The account-creation domain and Effect service composition start from Effect's official HTTP server example rather than a pumped-fn example. `sources.lock.json` pins the upstream repositories, files, documentation, commits, package versions, and adaptation boundary.
+The account domain and Effect composition start from Effect's official HTTP server example. `sources.lock.json` pins each external source and the browser-safe adaptation boundary.
 
 ## Verify
 
@@ -14,11 +14,11 @@ pnpm -F @pumped-fn/compare build
 pnpm -F @pumped-fn/compare browser:smoke
 ```
 
-The browser opens the exact checked-in lane and scenario files in an editable Sandpack workspace. Node and Chromium execute the same three-request lifecycle contract.
+The browser opens all fifteen checked-in Build, Test, and Operate proof files in an editable Sandpack workspace. Node and Chromium execute the unchanged three-request lifecycle contract.
 
 ## Source policy
 
-- Competitor code follows the official service, layer, container, scope, lifetime, and disposal shapes named in `sources.lock.json`.
+- Competitor code follows the official service, layer, container, scope, lifetime, test, and disposal shapes named in `sources.lock.json`.
 - All lanes satisfy the same black-box contract, but their internal file shape remains idiomatic.
-- Source provenance and executable results are shown separately. Passing the shared suite does not turn a subjective readability claim into a measured fact.
+- Operations wording describes the checked-in lane. It does not claim a product cannot be instrumented.
 - `examples/invoice-triage` remains the canonical pumped-fn application. This package is a comparison and verification surface.

--- a/playground/compare/cases/account-onboarding/lanes/awilix.ts
+++ b/playground/compare/cases/account-onboarding/lanes/awilix.ts
@@ -1,5 +1,6 @@
 import { asFunction, asValue, createContainer, InjectionMode } from "awilix"
 import type { Database, Lane, Outcome, ProvisionInput, RequestFacts } from "../contract"
+import { silentTrace, type Trace } from "../trace"
 
 type Accounts = {
   provision(input: ProvisionInput): Promise<Outcome>
@@ -11,14 +12,15 @@ type AccountsDeps = {
   uuid: { next(): string }
   actorId: string
   requestId: string
+  trace: Trace
 }
 
 type Cradle = AccountsDeps & {
   accounts: Accounts
 }
 
-const createAccounts = ({ database, clock, uuid, actorId, requestId }: AccountsDeps): Accounts => ({
-  async provision(input) {
+export const createAccounts = ({ database, clock, uuid, actorId, requestId, trace }: AccountsDeps): Accounts => ({
+  provision: (input) => trace.span("account.provision.awilix", async () => {
     const user = {
       id: uuid.next(),
       email: input.email,
@@ -27,42 +29,45 @@ const createAccounts = ({ database, clock, uuid, actorId, requestId }: AccountsD
       createdAt: clock.now(),
     }
     if (await (await database).insertUser(user) === "duplicate") {
-      return { ok: false, error: { kind: "duplicate-email", email: input.email } }
+      return { ok: false, error: { kind: "duplicate-email" as const, email: input.email } }
     }
-    return { ok: true, user }
-  },
+    return { ok: true as const, user }
+  }),
 })
+
+export function startAwilix(fixture: Parameters<Lane["start"]>[0], trace: Trace = silentTrace): Awaited<ReturnType<Lane["start"]>> {
+  const container = createContainer<Cradle>({
+    injectionMode: InjectionMode.PROXY,
+    strict: true,
+  })
+  container.register({
+    database: asFunction(() => fixture.openDatabase())
+      .singleton()
+      .disposer((database) => database.then((connection) => connection.close())),
+    clock: asValue({ now: () => fixture.now() }),
+    uuid: asValue({ next: () => fixture.nextId() }),
+    trace: asValue(trace),
+    accounts: asFunction(createAccounts).scoped(),
+  })
+
+  return {
+    async provision(input: ProvisionInput, facts: RequestFacts): Promise<Outcome> {
+      const scope = container.createScope()
+      scope.register({
+        actorId: asValue(facts.actorId),
+        requestId: asValue(facts.requestId),
+      })
+      try {
+        return await scope.resolve("accounts").provision(input)
+      } finally {
+        await scope.dispose()
+      }
+    },
+    close: () => container.dispose(),
+  }
+}
 
 export const awilix = {
   id: "awilix",
-  start(fixture) {
-    const container = createContainer<Cradle>({
-      injectionMode: InjectionMode.PROXY,
-      strict: true,
-    })
-    container.register({
-      database: asFunction(() => fixture.openDatabase())
-        .singleton()
-        .disposer((database) => database.then((connection) => connection.close())),
-      clock: asValue({ now: () => fixture.now() }),
-      uuid: asValue({ next: () => fixture.nextId() }),
-      accounts: asFunction(createAccounts).scoped(),
-    })
-
-    return {
-      async provision(input: ProvisionInput, facts: RequestFacts): Promise<Outcome> {
-        const scope = container.createScope()
-        scope.register({
-          actorId: asValue(facts.actorId),
-          requestId: asValue(facts.requestId),
-        })
-        try {
-          return await scope.resolve("accounts").provision(input)
-        } finally {
-          await scope.dispose()
-        }
-      },
-      close: () => container.dispose(),
-    }
-  },
+  start: startAwilix,
 } satisfies Lane

--- a/playground/compare/cases/account-onboarding/lanes/effect.ts
+++ b/playground/compare/cases/account-onboarding/lanes/effect.ts
@@ -1,13 +1,13 @@
-import { Context, Effect, Layer, ManagedRuntime } from "effect"
+import { Context, Effect, Layer, ManagedRuntime, type Tracer } from "effect"
 import type { Database as DatabaseValue, Lane, Outcome, ProvisionInput, RequestFacts } from "../contract"
 
-class Database extends Context.Tag("comparison/Database")<Database, DatabaseValue>() {}
-class Clock extends Context.Tag("comparison/Clock")<Clock, { now(): string }>() {}
-class Uuid extends Context.Tag("comparison/Uuid")<Uuid, { next(): string }>() {}
-class ActorId extends Context.Tag("comparison/ActorId")<ActorId, string>() {}
-class RequestId extends Context.Tag("comparison/RequestId")<RequestId, string>() {}
+export class Database extends Context.Tag("comparison/Database")<Database, DatabaseValue>() {}
+export class Clock extends Context.Tag("comparison/Clock")<Clock, { now(): string }>() {}
+export class Uuid extends Context.Tag("comparison/Uuid")<Uuid, { next(): string }>() {}
+export class ActorId extends Context.Tag("comparison/ActorId")<ActorId, string>() {}
+export class RequestId extends Context.Tag("comparison/RequestId")<RequestId, string>() {}
 
-class Accounts extends Effect.Service<Accounts>()("comparison/Accounts", {
+export class Accounts extends Effect.Service<Accounts>()("comparison/Accounts", {
   effect: Effect.gen(function*() {
     const database = yield* Database
     const clock = yield* Clock
@@ -34,42 +34,43 @@ class Accounts extends Effect.Service<Accounts>()("comparison/Accounts", {
   }),
 }) {}
 
-export const effect = {
-  id: "effect",
-  start(fixture) {
-    const database = Layer.scoped(
-      Database,
-      Effect.acquireRelease(
-        Effect.promise(() => fixture.openDatabase()),
-        (database) => Effect.promise(() => database.close()),
-      ),
-    )
-    const runtime = ManagedRuntime.make(
-      Accounts.Default.pipe(
-        Layer.provide(
-          Layer.mergeAll(
-            database,
-            Layer.succeed(Clock, { now: () => fixture.now() }),
-            Layer.succeed(Uuid, { next: () => fixture.nextId() }),
-          ),
+export function startEffect(fixture: Parameters<Lane["start"]>[0], tracer?: Tracer.Tracer): Awaited<ReturnType<Lane["start"]>> {
+  const database = Layer.scoped(
+    Database,
+    Effect.acquireRelease(
+      Effect.promise(() => fixture.openDatabase()),
+      (database) => Effect.promise(() => database.close()),
+    ),
+  )
+  const runtime = ManagedRuntime.make(
+    Accounts.Default.pipe(
+      Layer.provide(
+        Layer.mergeAll(
+          database,
+          Layer.succeed(Clock, { now: () => fixture.now() }),
+          Layer.succeed(Uuid, { next: () => fixture.nextId() }),
         ),
       ),
-    )
+    ),
+  )
 
-    return {
-      provision(input: ProvisionInput, facts: RequestFacts): Promise<Outcome> {
-        return runtime.runPromise(
-          Effect.flatMap(Accounts, (accounts) => accounts.provision(input)).pipe(
-            Effect.provideService(ActorId, facts.actorId),
-            Effect.provideService(RequestId, facts.requestId),
-            Effect.match({
-              onFailure: (error) => ({ ok: false as const, error }),
-              onSuccess: (user) => ({ ok: true as const, user }),
-            }),
-          ),
-        )
-      },
-      close: () => runtime.dispose(),
-    }
-  },
+  return {
+    provision(input: ProvisionInput, facts: RequestFacts): Promise<Outcome> {
+      const operation = Effect.flatMap(Accounts, (accounts) => accounts.provision(input)).pipe(
+        Effect.provideService(ActorId, facts.actorId),
+        Effect.provideService(RequestId, facts.requestId),
+        Effect.match({
+          onFailure: (error) => ({ ok: false as const, error }),
+          onSuccess: (user) => ({ ok: true as const, user }),
+        }),
+      )
+      return runtime.runPromise(tracer === undefined ? operation : operation.pipe(Effect.withTracer(tracer)))
+    },
+    close: () => runtime.dispose(),
+  }
+}
+
+export const effect = {
+  id: "effect",
+  start: startEffect,
 } satisfies Lane

--- a/playground/compare/cases/account-onboarding/lanes/inversify.ts
+++ b/playground/compare/cases/account-onboarding/lanes/inversify.ts
@@ -1,63 +1,71 @@
 import "reflect-metadata"
 import { Container, inject, injectable } from "inversify"
 import type { Database, Lane, Outcome, ProvisionInput, RequestFacts } from "../contract"
+import { silentTrace, type Trace } from "../trace"
 
-const databaseId = Symbol("comparison.database")
-const clockId = Symbol("comparison.clock")
-const uuidId = Symbol("comparison.uuid")
-const actorId = Symbol("request.actor-id")
-const requestId = Symbol("request.id")
+export const databaseId = Symbol("comparison.database")
+export const clockId = Symbol("comparison.clock")
+export const uuidId = Symbol("comparison.uuid")
+export const actorId = Symbol("request.actor-id")
+export const requestId = Symbol("request.id")
+export const traceId = Symbol("comparison.trace")
 
 @injectable()
-class Accounts {
+export class Accounts {
   constructor(
     @inject(databaseId) private readonly database: Database,
     @inject(clockId) private readonly clock: { now(): string },
     @inject(uuidId) private readonly uuid: { next(): string },
     @inject(actorId) private readonly actorId: string,
     @inject(requestId) private readonly requestId: string,
+    @inject(traceId) private readonly trace: Trace,
   ) {}
 
   async provision(input: ProvisionInput): Promise<Outcome> {
-    const user = {
-      id: this.uuid.next(),
-      email: input.email,
-      actorId: this.actorId,
-      requestId: this.requestId,
-      createdAt: this.clock.now(),
-    }
-    if (await this.database.insertUser(user) === "duplicate") {
-      return { ok: false, error: { kind: "duplicate-email", email: input.email } }
-    }
-    return { ok: true, user }
+    return this.trace.span("account.provision.inversify", async () => {
+      const user = {
+        id: this.uuid.next(),
+        email: input.email,
+        actorId: this.actorId,
+        requestId: this.requestId,
+        createdAt: this.clock.now(),
+      }
+      if (await this.database.insertUser(user) === "duplicate") {
+        return { ok: false, error: { kind: "duplicate-email", email: input.email } }
+      }
+      return { ok: true, user }
+    })
+  }
+}
+
+export function startInversify(fixture: Parameters<Lane["start"]>[0], trace: Trace = silentTrace): Awaited<ReturnType<Lane["start"]>> {
+  const container = new Container()
+  container
+    .bind<Database>(databaseId)
+    .toDynamicValue(() => fixture.openDatabase())
+    .inSingletonScope()
+    .onDeactivation((database) => database.close())
+  container.bind(clockId).toConstantValue({ now: () => fixture.now() })
+  container.bind(uuidId).toConstantValue({ next: () => fixture.nextId() })
+  container.bind(traceId).toConstantValue(trace)
+
+  return {
+    async provision(input: ProvisionInput, facts: RequestFacts): Promise<Outcome> {
+      const request = new Container({ parent: container })
+      request.bind(actorId).toConstantValue(facts.actorId)
+      request.bind(requestId).toConstantValue(facts.requestId)
+      request.bind(Accounts).toSelf()
+      try {
+        return await (await request.getAsync(Accounts)).provision(input)
+      } finally {
+        await request.unbindAllAsync()
+      }
+    },
+    close: () => container.unbindAllAsync(),
   }
 }
 
 export const inversify = {
   id: "inversify",
-  start(fixture) {
-    const container = new Container()
-    container
-      .bind<Database>(databaseId)
-      .toDynamicValue(() => fixture.openDatabase())
-      .inSingletonScope()
-      .onDeactivation((database) => database.close())
-    container.bind(clockId).toConstantValue({ now: () => fixture.now() })
-    container.bind(uuidId).toConstantValue({ next: () => fixture.nextId() })
-
-    return {
-      async provision(input: ProvisionInput, facts: RequestFacts): Promise<Outcome> {
-        const request = new Container({ parent: container })
-        request.bind(actorId).toConstantValue(facts.actorId)
-        request.bind(requestId).toConstantValue(facts.requestId)
-        request.bind(Accounts).toSelf()
-        try {
-          return await (await request.getAsync(Accounts)).provision(input)
-        } finally {
-          await request.unbindAllAsync()
-        }
-      },
-      close: () => container.unbindAllAsync(),
-    }
-  },
+  start: startInversify,
 } satisfies Lane

--- a/playground/compare/cases/account-onboarding/lanes/plain.ts
+++ b/playground/compare/cases/account-onboarding/lanes/plain.ts
@@ -1,25 +1,28 @@
 import type { Lane, Outcome, ProvisionInput, RequestFacts } from "../contract"
+import { silentTrace, type Trace } from "../trace"
+
+export async function startPlain(fixture: Parameters<Lane["start"]>[0], trace: Trace = silentTrace): Promise<Awaited<ReturnType<Lane["start"]>>> {
+  const database = await fixture.openDatabase()
+
+  return {
+    provision: (input: ProvisionInput, facts: RequestFacts): Promise<Outcome> => trace.span("account.provision.plain", async () => {
+      const user = {
+        id: fixture.nextId(),
+        email: input.email,
+        actorId: facts.actorId,
+        requestId: facts.requestId,
+        createdAt: fixture.now(),
+      }
+      if (await database.insertUser(user) === "duplicate") {
+        return { ok: false, error: { kind: "duplicate-email", email: input.email } }
+      }
+      return { ok: true, user }
+    }),
+    close: () => database.close(),
+  }
+}
 
 export const plain = {
   id: "plain",
-  async start(fixture) {
-    const database = await fixture.openDatabase()
-
-    return {
-      async provision(input: ProvisionInput, facts: RequestFacts): Promise<Outcome> {
-        const user = {
-          id: fixture.nextId(),
-          email: input.email,
-          actorId: facts.actorId,
-          requestId: facts.requestId,
-          createdAt: fixture.now(),
-        }
-        if (await database.insertUser(user) === "duplicate") {
-          return { ok: false, error: { kind: "duplicate-email", email: input.email } }
-        }
-        return { ok: true, user }
-      },
-      close: () => database.close(),
-    }
-  },
+  start: startPlain,
 } satisfies Lane

--- a/playground/compare/cases/account-onboarding/lanes/pumped.ts
+++ b/playground/compare/cases/account-onboarding/lanes/pumped.ts
@@ -1,9 +1,10 @@
-import { atom, createScope, flow, isFault, resource, tag, tags, typed } from "@pumped-fn/lite"
+import { atom, createScope, flow, isFault, resource, tag, tags, typed, type Lite } from "@pumped-fn/lite"
 import type { Database, DuplicateEmail, Fixture, Lane, Outcome, ProvisionInput, RequestFacts } from "../contract"
+import type { Trace } from "../trace"
 
-const caseFixture = tag<Fixture>({ label: "comparison.fixture" })
-const actorId = tag<string>({ label: "request.actor-id" })
-const requestId = tag<string>({ label: "request.id" })
+export const caseFixture = tag<Fixture>({ label: "comparison.fixture" })
+export const actorId = tag<string>({ label: "request.actor-id" })
+export const requestId = tag<string>({ label: "request.id" })
 
 const clock = atom({
   deps: { caseFixture: tags.required(caseFixture) },
@@ -15,7 +16,7 @@ const uuid = atom({
   factory: (_, { caseFixture }) => ({ next: () => caseFixture.nextId() }),
 })
 
-const database = resource({
+export const database = resource({
   name: "comparison.database",
   ownership: "boundary",
   deps: { caseFixture: tags.required(caseFixture) },
@@ -30,7 +31,7 @@ const database = resource({
   },
 })
 
-const provision = flow({
+export const provision = flow({
   name: "account.provision.pumped",
   parse: typed<ProvisionInput>(),
   faults: typed<DuplicateEmail>(),
@@ -59,32 +60,41 @@ const provision = flow({
   },
 })
 
+export async function startPumped(fixture: Fixture, trace?: Trace): Promise<Awaited<ReturnType<Lane["start"]>>> {
+  const extensions: Lite.Extension[] = trace === undefined ? [] : [{
+    name: "comparison.trace",
+    async wrapExec(next, _target, ctx) {
+      trace.record(ctx.name ?? "anonymous")
+      return next()
+    },
+  }]
+  const scope = createScope({ extensions, tags: [caseFixture(fixture)] })
+  const root = scope.createContext()
+  await root.resolve(database)
+
+  return {
+    async provision(input: ProvisionInput, facts: RequestFacts): Promise<Outcome> {
+      const ctx = scope.createContext({
+        parent: root,
+        tags: [actorId(facts.actorId), requestId(facts.requestId)],
+      })
+      try {
+        return { ok: true, user: await ctx.exec({ flow: provision, input }) }
+      } catch (error) {
+        if (isFault(provision, error)) return { ok: false, error: error.fault }
+        throw error
+      } finally {
+        await ctx.close()
+      }
+    },
+    async close() {
+      await root.close()
+      await scope.dispose()
+    },
+  }
+}
+
 export const pumped = {
   id: "pumped-fn",
-  async start(fixture) {
-    const scope = createScope({ tags: [caseFixture(fixture)] })
-    const root = scope.createContext()
-    await root.resolve(database)
-
-    return {
-      async provision(input: ProvisionInput, facts: RequestFacts): Promise<Outcome> {
-        const ctx = scope.createContext({
-          parent: root,
-          tags: [actorId(facts.actorId), requestId(facts.requestId)],
-        })
-        try {
-          return { ok: true, user: await ctx.exec({ flow: provision, input }) }
-        } catch (error) {
-          if (isFault(provision, error)) return { ok: false, error: error.fault }
-          throw error
-        } finally {
-          await ctx.close()
-        }
-      },
-      async close() {
-        await root.close()
-        await scope.dispose()
-      },
-    }
-  },
+  start: startPumped,
 } satisfies Lane

--- a/playground/compare/cases/account-onboarding/operations/awilix.test.ts
+++ b/playground/compare/cases/account-onboarding/operations/awilix.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+import { makeFixture } from "../fixture"
+import { startAwilix } from "../lanes/awilix"
+import { createTrace } from "../trace"
+
+describe("Awilix operations", () => {
+  it("records the injected business span", async () => {
+    const trace = createTrace()
+    const runtime = startAwilix(makeFixture(), trace)
+
+    await runtime.provision({ email: "test@example.com" }, { actorId: "admin-test", requestId: "request-test" })
+    await runtime.close()
+    expect(trace.names).toEqual(["account.provision.awilix"])
+  })
+})

--- a/playground/compare/cases/account-onboarding/operations/effect.test.ts
+++ b/playground/compare/cases/account-onboarding/operations/effect.test.ts
@@ -1,0 +1,52 @@
+import { Context, type Exit, Tracer } from "effect"
+import { describe, expect, it } from "vitest"
+import { makeFixture } from "../fixture"
+import { startEffect } from "../lanes/effect"
+import { createTrace, type Trace } from "../trace"
+
+function effectTracer(trace: Trace): Tracer.Tracer {
+  let sequence = 0
+  return Tracer.make({
+    context: (run) => run(),
+    span(name, parent, context, links, startTime, kind) {
+      trace.record(name)
+      sequence += 1
+      let status: Tracer.SpanStatus = { _tag: "Started", startTime }
+      const attributes = new Map<string, unknown>()
+      return {
+        _tag: "Span",
+        name,
+        spanId: `span-${sequence}`,
+        traceId: "comparison-trace",
+        parent,
+        context: Context.empty(),
+        get status() {
+          return status
+        },
+        attributes,
+        links,
+        sampled: true,
+        kind,
+        end(endTime: bigint, exit: Exit.Exit<unknown, unknown>) {
+          status = { _tag: "Ended", startTime, endTime, exit }
+        },
+        attribute(key, value) {
+          attributes.set(key, value)
+        },
+        event() {},
+        addLinks() {},
+      }
+    },
+  })
+}
+
+describe("Effect operations", () => {
+  it("records the explicit Effect span", async () => {
+    const trace = createTrace()
+    const runtime = startEffect(makeFixture(), effectTracer(trace))
+
+    await runtime.provision({ email: "test@example.com" }, { actorId: "admin-test", requestId: "request-test" })
+    await runtime.close()
+    expect(trace.names).toContain("account.provision.effect")
+  })
+})

--- a/playground/compare/cases/account-onboarding/operations/inversify.test.ts
+++ b/playground/compare/cases/account-onboarding/operations/inversify.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+import { makeFixture } from "../fixture"
+import { startInversify } from "../lanes/inversify"
+import { createTrace } from "../trace"
+
+describe("Inversify operations", () => {
+  it("records the explicitly bound business span", async () => {
+    const trace = createTrace()
+    const runtime = startInversify(makeFixture(), trace)
+
+    await runtime.provision({ email: "test@example.com" }, { actorId: "admin-test", requestId: "request-test" })
+    await runtime.close()
+    expect(trace.names).toEqual(["account.provision.inversify"])
+  })
+})

--- a/playground/compare/cases/account-onboarding/operations/plain.test.ts
+++ b/playground/compare/cases/account-onboarding/operations/plain.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+import { makeFixture } from "../fixture"
+import { startPlain } from "../lanes/plain"
+import { createTrace } from "../trace"
+
+describe("Plain TypeScript operations", () => {
+  it("records the explicit application span", async () => {
+    const trace = createTrace()
+    const runtime = await startPlain(makeFixture(), trace)
+
+    await runtime.provision({ email: "test@example.com" }, { actorId: "admin-test", requestId: "request-test" })
+    await runtime.close()
+    expect(trace.names).toEqual(["account.provision.plain"])
+  })
+})

--- a/playground/compare/cases/account-onboarding/operations/pumped.test.ts
+++ b/playground/compare/cases/account-onboarding/operations/pumped.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { makeFixture } from "../fixture"
+import { startPumped } from "../lanes/pumped"
+import { createTrace } from "../trace"
+
+describe("pumped-fn operations", () => {
+  it("records named graph execution", async () => {
+    const trace = createTrace()
+    const runtime = await startPumped(makeFixture(), trace)
+
+    await runtime.provision({ email: "test@example.com" }, { actorId: "admin-test", requestId: "request-test" })
+    await runtime.close()
+    expect(trace.names).toEqual(expect.arrayContaining([
+      "database.open",
+      "account.provision.pumped",
+      "database.insertUser",
+    ]))
+  })
+})

--- a/playground/compare/cases/account-onboarding/tests/awilix.test.ts
+++ b/playground/compare/cases/account-onboarding/tests/awilix.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import type { Database } from "../contract"
+import { createAccounts } from "../lanes/awilix"
+import { silentTrace } from "../trace"
+
+describe("Awilix substitution", () => {
+  it("calls the plain factory with object fakes", async () => {
+    const emails: string[] = []
+    const fakeDatabase: Database = {
+      async insertUser(user) {
+        emails.push(user.email)
+        return "inserted"
+      },
+      async close() {},
+    }
+    const accounts = createAccounts({
+      database: Promise.resolve(fakeDatabase),
+      clock: { now: () => "2026-07-10T00:00:00.000Z" },
+      uuid: { next: () => "user-test" },
+      actorId: "admin-test",
+      requestId: "request-test",
+      trace: silentTrace,
+    })
+
+    await expect(accounts.provision({ email: "test@example.com" })).resolves.toMatchObject({ ok: true })
+    expect(emails).toEqual(["test@example.com"])
+  })
+})

--- a/playground/compare/cases/account-onboarding/tests/effect.test.ts
+++ b/playground/compare/cases/account-onboarding/tests/effect.test.ts
@@ -1,0 +1,34 @@
+import { Effect, Layer } from "effect"
+import { describe, expect, it } from "vitest"
+import type { Database as DatabaseValue } from "../contract"
+import { Accounts, ActorId, Clock, Database, RequestId, Uuid } from "../lanes/effect"
+
+describe("Effect substitution", () => {
+  it("provides test services through Layers", async () => {
+    const emails: string[] = []
+    const fakeDatabase: DatabaseValue = {
+      async insertUser(user) {
+        emails.push(user.email)
+        return "inserted"
+      },
+      async close() {},
+    }
+    const services = Layer.mergeAll(
+      Layer.succeed(Database, fakeDatabase),
+      Layer.succeed(Clock, { now: () => "2026-07-10T00:00:00.000Z" }),
+      Layer.succeed(Uuid, { next: () => "user-test" }),
+    )
+    const program = Effect.flatMap(Accounts, (accounts) => accounts.provision({ email: "test@example.com" })).pipe(
+      Effect.provideService(ActorId, "admin-test"),
+      Effect.provideService(RequestId, "request-test"),
+      Effect.provide(Accounts.Default.pipe(Layer.provide(services))),
+    )
+
+    await expect(Effect.runPromise(program)).resolves.toMatchObject({
+      email: "test@example.com",
+      actorId: "admin-test",
+      requestId: "request-test",
+    })
+    expect(emails).toEqual(["test@example.com"])
+  })
+})

--- a/playground/compare/cases/account-onboarding/tests/inversify.test.ts
+++ b/playground/compare/cases/account-onboarding/tests/inversify.test.ts
@@ -1,0 +1,31 @@
+import "reflect-metadata"
+import { Container } from "inversify"
+import { describe, expect, it } from "vitest"
+import type { Database } from "../contract"
+import { Accounts, actorId, clockId, databaseId, requestId, traceId, uuidId } from "../lanes/inversify"
+import { silentTrace } from "../trace"
+
+describe("Inversify substitution", () => {
+  it("binds fakes in a test container", async () => {
+    const emails: string[] = []
+    const fakeDatabase: Database = {
+      async insertUser(user) {
+        emails.push(user.email)
+        return "inserted"
+      },
+      async close() {},
+    }
+    const container = new Container()
+    container.bind(databaseId).toConstantValue(fakeDatabase)
+    container.bind(clockId).toConstantValue({ now: () => "2026-07-10T00:00:00.000Z" })
+    container.bind(uuidId).toConstantValue({ next: () => "user-test" })
+    container.bind(actorId).toConstantValue("admin-test")
+    container.bind(requestId).toConstantValue("request-test")
+    container.bind(traceId).toConstantValue(silentTrace)
+    container.bind(Accounts).toSelf()
+
+    await expect(container.get(Accounts).provision({ email: "test@example.com" })).resolves.toMatchObject({ ok: true })
+    expect(emails).toEqual(["test@example.com"])
+    await container.unbindAllAsync()
+  })
+})

--- a/playground/compare/cases/account-onboarding/tests/plain.test.ts
+++ b/playground/compare/cases/account-onboarding/tests/plain.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { makeFixture } from "../fixture"
+import { plain } from "../lanes/plain"
+
+describe("Plain TypeScript substitution", () => {
+  it("passes the fixture directly", async () => {
+    const fixture = makeFixture()
+    const runtime = await plain.start(fixture)
+
+    await expect(runtime.provision(
+      { email: "test@example.com" },
+      { actorId: "admin-test", requestId: "request-test" },
+    )).resolves.toMatchObject({ ok: true })
+    await runtime.close()
+    expect(fixture.events.at(-1)).toBe("database.release")
+  })
+})

--- a/playground/compare/cases/account-onboarding/tests/pumped.test.ts
+++ b/playground/compare/cases/account-onboarding/tests/pumped.test.ts
@@ -1,0 +1,32 @@
+import { createScope, preset } from "@pumped-fn/lite"
+import { describe, expect, it } from "vitest"
+import type { Database } from "../contract"
+import { makeFixture } from "../fixture"
+import { actorId, caseFixture, database, provision, requestId } from "../lanes/pumped"
+
+describe("pumped-fn substitution", () => {
+  it("replaces the database at the scope seam", async () => {
+    const emails: string[] = []
+    const fakeDatabase: Database = {
+      async insertUser(user) {
+        emails.push(user.email)
+        return "inserted"
+      },
+      async close() {},
+    }
+    const scope = createScope({
+      presets: [preset(database, fakeDatabase)],
+      tags: [caseFixture(makeFixture()), actorId("admin-test"), requestId("request-test")],
+    })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: provision, input: { email: "test@example.com" } })).resolves.toMatchObject({
+      email: "test@example.com",
+      actorId: "admin-test",
+      requestId: "request-test",
+    })
+    expect(emails).toEqual(["test@example.com"])
+    await ctx.close()
+    await scope.dispose()
+  })
+})

--- a/playground/compare/cases/account-onboarding/trace.ts
+++ b/playground/compare/cases/account-onboarding/trace.ts
@@ -1,0 +1,25 @@
+export type Trace = {
+  readonly names: readonly string[]
+  record(name: string): void
+  span<Output>(name: string, run: () => Promise<Output>): Promise<Output>
+}
+
+export const createTrace = (): Trace => {
+  const names: string[] = []
+  return {
+    names,
+    record(name) {
+      names.push(name)
+    },
+    async span(name, run) {
+      names.push(name)
+      return run()
+    },
+  }
+}
+
+export const silentTrace: Trace = {
+  names: [],
+  record() {},
+  span: (_name, run) => run(),
+}

--- a/playground/compare/index.html
+++ b/playground/compare/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>pumped-fn comparison lab</title>
+    <title>Build, test, and operate | pumped-fn</title>
   </head>
   <body>
     <div id="app"></div>

--- a/playground/compare/package.json
+++ b/playground/compare/package.json
@@ -5,16 +5,20 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "build:pages": "PUMPED_COMPARE_BASE_PATH=/pumped-fn/compare/ vite build",
+    "build:pages": "PUMPED_COMPARE_BASE_PATH=/pumped-fn/ vite build",
     "test": "vitest run",
     "typecheck": "tsgo --noEmit",
     "lint": "pnpm -F @pumped-fn/lite-lint build && node ../../pkg/tool/lint/dist/cli.mjs README.md cases src sandbox scripts vite.config.ts",
     "browser:smoke": "node scripts/sandpack-smoke.mjs",
     "pages:stage": "pnpm build:pages && node scripts/stage-pages.mjs",
-    "pages:verify": "node scripts/verify-pages.mjs",
+    "pages:verify": "node --test scripts/adapters/color-audit.check.mjs && node scripts/verify-pages.mjs",
     "pages:browser:smoke": "node scripts/pages-browser-smoke.mjs",
     "pages:verify:public": "node scripts/adapters/pages-public.mjs",
+    "pages:stage:rollback": "node scripts/stage-pages-rollback.mjs",
+    "pages:verify:rollback": "node scripts/verify-pages-rollback.mjs",
+    "pages:verify:public:rollback": "node scripts/adapters/pages-public-rollback.mjs",
     "pages:dry-run": "pnpm pages:stage && pnpm pages:verify && pnpm pages:browser:smoke",
+    "pages:rollback:dry-run": "pnpm pages:stage:rollback && pnpm pages:verify:rollback",
     "verify": "pnpm lint && pnpm test && pnpm typecheck && pnpm build && pnpm browser:smoke"
   },
   "dependencies": {

--- a/playground/compare/sandbox/main.ts
+++ b/playground/compare/sandbox/main.ts
@@ -16,13 +16,13 @@ async function run() {
   root.dataset.comparisonReady = "true"
   root.innerHTML = `
     <header>
-      <p>Browser contract result</p>
-      <h1>All five lanes completed the same lifecycle</h1>
+      <p>Executable lifecycle</p>
+      <h1>Success · duplicate rollback · success</h1>
     </header>
     <div class="results">
       ${results.map((result) => `
         <article>
-          <span>contract passed</span>
+          <span>passed</span>
           <h2>${result.lane}</h2>
           <dl>
             <dt>requests</dt><dd>3</dd>

--- a/playground/compare/sandbox/styles.css
+++ b/playground/compare/sandbox/styles.css
@@ -1,19 +1,21 @@
 :root {
-  color: #dfe8e1;
-  background: #111713;
+  color: #1f1f1f;
+  background: #ffffff;
   font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  color-scheme: light;
 }
 
 body {
   margin: 0;
   padding: 24px;
+  background: #ffffff;
 }
 
 #app > header p {
   margin: 0 0 8px;
-  color: #7ea98a;
+  color: #737373;
   font-size: 0.7rem;
-  letter-spacing: 0.14em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
@@ -31,18 +33,18 @@ h1 {
 
 article {
   padding: 16px;
-  border: 1px solid #34423a;
-  border-radius: 8px;
-  background: #18211b;
+  border: 1px solid #d4d4d4;
+  border-radius: 4px;
+  background: #fafafa;
 }
 
 article span {
   display: inline-block;
   margin-bottom: 16px;
   padding: 4px 7px;
+  border: 1px solid #a3a3a3;
   border-radius: 999px;
-  background: #244e31;
-  color: #a9e2b8;
+  color: #404040;
   font-size: 0.68rem;
 }
 
@@ -56,11 +58,11 @@ dl {
   grid-template-columns: 1fr auto;
   gap: 7px;
   margin: 0;
-  color: #9eafa4;
+  color: #737373;
   font-size: 0.7rem;
 }
 
 dd {
   margin: 0;
-  color: #e5ede7;
+  color: #262626;
 }

--- a/playground/compare/scripts/adapters/color-audit.check.mjs
+++ b/playground/compare/scripts/adapters/color-audit.check.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+import { auditAuthoredSource } from "./color-audit.mjs"
+
+test("accepts grayscale authored colors", () => {
+  assert.equal(auditAuthoredSource("a { color: #333; box-shadow: 0 1px rgb(9 9 9 / 0.2); }", "fixture.css"), 2)
+})
+
+test("rejects a chromatic named color", () => {
+  assert.throws(() => auditAuthoredSource("a { color: red; }", "fixture.css"), /unsupported authored color syntax/)
+})
+
+test("rejects unsupported modern color syntax", () => {
+  assert.throws(() => auditAuthoredSource("a { color: oklch(50% 0 0); }", "fixture.css"), /unsupported authored color syntax/)
+})
+
+test("rejects unequal RGB channels", () => {
+  assert.throws(() => auditAuthoredSource("a { color: rgb(1 2 1); }", "fixture.css"), /non-grayscale authored color/)
+})

--- a/playground/compare/scripts/adapters/color-audit.mjs
+++ b/playground/compare/scripts/adapters/color-audit.mjs
@@ -1,0 +1,141 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { compareRoot } from "../pages-lib.mjs"
+
+const authoredFiles = [
+  "src/app.tsx",
+  "src/styles.css",
+  "sandbox/styles.css",
+]
+const unsupportedColorFunction = /\b(?:color|color-mix|hsl|hsla|hwb|lab|lch|oklab|oklch)\s*\(/gi
+const colorToken = /#[\da-fA-F]{3,8}\b|rgba?\([^)]*\)/g
+
+function hexChannels(token) {
+  const value = token.slice(1)
+  if (![3, 4, 6, 8].includes(value.length) || !/^[\da-f]+$/i.test(value)) {
+    throw new Error(`unsupported hex color syntax: ${token}`)
+  }
+  const normalized = value.length <= 4 ? [...value].map((part) => `${part}${part}`).join("") : value
+  return [0, 2, 4].map((offset) => Number.parseInt(normalized.slice(offset, offset + 2), 16))
+}
+
+function rgbChannels(token) {
+  const value = token.slice(token.indexOf("(") + 1, -1).trim()
+  if (value.includes("%") || /\b(?:calc|var)\s*\(/i.test(value)) throw new Error(`unsupported rgb color syntax: ${token}`)
+  const channels = value.replaceAll(",", " ").replace("/", " ").split(/\s+/).filter(Boolean)
+  if (channels.length < 3 || channels.slice(0, 3).some((channel) => !/^\d+(?:\.\d+)?$/.test(channel))) {
+    throw new Error(`unsupported rgb color syntax: ${token}`)
+  }
+  return channels.slice(0, 3).map(Number)
+}
+
+function assertGrayscale(token, source) {
+  if (!token.startsWith("#") && !/^rgba?\(/i.test(token)) throw new Error(`unsupported color syntax in ${source}: ${token}`)
+  const [red, green, blue] = token.startsWith("#") ? hexChannels(token) : rgbChannels(token)
+  if (red !== green || green !== blue) throw new Error(`non-grayscale authored color in ${source}: ${token}`)
+}
+
+export async function auditAuthoredGrayscale() {
+  let checkedColorCount = 0
+  for (const relativePath of authoredFiles) {
+    const source = await readFile(join(compareRoot, relativePath), "utf8")
+    checkedColorCount += auditAuthoredSource(source, relativePath)
+  }
+  if (checkedColorCount === 0) throw new Error("authored grayscale audit found no color tokens")
+  return checkedColorCount
+}
+
+export function auditAuthoredSource(source, relativePath) {
+  const unsupported = [...source.matchAll(unsupportedColorFunction)].map(([match]) => match)
+  if (unsupported.length > 0) throw new Error(`unsupported authored color syntax in ${relativePath}: ${unsupported.join(", ")}`)
+  let checkedColorCount = 0
+  for (const [token] of source.matchAll(colorToken)) {
+    assertGrayscale(token, relativePath)
+    checkedColorCount += 1
+  }
+  if (relativePath.endsWith(".css")) {
+    for (const [, property, rawValue] of source.matchAll(/(?:^|[;{\n])\s*([\w-]+)\s*:\s*([^;{}]+);/g)) {
+      if (property === "color-scheme" || !/(?:color|background|border|outline|shadow|fill|stroke)/i.test(property)) continue
+      const remainder = rawValue
+        .replace(colorToken, " ")
+        .replace(/-?\d*\.?\d+(?:px|rem|em|%|s|deg)?/gi, " ")
+        .replace(/\b(?:solid|none|transparent|currentcolor|inherit|initial|unset|revert|inset|outset)\b/gi, " ")
+        .replace(/[(),/.-]/g, " ")
+        .trim()
+      if (remainder !== "") throw new Error(`unsupported authored color syntax in ${relativePath}: ${property}: ${rawValue.trim()}`)
+    }
+  }
+  if (relativePath === "src/app.tsx") {
+    const theme = source.match(/const grayscaleTheme = \{\s*colors:\s*\{([\s\S]*?)\n\s*},\s*syntax:\s*\{([\s\S]*?)\n\s*},\s*font:/)
+    if (!theme) throw new Error("grayscaleTheme colors and syntax blocks are missing")
+    for (const block of theme.slice(1)) {
+      for (const [, token] of block.matchAll(/"([^"]+)"/g)) {
+        if (token === "italic") continue
+        assertGrayscale(token, "src/app.tsx grayscaleTheme")
+      }
+    }
+  }
+  return checkedColorCount
+}
+
+export async function auditComputedGrayscale(page) {
+  const findings = []
+  for (const frame of page.frames()) {
+    findings.push(...await frame.evaluate(() => {
+      const properties = [
+        "background-color",
+        "background-image",
+        "border-bottom-color",
+        "border-left-color",
+        "border-right-color",
+        "border-top-color",
+        "box-shadow",
+        "caret-color",
+        "color",
+        "column-rule-color",
+        "fill",
+        "outline-color",
+        "stroke",
+        "text-decoration-color",
+        "text-shadow",
+      ]
+      const unsupported = /\b(?:color|color-mix|hsl|hsla|hwb|lab|lch|oklab|oklch)\s*\(/i
+      const rgb = /rgba?\(\s*(\d+(?:\.\d+)?)\s*(?:,|\s)\s*(\d+(?:\.\d+)?)\s*(?:,|\s)\s*(\d+(?:\.\d+)?)(?:\s*(?:,|\/)\s*[\d.]+)?\s*\)/g
+      const localFindings = []
+      for (const element of document.querySelectorAll("*")) {
+        for (const pseudo of [null, "::before", "::after"]) {
+          const style = getComputedStyle(element, pseudo)
+          for (const property of properties) {
+            const value = style.getPropertyValue(property)
+            if (unsupported.test(value)) {
+              localFindings.push(`${element.tagName}${pseudo ?? ""} ${property} unsupported ${value}`)
+              continue
+            }
+            for (const match of value.matchAll(rgb)) {
+              const [red, green, blue] = match.slice(1, 4).map(Number)
+              if (red !== green || green !== blue) {
+                localFindings.push(`${element.tagName}${pseudo ?? ""} ${property} ${match[0]}`)
+              }
+            }
+          }
+        }
+      }
+      return localFindings
+    }))
+  }
+  if (findings.length > 0) throw new Error(`computed non-grayscale colors\n${findings.join("\n")}`)
+  return 0
+}
+
+export async function auditHorizontalOverflow(page, viewport) {
+  const overflow = await page.evaluate(() => ({
+    documentClientWidth: document.documentElement.clientWidth,
+    documentScrollWidth: document.documentElement.scrollWidth,
+    bodyClientWidth: document.body.clientWidth,
+    bodyScrollWidth: document.body.scrollWidth,
+  }))
+  if (overflow.documentScrollWidth > overflow.documentClientWidth || overflow.bodyScrollWidth > overflow.bodyClientWidth) {
+    throw new Error(`horizontal overflow at ${viewport.width}x${viewport.height}: ${JSON.stringify(overflow)}`)
+  }
+  return overflow
+}

--- a/playground/compare/scripts/adapters/pages-public-rollback.mjs
+++ b/playground/compare/scripts/adapters/pages-public-rollback.mjs
@@ -1,0 +1,50 @@
+import { loadBaseline, sha256 } from "../pages-lib.mjs"
+
+const baseUrlSource = process.argv[2] ?? process.env.PAGES_PUBLIC_BASE_URL
+if (!baseUrlSource) throw new Error("public Pages base URL argument or PAGES_PUBLIC_BASE_URL is required")
+const baseUrl = new URL(baseUrlSource)
+if (!/^https?:$/.test(baseUrl.protocol) || baseUrl.username || baseUrl.password || baseUrl.search || baseUrl.hash) {
+  throw new Error("public Pages base URL must be an HTTP URL without credentials, query, or fragment")
+}
+baseUrl.pathname = `${baseUrl.pathname.replace(/\/+$/, "")}/`
+
+const baseline = await loadBaseline()
+const requestTimeoutMs = 15000
+const deadline = Date.now() + 120000
+
+async function fetchBytes(path) {
+  const url = new URL(path, baseUrl)
+  url.searchParams.set("pumped-fn-rollback", baseline.provenance.rootSha256)
+  const response = await fetch(url, {
+    headers: { "cache-control": "no-cache" },
+    signal: AbortSignal.timeout(requestTimeoutMs),
+  })
+  if (!response.ok) throw new Error(`${response.status} ${url}`)
+  return Buffer.from(await response.arrayBuffer())
+}
+
+let observedRoot
+while (Date.now() < deadline) {
+  observedRoot = sha256(await fetchBytes("index.html"))
+  if (observedRoot === baseline.provenance.rootSha256) break
+  await new Promise((resolve) => setTimeout(resolve, 2000))
+}
+if (observedRoot !== baseline.provenance.rootSha256) throw new Error("public rollback root did not reach baseline provenance")
+
+let cursor = 0
+async function verifyNextFile() {
+  while (cursor < baseline.entries.length) {
+    const { path, digest } = baseline.entries[cursor++]
+    const encodedPath = path.split("/").map(encodeURIComponent).join("/")
+    if (sha256(await fetchBytes(encodedPath)) !== digest) throw new Error(`public rollback digest mismatch: ${path}`)
+  }
+}
+await Promise.all(Array.from({ length: 8 }, verifyNextFile))
+
+process.stdout.write(`${JSON.stringify({
+  status: "verified-public-baseline-rollback",
+  baseUrl: baseUrl.href,
+  baselinePathCount: baseline.entries.length,
+  baselineManifestSha256: baseline.provenance.manifestSha256,
+  baselineRootSha256: baseline.provenance.rootSha256,
+})}\n`)

--- a/playground/compare/scripts/adapters/pages-public.mjs
+++ b/playground/compare/scripts/adapters/pages-public.mjs
@@ -1,7 +1,10 @@
 import { chromium } from "playwright"
+import { auditComputedGrayscale, auditHorizontalOverflow } from "./color-audit.mjs"
 import { loadBaseline, parseManifest, sha256 } from "../pages-lib.mjs"
 
 const expectedLanes = ["pumped-fn", "effect", "awilix", "inversify", "plain"]
+const expectedLaneLabels = ["pumped-fn", "Effect", "Awilix", "Inversify", "Plain TS"]
+const expectedDimensions = ["Build", "Test", "Operate"]
 const expectedEvents = [
   "database.acquire",
   "uuid.next",
@@ -51,10 +54,21 @@ const expectedOutcomes = {
 const baseUrlSource = process.argv[2] ?? process.env.PAGES_PUBLIC_BASE_URL
 const expectedRevision = process.argv[3] ?? process.env.PAGES_EXPECTED_REVISION
 const expectedTreeState = process.env.PAGES_EXPECTED_TREE_STATE ?? "clean"
+const verifierTimeoutMs = Number(process.env.PAGES_VERIFY_TIMEOUT_MS ?? 360000)
 if (!baseUrlSource) throw new Error("public Pages base URL argument or PAGES_PUBLIC_BASE_URL is required")
 if (!expectedRevision) throw new Error("expected revision argument or PAGES_EXPECTED_REVISION is required")
 if (!/^[a-f0-9]{40}$/.test(expectedRevision)) throw new Error("expected revision must be a full Git SHA")
 if (!/^(clean|dirty)$/.test(expectedTreeState)) throw new Error("expected tree state must be clean or dirty")
+if (!Number.isSafeInteger(verifierTimeoutMs) || verifierTimeoutMs < 30000) throw new Error("invalid Pages verifier timeout")
+
+function phase(name, details = {}) {
+  process.stdout.write(`${JSON.stringify({ pagesVerifyPhase: name, ...details })}\n`)
+}
+
+const watchdog = setTimeout(() => {
+  process.stderr.write(`${JSON.stringify({ pagesVerifyPhase: "timeout", timeoutMs: verifierTimeoutMs })}\n`)
+  process.exit(124)
+}, verifierTimeoutMs)
 
 const baseUrl = new URL(baseUrlSource)
 if (!/^https?:$/.test(baseUrl.protocol) || baseUrl.username || baseUrl.password || baseUrl.search || baseUrl.hash) {
@@ -63,6 +77,7 @@ if (!/^https?:$/.test(baseUrl.protocol) || baseUrl.username || baseUrl.password 
 baseUrl.pathname = `${baseUrl.pathname.replace(/\/+$/, "")}/`
 
 const baseline = await loadBaseline()
+const preservedEntries = baseline.entries.filter(({ path }) => path !== "index.html")
 const requestTimeoutMs = 15000
 const revisionDeadline = Date.now() + 120000
 
@@ -78,7 +93,7 @@ async function fetchBytes(url) {
 }
 
 async function loadRevision() {
-  const url = new URL("compare/revision.json", baseUrl)
+  const url = new URL("revision.json", baseUrl)
   let lastError
   while (Date.now() < revisionDeadline) {
     try {
@@ -94,44 +109,60 @@ async function loadRevision() {
 }
 
 const revision = await loadRevision()
-if (revision.schemaVersion !== 1) throw new Error("revision metadata has the wrong schema version")
+phase("revision-pinned", { sourceRevision: revision.sourceRevision })
+if (revision.schemaVersion !== 2) throw new Error("revision metadata has the wrong schema version")
 if (revision.repository !== "pumped-fn/pumped-fn") throw new Error("revision metadata has the wrong repository")
-if (revision.basePath !== "/pumped-fn/compare/") throw new Error("revision metadata has the wrong base path")
+if (revision.basePath !== "/pumped-fn/") throw new Error("revision metadata has the wrong base path")
 if (revision.sourceTreeState !== expectedTreeState) throw new Error("revision metadata has the wrong tree state")
-if (revision.baselineManifestSha256 !== baseline.provenance.manifestSha256) {
-  throw new Error("revision metadata has the wrong baseline manifest")
-}
-if (revision.baselinePathCount !== baseline.entries.length) throw new Error("revision metadata has the wrong baseline count")
-if (!Array.isArray(revision.comparisonAssets)) throw new Error("revision metadata has no comparison assets")
-const comparisonManifest = `${revision.comparisonAssets.map(({ path, digest }) => `${path} ${digest}`).join("\n")}\n`
-const comparisonAssets = parseManifest(comparisonManifest)
-if (revision.comparisonAssetPathCount !== comparisonAssets.length) {
-  throw new Error("revision metadata has the wrong comparison asset count")
-}
-if (revision.comparisonAssetManifestSha256 !== sha256(comparisonManifest)) {
-  throw new Error("revision metadata has the wrong comparison asset manifest")
-}
+if (revision.baselineManifestSha256 !== baseline.provenance.manifestSha256) throw new Error("wrong baseline manifest")
+if (revision.baselinePathCount !== 109 || revision.preservedBaselinePathCount !== 108) throw new Error("wrong baseline counts")
+if (JSON.stringify(revision.replacedBaselinePaths) !== JSON.stringify(["index.html"])) throw new Error("wrong replacement set")
 
-async function verifyFiles(entries, prefix, label) {
+const homepageManifest = `${revision.homepageAssets.map(({ path, digest }) => `${path} ${digest}`).join("\n")}\n`
+const homepageAssets = parseManifest(homepageManifest)
+if (revision.homepageAssetPathCount !== homepageAssets.length) throw new Error("wrong homepage asset count")
+if (revision.homepageAssetManifestSha256 !== sha256(homepageManifest)) throw new Error("wrong homepage asset manifest")
+if (revision.legacyRedirects.length !== 1) throw new Error("wrong redirect count")
+const [redirect] = revision.legacyRedirects
+if (redirect.path !== "compare/index.html" || redirect.target !== "/pumped-fn/") throw new Error("wrong redirect contract")
+
+const expectedRollback = {
+  archiveSha256: baseline.provenance.archiveSha256,
+  manifestSha256: baseline.provenance.manifestSha256,
+  rootSha256: baseline.provenance.rootSha256,
+  pathCount: baseline.provenance.pathCount,
+}
+if (JSON.stringify(revision.rollback) !== JSON.stringify(expectedRollback)) throw new Error("wrong rollback provenance")
+
+async function verifyFiles(entries, label) {
   let cursor = 0
   async function verifyNextFile() {
     while (cursor < entries.length) {
       const { path, digest } = entries[cursor++]
       const encodedPath = path.split("/").map(encodeURIComponent).join("/")
-      const actualDigest = sha256(await fetchBytes(new URL(`${prefix}${encodedPath}`, baseUrl)))
+      const actualDigest = sha256(await fetchBytes(new URL(encodedPath, baseUrl)))
       if (actualDigest !== digest) throw new Error(`public ${label} digest mismatch: ${path}`)
     }
   }
   await Promise.all(Array.from({ length: Math.min(8, entries.length) }, verifyNextFile))
 }
-await Promise.all([
-  verifyFiles(baseline.entries, "", "baseline"),
-  verifyFiles(comparisonAssets, "compare/", "comparison asset"),
-])
 
-const browser = await chromium.launch({ headless: true })
-try {
-  const page = await browser.newPage()
+await Promise.all([
+  verifyFiles(preservedEntries, "preserved baseline"),
+  verifyFiles(homepageAssets, "homepage asset"),
+  verifyFiles([{ path: redirect.path, digest: redirect.digest }], "legacy redirect"),
+])
+phase("asset-digests-verified", {
+  preservedBaselinePathCount: preservedEntries.length,
+  homepageAssetPathCount: homepageAssets.length,
+})
+const stagedContentEntries = [...preservedEntries, ...homepageAssets, { path: redirect.path, digest: redirect.digest }]
+  .sort((left, right) => left.path < right.path ? -1 : left.path > right.path ? 1 : 0)
+const stagedContentManifest = `${stagedContentEntries.map(({ path, digest }) => `${path} ${digest}`).join("\n")}\n`
+if (revision.stagedContentPathCount !== stagedContentEntries.length) throw new Error("wrong staged content count")
+if (revision.stagedContentManifestSha256 !== sha256(stagedContentManifest)) throw new Error("wrong staged content manifest")
+
+function collectDiagnostics(page) {
   const diagnostics = []
   page.on("console", (message) => {
     if (message.type() === "error") diagnostics.push(message.text())
@@ -146,46 +177,85 @@ try {
     if (failure === "net::ERR_ABORTED" && hostname.endsWith(".codesandbox.io")) return
     diagnostics.push(`${failure} ${request.url()}`)
   })
-  const comparisonUrl = new URL("compare/", baseUrl)
-  comparisonUrl.searchParams.set("pumped-fn-revision", expectedRevision)
-  await page.goto(comparisonUrl.href, {
-    waitUntil: "domcontentloaded",
-    timeout: requestTimeoutMs,
-  })
-  const preview = page.frameLocator('iframe[title="Sandpack Preview"]')
-  try {
-    await preview.locator('[data-comparison-ready="true"]').waitFor({ timeout: 120000 })
-  } catch (error) {
-    throw new Error(`${error.message}\n${diagnostics.join("\n")}\n${await preview.locator("body").innerText()}`)
+  return diagnostics
+}
+
+async function verifySelectors(page) {
+  const tabs = page.getByRole("button", { name: /^(Build|Test|Operate)$/ })
+  if (await tabs.allTextContents().then((values) => values.join("\n")) !== expectedDimensions.join("\n")) {
+    throw new Error("comparison dimension selectors are incomplete")
   }
-  const source = await preview.locator("#app").getAttribute("data-results")
-  if (!source) throw new Error("comparison results are missing")
-  const results = JSON.parse(source)
-  if (results.map(({ lane }) => lane).join("\n") !== expectedLanes.join("\n")) {
-    throw new Error("public comparison did not execute all five expected lanes in order")
-  }
-  for (const result of results) {
-    const actual = {
-      success: result.success,
-      duplicate: result.duplicate,
-      secondSuccess: result.secondSuccess,
-      events: result.events,
-    }
-    const expected = { ...expectedOutcomes, events: expectedEvents }
-    if (JSON.stringify(actual) !== JSON.stringify(expected)) {
-      throw new Error(`${result.lane} did not complete the exact three-request lifecycle`)
+  for (const dimension of expectedDimensions) {
+    await page.getByRole("button", { name: dimension, exact: true }).click()
+    for (const lane of expectedLaneLabels) {
+      await page.getByRole("button", { name: lane, exact: true }).click()
+      await page.getByRole("heading", { name: `${dimension}: ${lane}`, exact: true }).waitFor()
     }
   }
-  if (diagnostics.length > 0) throw new Error(`public comparison emitted diagnostics\n${diagnostics.join("\n")}`)
+}
+
+const browser = await chromium.launch({ headless: true })
+try {
+  for (const viewport of [{ width: 375, height: 812 }, { width: 1440, height: 900 }]) {
+    phase("viewport-start", viewport)
+    const page = await browser.newPage({ viewport })
+    page.setDefaultTimeout(10000)
+    const diagnostics = collectDiagnostics(page)
+    const homepageUrl = new URL(baseUrl)
+    homepageUrl.searchParams.set("pumped-fn-revision", expectedRevision)
+    await page.goto(homepageUrl.href, { waitUntil: "domcontentloaded", timeout: requestTimeoutMs })
+    const preview = page.frameLocator('iframe[title="Sandpack Preview"]')
+    try {
+      await preview.locator('[data-comparison-ready="true"]').waitFor({ timeout: 90000 })
+    } catch (error) {
+      const previewBody = await preview.locator("body").innerText({ timeout: 5000 }).catch((bodyError) => `preview body unavailable: ${bodyError.message}`)
+      throw new Error(`${error.message}\n${diagnostics.join("\n")}\n${previewBody}`)
+    }
+    const source = await preview.locator("#app").getAttribute("data-results")
+    if (!source) throw new Error("comparison results are missing")
+    const results = JSON.parse(source)
+    if (results.map(({ lane }) => lane).join("\n") !== expectedLanes.join("\n")) {
+      throw new Error("public comparison did not execute all five expected lanes in order")
+    }
+    for (const result of results) {
+      const actual = {
+        success: result.success,
+        duplicate: result.duplicate,
+        secondSuccess: result.secondSuccess,
+        events: result.events,
+      }
+      if (JSON.stringify(actual) !== JSON.stringify({ ...expectedOutcomes, events: expectedEvents })) {
+        throw new Error(`${result.lane} did not complete the exact three-request lifecycle`)
+      }
+    }
+    await verifySelectors(page)
+    await auditComputedGrayscale(page)
+    await auditHorizontalOverflow(page, viewport)
+    if (diagnostics.length > 0) throw new Error(`public comparison emitted diagnostics\n${diagnostics.join("\n")}`)
+    await page.close()
+    phase("viewport-complete", viewport)
+  }
+
+  phase("redirect-start")
+  const redirectPage = await browser.newPage()
+  await redirectPage.goto(new URL("compare/", baseUrl).href, { waitUntil: "domcontentloaded", timeout: requestTimeoutMs })
+  await redirectPage.waitForURL((url) => url.pathname === baseUrl.pathname, { timeout: requestTimeoutMs })
+  await redirectPage.close()
+  phase("redirect-complete")
 } finally {
   await browser.close()
 }
 
+clearTimeout(watchdog)
 process.stdout.write(`${JSON.stringify({
-  status: "verified-public",
+  status: "verified-public-root",
   baseUrl: baseUrl.href,
   sourceRevision: revision.sourceRevision,
-  unchangedNonComparePathCount: baseline.entries.length,
-  comparisonAssetPathCount: comparisonAssets.length,
+  preservedBaselinePathCount: preservedEntries.length,
+  homepageAssetPathCount: homepageAssets.length,
   comparisonLaneCount: expectedLanes.length,
+  comparisonDimensionCount: expectedDimensions.length,
+  viewportCount: 2,
+  computedNonGrayscaleColorCount: 0,
+  horizontalOverflowViewportCount: 0,
 })}\n`)

--- a/playground/compare/scripts/adapters/watchdog.mjs
+++ b/playground/compare/scripts/adapters/watchdog.mjs
@@ -1,0 +1,4 @@
+export function startWatchdog(timeoutMs, onTimeout) {
+  const timer = setTimeout(onTimeout, timeoutMs)
+  return () => clearTimeout(timer)
+}

--- a/playground/compare/scripts/pages-browser-smoke.mjs
+++ b/playground/compare/scripts/pages-browser-smoke.mjs
@@ -2,6 +2,7 @@ import { createReadStream } from "node:fs"
 import { readFile, stat } from "node:fs/promises"
 import { createServer } from "node:http"
 import { extname, join, normalize, sep } from "node:path"
+import { startWatchdog } from "./adapters/watchdog.mjs"
 import { stageRoot } from "./pages-lib.mjs"
 
 const types = new Map([
@@ -21,7 +22,7 @@ const server = createServer(async (request, response) => {
       return
     }
     const requestPath = decodeURIComponent(url.pathname.slice("/pumped-fn/".length))
-    const relativePath = requestPath.endsWith("/") ? `${requestPath}index.html` : requestPath
+    const relativePath = requestPath === "" || requestPath.endsWith("/") ? `${requestPath}index.html` : requestPath
     const safePath = normalize(relativePath).split(sep).join("/")
     if (safePath.startsWith("../") || safePath === "..") {
       response.writeHead(400).end()
@@ -37,14 +38,32 @@ const server = createServer(async (request, response) => {
   }
 })
 
-await new Promise((resolve) => server.listen(4179, "127.0.0.1", resolve))
+function phase(name, details = {}) {
+  process.stdout.write(`${JSON.stringify({ pagesSmokePhase: name, ...details })}\n`)
+}
+
+const stopWatchdog = startWatchdog(180000, () => {
+  process.stderr.write(`${JSON.stringify({ pagesSmokePhase: "timeout", timeoutMs: 180000 })}\n`)
+  server.closeAllConnections()
+  process.exit(124)
+}, 180000)
+
+await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve))
 
 try {
-  const revision = JSON.parse(await readFile(join(stageRoot, "compare", "revision.json"), "utf8"))
-  process.env.PAGES_PUBLIC_BASE_URL = "http://127.0.0.1:4179/pumped-fn/"
+  const revision = JSON.parse(await readFile(join(stageRoot, "revision.json"), "utf8"))
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("local Pages server has no TCP address")
+  phase("server-ready", { port: address.port })
+  process.env.PAGES_PUBLIC_BASE_URL = `http://127.0.0.1:${address.port}/pumped-fn/`
   process.env.PAGES_EXPECTED_REVISION = revision.sourceRevision
   process.env.PAGES_EXPECTED_TREE_STATE = revision.sourceTreeState
+  process.env.PAGES_VERIFY_TIMEOUT_MS = "170000"
+  phase("public-verifier-start")
   await import("./adapters/pages-public.mjs")
+  phase("public-verifier-complete")
 } finally {
+  stopWatchdog()
+  server.closeAllConnections()
   await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
 }

--- a/playground/compare/scripts/stage-pages-rollback.mjs
+++ b/playground/compare/scripts/stage-pages-rollback.mjs
@@ -1,0 +1,32 @@
+import { mkdtemp, mkdir, rename, rm, writeFile } from "node:fs/promises"
+import {
+  extractBaseline,
+  fileManifest,
+  pagesRoot,
+  sha256,
+  stageManifestPath,
+  stageRoot,
+} from "./pages-lib.mjs"
+
+await mkdir(pagesRoot, { recursive: true })
+const temporaryRoot = await mkdtemp(`${stageRoot}.rollback-`)
+
+try {
+  const baseline = await extractBaseline(temporaryRoot)
+  const stagedManifest = await fileManifest(temporaryRoot, baseline.entries.map(({ path }) => path))
+  await rm(stageRoot, { force: true, recursive: true })
+  await rename(temporaryRoot, stageRoot)
+  await writeFile(stageManifestPath, stagedManifest)
+  process.stdout.write(`${JSON.stringify({
+    status: "staged-baseline-rollback",
+    output: stageRoot,
+    baselinePathCount: baseline.entries.length,
+    baselineManifestSha256: baseline.provenance.manifestSha256,
+    baselineArchiveSha256: baseline.provenance.archiveSha256,
+    baselineRootSha256: baseline.provenance.rootSha256,
+    stagedManifestSha256: sha256(stagedManifest),
+  })}\n`)
+} catch (error) {
+  await rm(temporaryRoot, { force: true, recursive: true })
+  throw error
+}

--- a/playground/compare/scripts/stage-pages.mjs
+++ b/playground/compare/scripts/stage-pages.mjs
@@ -18,6 +18,8 @@ import {
 const compareDist = join(compareRoot, "dist")
 const revision = process.env.GITHUB_SHA ?? run("git", ["rev-parse", "HEAD"], { cwd: compareRoot }).trim()
 const treeState = run("git", ["status", "--porcelain"], { cwd: compareRoot }).trim() === "" ? "clean" : "dirty"
+const redirectPath = "compare/index.html"
+const redirectSource = "<!doctype html><html lang=\"en\"><head><meta charset=\"UTF-8\"><meta name=\"viewport\" content=\"width=device-width,initial-scale=1\"><meta http-equiv=\"refresh\" content=\"0;url=/pumped-fn/\"><link rel=\"canonical\" href=\"/pumped-fn/\"><title>pumped-fn comparison</title></head><body><a href=\"/pumped-fn/\">Open the pumped-fn comparison</a></body></html>\n"
 
 await mkdir(pagesRoot, { recursive: true })
 const temporaryRoot = await mkdtemp(`${stageRoot}.tmp-`)
@@ -26,41 +28,81 @@ const completeStage = join(temporaryRoot, "site")
 
 try {
   const baseline = await extractBaseline(baselineStage)
+  const homepagePaths = await listFiles(compareDist)
+  if (!homepagePaths.includes("index.html")) throw new Error("homepage build has no index.html")
+  const baselinePaths = new Set(baseline.entries.map(({ path }) => path))
+  const collisions = homepagePaths.filter((path) => baselinePaths.has(path))
+  if (collisions.join("\n") !== "index.html") {
+    throw new Error(`generated/baseline collision set must equal index.html: ${collisions.join(", ")}`)
+  }
+  for (const reservedPath of ["revision.json", redirectPath]) {
+    if (homepagePaths.includes(reservedPath) || baselinePaths.has(reservedPath)) {
+      throw new Error(`reserved Pages path is occupied: ${reservedPath}`)
+    }
+  }
+
   await copyTree(baselineStage, completeStage)
-  await copyTree(compareDist, join(completeStage, "compare"))
-  const comparePaths = await listFiles(join(completeStage, "compare"))
-  if (!comparePaths.includes("index.html")) throw new Error("comparison build has no index.html")
-  const compareManifest = await fileManifest(join(completeStage, "compare"), comparePaths)
+  await rm(join(completeStage, "index.html"))
+  await copyTree(compareDist, completeStage)
+  await mkdir(join(completeStage, "compare"), { recursive: true })
+  await writeFile(join(completeStage, redirectPath), redirectSource)
+
+  const preservedEntries = baseline.entries.filter(({ path }) => path !== "index.html")
+  await validateDigests(completeStage, preservedEntries)
+  const homepageManifest = await fileManifest(completeStage, homepagePaths)
+  const legacyRedirects = [{
+    path: redirectPath,
+    digest: sha256(redirectSource),
+    target: "/pumped-fn/",
+  }]
+  const stagedContentPaths = [...preservedEntries.map(({ path }) => path), ...homepagePaths, redirectPath].sort()
+  const stagedContentManifest = await fileManifest(completeStage, stagedContentPaths)
   const revisionMetadata = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     repository: "pumped-fn/pumped-fn",
-    basePath: "/pumped-fn/compare/",
+    basePath: "/pumped-fn/",
     sourceRevision: revision,
     sourceTreeState: treeState,
     baselineManifestSha256: baseline.provenance.manifestSha256,
     baselinePathCount: baseline.entries.length,
-    comparisonAssetPathCount: comparePaths.length,
-    comparisonAssetManifestSha256: sha256(compareManifest),
-    comparisonAssets: parseManifest(compareManifest),
+    replacedBaselinePaths: ["index.html"],
+    preservedBaselinePathCount: preservedEntries.length,
+    homepageAssetPathCount: homepagePaths.length,
+    homepageAssetManifestSha256: sha256(homepageManifest),
+    homepageAssets: parseManifest(homepageManifest),
+    legacyRedirects,
+    stagedContentPathCount: stagedContentPaths.length,
+    stagedContentManifestSha256: sha256(stagedContentManifest),
+    rollback: {
+      archiveSha256: baseline.provenance.archiveSha256,
+      manifestSha256: baseline.provenance.manifestSha256,
+      rootSha256: baseline.provenance.rootSha256,
+      pathCount: baseline.provenance.pathCount,
+    },
   }
-  await writeFile(join(completeStage, "compare", "revision.json"), `${JSON.stringify(revisionMetadata, null, 2)}\n`)
-  const nonComparePaths = (await listFiles(completeStage)).filter((path) => !path.startsWith("compare/"))
-  if (nonComparePaths.join("\n") !== baseline.entries.map(({ path }) => path).join("\n")) {
-    throw new Error("non-compare path set changed after overlay")
+  await writeFile(join(completeStage, "revision.json"), `${JSON.stringify(revisionMetadata, null, 2)}\n`)
+
+  const finalPaths = await listFiles(completeStage)
+  const expectedPaths = [...stagedContentPaths, "revision.json"].sort()
+  if (finalPaths.join("\n") !== expectedPaths.join("\n")) throw new Error("final staged path set is not exact")
+  if (finalPaths.filter((path) => path.startsWith("compare/")).join("\n") !== redirectPath) {
+    throw new Error("compare/ contains more than the legacy redirect")
   }
-  await validateDigests(completeStage, baseline.entries)
-  const stagedManifest = await fileManifest(completeStage)
+
+  const stagedManifest = await fileManifest(completeStage, finalPaths)
   await rm(stageRoot, { force: true, recursive: true })
   await rename(completeStage, stageRoot)
   await writeFile(stageManifestPath, stagedManifest)
   process.stdout.write(`${JSON.stringify({
-    status: "staged",
+    status: "staged-root",
     output: stageRoot,
     manifest: stageManifestPath,
     baselinePathCount: baseline.entries.length,
-    comparisonPathCount: comparePaths.length + 1,
-    stagedPathCount: stagedManifest.trimEnd().split("\n").length,
+    preservedBaselinePathCount: preservedEntries.length,
+    homepageAssetPathCount: homepagePaths.length,
+    stagedPathCount: finalPaths.length,
     stagedManifestSha256: sha256(stagedManifest),
+    stagedContentManifestSha256: sha256(stagedContentManifest),
     sourceRevision: revision,
   })}\n`)
 } finally {

--- a/playground/compare/scripts/verify-pages-rollback.mjs
+++ b/playground/compare/scripts/verify-pages-rollback.mjs
@@ -1,0 +1,31 @@
+import { readFile } from "node:fs/promises"
+import {
+  fileManifest,
+  listFiles,
+  loadBaseline,
+  sha256,
+  stageManifestPath,
+  stageRoot,
+  validateFiles,
+} from "./pages-lib.mjs"
+
+const baseline = await loadBaseline()
+const pathCount = await validateFiles(stageRoot, baseline.entries)
+const stagedPaths = await listFiles(stageRoot)
+const stagedManifest = await fileManifest(stageRoot, stagedPaths)
+const recordedManifest = await readFile(stageManifestPath, "utf8")
+if (recordedManifest !== stagedManifest) throw new Error("rollback staging manifest does not match staged bytes")
+if (sha256(await readFile(`${stageRoot}/index.html`)) !== baseline.provenance.rootSha256) {
+  throw new Error("rollback root digest does not match provenance")
+}
+if (stagedPaths.includes("revision.json") || stagedPaths.some((path) => path.startsWith("compare/"))) {
+  throw new Error("rollback artifact contains successor-only paths")
+}
+
+process.stdout.write(`${JSON.stringify({
+  status: "verified-baseline-rollback",
+  baselinePathCount: pathCount,
+  baselineManifestSha256: baseline.provenance.manifestSha256,
+  baselineRootSha256: baseline.provenance.rootSha256,
+  stagedManifestSha256: sha256(stagedManifest),
+})}\n`)

--- a/playground/compare/scripts/verify-pages.mjs
+++ b/playground/compare/scripts/verify-pages.mjs
@@ -10,55 +10,78 @@ import {
   stageRoot,
   validateDigests,
 } from "./pages-lib.mjs"
+import { auditAuthoredGrayscale } from "./adapters/color-audit.mjs"
 
 const baseline = await loadBaseline()
+const preservedEntries = baseline.entries.filter(({ path }) => path !== "index.html")
 const stagedPaths = await listFiles(stageRoot)
-const nonComparePaths = stagedPaths.filter((path) => !path.startsWith("compare/"))
-const comparePaths = stagedPaths.filter((path) => path.startsWith("compare/"))
+const revision = JSON.parse(await readFile(join(stageRoot, "revision.json"), "utf8"))
 
-if (nonComparePaths.join("\n") !== baseline.entries.map(({ path }) => path).join("\n")) {
-  throw new Error("non-compare path set does not match the ratified baseline")
+if (revision.schemaVersion !== 2) throw new Error("revision metadata has the wrong schema version")
+if (revision.repository !== "pumped-fn/pumped-fn") throw new Error("revision metadata has the wrong repository")
+if (revision.basePath !== "/pumped-fn/") throw new Error("revision metadata has the wrong base path")
+if (!/^[a-f0-9]{40}$/.test(revision.sourceRevision)) throw new Error("revision metadata has an invalid source revision")
+if (!/^(clean|dirty)$/.test(revision.sourceTreeState)) throw new Error("revision metadata has an invalid tree state")
+if (revision.baselineManifestSha256 !== baseline.provenance.manifestSha256) throw new Error("wrong baseline manifest")
+if (revision.baselinePathCount !== 109 || revision.baselinePathCount !== baseline.entries.length) throw new Error("wrong baseline count")
+if (JSON.stringify(revision.replacedBaselinePaths) !== JSON.stringify(["index.html"])) throw new Error("wrong replacement set")
+if (revision.preservedBaselinePathCount !== 108 || revision.preservedBaselinePathCount !== preservedEntries.length) {
+  throw new Error("wrong preserved baseline count")
 }
-await validateDigests(stageRoot, baseline.entries)
-if (!comparePaths.includes("compare/index.html") || !comparePaths.includes("compare/revision.json")) {
-  throw new Error("comparison overlay is incomplete")
+await validateDigests(stageRoot, preservedEntries)
+
+const homepageManifest = `${revision.homepageAssets.map(({ path, digest }) => `${path} ${digest}`).join("\n")}\n`
+const homepageAssets = parseManifest(homepageManifest)
+if (!homepageAssets.some(({ path }) => path === "index.html")) throw new Error("homepage manifest has no index")
+if (revision.homepageAssetPathCount !== homepageAssets.length) throw new Error("wrong homepage asset count")
+if (revision.homepageAssetManifestSha256 !== sha256(homepageManifest)) throw new Error("wrong homepage manifest")
+await validateDigests(stageRoot, homepageAssets)
+
+if (revision.legacyRedirects.length !== 1) throw new Error("wrong legacy redirect count")
+const [redirect] = revision.legacyRedirects
+if (redirect.path !== "compare/index.html" || redirect.target !== "/pumped-fn/") throw new Error("wrong legacy redirect")
+if (sha256(await readFile(join(stageRoot, redirect.path))) !== redirect.digest) throw new Error("legacy redirect digest mismatch")
+if (stagedPaths.filter((path) => path.startsWith("compare/")).join("\n") !== redirect.path) {
+  throw new Error("compare/ contains duplicate application assets")
 }
 
-const index = await readFile(join(stageRoot, "compare", "index.html"), "utf8")
-if (!index.includes("/pumped-fn/compare/")) throw new Error("comparison build does not use the Pages subpath")
+const stagedContentPaths = [
+  ...preservedEntries.map(({ path }) => path),
+  ...homepageAssets.map(({ path }) => path),
+  redirect.path,
+].sort()
+const stagedContentManifest = await fileManifest(stageRoot, stagedContentPaths)
+if (revision.stagedContentPathCount !== stagedContentPaths.length) throw new Error("wrong staged content count")
+if (revision.stagedContentManifestSha256 !== sha256(stagedContentManifest)) throw new Error("wrong staged content manifest")
+const expectedPaths = [...stagedContentPaths, "revision.json"].sort()
+if (stagedPaths.join("\n") !== expectedPaths.join("\n")) throw new Error("staged path set is not exact")
 
-const revision = JSON.parse(await readFile(join(stageRoot, "compare", "revision.json"), "utf8"))
-if (revision.basePath !== "/pumped-fn/compare/") throw new Error("revision metadata has the wrong base path")
-if (revision.baselineManifestSha256 !== baseline.provenance.manifestSha256) {
-  throw new Error("revision metadata has the wrong baseline manifest")
+const expectedRollback = {
+  archiveSha256: baseline.provenance.archiveSha256,
+  manifestSha256: baseline.provenance.manifestSha256,
+  rootSha256: baseline.provenance.rootSha256,
+  pathCount: baseline.provenance.pathCount,
 }
-if (revision.baselinePathCount !== baseline.entries.length) throw new Error("revision metadata has the wrong baseline count")
+if (JSON.stringify(revision.rollback) !== JSON.stringify(expectedRollback)) throw new Error("wrong rollback provenance")
 
-const compareAssetPaths = comparePaths
-  .filter((path) => path !== "compare/revision.json")
-  .map((path) => path.slice("compare/".length))
-const compareManifest = await fileManifest(join(stageRoot, "compare"), compareAssetPaths)
-if (revision.comparisonAssetPathCount !== compareAssetPaths.length) {
-  throw new Error("revision metadata has the wrong comparison path count")
-}
-if (revision.comparisonAssetManifestSha256 !== sha256(compareManifest)) {
-  throw new Error("revision metadata has the wrong comparison manifest")
-}
-if (JSON.stringify(revision.comparisonAssets) !== JSON.stringify(parseManifest(compareManifest))) {
-  throw new Error("revision metadata has the wrong comparison assets")
-}
+const index = await readFile(join(stageRoot, "index.html"), "utf8")
+if (!index.includes("/pumped-fn/")) throw new Error("homepage build does not use the root Pages base")
+if (index.includes("/pumped-fn/compare/")) throw new Error("homepage build still uses the comparison subpath")
+await auditAuthoredGrayscale()
 
 const expectedStagedManifest = await fileManifest(stageRoot, stagedPaths)
 const recordedStagedManifest = await readFile(stageManifestPath, "utf8")
 if (recordedStagedManifest !== expectedStagedManifest) throw new Error("staging manifest does not match staged bytes")
 
 process.stdout.write(`${JSON.stringify({
-  status: "verified",
+  status: "verified-root",
   baselinePathCount: baseline.entries.length,
-  unchangedNonComparePathCount: nonComparePaths.length,
-  comparisonPathCount: comparePaths.length,
+  preservedBaselinePathCount: preservedEntries.length,
+  homepageAssetPathCount: homepageAssets.length,
   stagedPathCount: stagedPaths.length,
+  authoredNonGrayscaleColorCount: 0,
   baselineManifestSha256: baseline.provenance.manifestSha256,
   stagedManifestSha256: sha256(recordedStagedManifest),
+  stagedContentManifestSha256: sha256(stagedContentManifest),
   sourceRevision: revision.sourceRevision,
 })}\n`)

--- a/playground/compare/sources.lock.json
+++ b/playground/compare/sources.lock.json
@@ -10,6 +10,8 @@
       "package": "@pumped-fn/lite@4.0.0",
       "license": "MIT",
       "files": [
+        "docs/test-without-mocks.md",
+        "docs/observability.md",
         "docs/vs-effect.md",
         "docs/vs-di-containers.md",
         "pkg/core/lite/src/index.ts"
@@ -32,7 +34,8 @@
       "documentation": [
         "https://effect.website/docs/requirements-management/services/",
         "https://effect.website/docs/requirements-management/layers/",
-        "https://effect.website/docs/resource-management/introduction/"
+        "https://effect.website/docs/resource-management/introduction/",
+        "https://effect.website/docs/observability/tracing/"
       ],
       "adaptation": "Keeps the official example's Effect.Service composition, service layers, typed failures, spans, and replaceable runtime dependencies. SQL, HTTP, policy, and repositories are collapsed into the shared browser-safe database contract; ManagedRuntime adapts the long-lived layer to the Lane Promise boundary."
     },
@@ -47,7 +50,7 @@
         "examples/koa/index.js",
         "examples/typescript/src/index.ts"
       ],
-      "adaptation": "Keeps strict proxy injection, a singleton disposable database, a scoped account service, and request child scopes."
+      "adaptation": "Keeps strict proxy injection, a singleton disposable database, a scoped account service, and request child scopes. The operations proof injects a small browser-safe Trace value and wraps provision explicitly in this lane."
     },
     {
       "id": "inversify",
@@ -65,7 +68,7 @@
         "https://inversify.io/docs/introduction/getting-started/",
         "https://inversify.io/docs/api/container/"
       ],
-      "adaptation": "Keeps the official decorator-based constructor injection, Container bindings, async dynamic resolution, singleton lifetime, child request containers, and asynchronous deactivation while replacing application IO with the shared browser-safe contract."
+      "adaptation": "Keeps the official decorator-based constructor injection, Container bindings, async dynamic resolution, singleton lifetime, child request containers, and asynchronous deactivation while replacing application IO with the shared browser-safe contract. The operations proof binds a small browser-safe Trace value and wraps provision explicitly in this lane."
     },
     {
       "id": "sandpack",

--- a/playground/compare/src/app.tsx
+++ b/playground/compare/src/app.tsx
@@ -7,137 +7,176 @@ import {
 } from "@codesandbox/sandpack-react"
 import { sandboxDependencies, sandboxFiles } from "./sandbox-files"
 
+type Dimension = "Build" | "Test" | "Operate"
+
+const dimensions: Dimension[] = ["Build", "Test", "Operate"]
+
 const lanes = [
   {
     id: "pumped-fn",
     label: "pumped-fn",
-    model: "Execution graph",
-    composition: "resource + flow deps",
-    request: "required request tags",
-    failure: "typed flow fault",
-    cleanup: "root-owned resource",
-    file: "/cases/account-onboarding/lanes/pumped.ts",
-    source: "workspace source",
+    source: "pumped-fn source",
+    href: "https://github.com/pumped-fn/pumped-fn/tree/ca2a8fa3ae462129034c9f05f6630f1099955ca0",
+    files: {
+      Build: "/cases/account-onboarding/lanes/pumped.ts",
+      Test: "/cases/account-onboarding/tests/pumped.test.ts",
+      Operate: "/cases/account-onboarding/operations/pumped.test.ts",
+    },
+    values: {
+      Build: "Graph edges declare dependencies, request facts, resource ownership, typed failure, and named side effects.",
+      Test: "Replace a graph edge at createScope, then execute the same flow without patching a module.",
+      Operate: "One extension observes graph execution; named child work is recorded without tracing calls in the flow.",
+    },
   },
   {
     id: "effect",
     label: "Effect",
-    model: "Program model",
-    composition: "Effect.Service + Layer",
-    request: "Context services",
-    failure: "Effect error channel",
-    cleanup: "scoped Layer",
-    file: "/cases/account-onboarding/lanes/effect.ts",
     source: "official example",
     href: "https://github.com/Effect-TS/examples/tree/91e24b045af2bcdbeb2e78e075825ed20a0038a7/examples/http-server",
+    files: {
+      Build: "/cases/account-onboarding/lanes/effect.ts",
+      Test: "/cases/account-onboarding/tests/effect.test.ts",
+      Operate: "/cases/account-onboarding/operations/effect.test.ts",
+    },
+    values: {
+      Build: "Services and Layers build a typed program runtime with scoped acquisition and request services.",
+      Test: "Provide test Layers to the same Effect service program and keep dependencies in the Effect type system.",
+      Operate: "withSpan names the operation; the runtime tracer receives the completed business span.",
+    },
   },
   {
     id: "awilix",
     label: "Awilix",
-    model: "DI container",
-    composition: "strict proxy cradle",
-    request: "child-scope values",
-    failure: "Outcome union",
-    cleanup: "singleton disposer",
-    file: "/cases/account-onboarding/lanes/awilix.ts",
     source: "official repository",
     href: "https://github.com/jeffijoe/awilix/tree/f72d175ddb950c3f13ef41e8be98b24471d59900",
+    files: {
+      Build: "/cases/account-onboarding/lanes/awilix.ts",
+      Test: "/cases/account-onboarding/tests/awilix.test.ts",
+      Operate: "/cases/account-onboarding/operations/awilix.test.ts",
+    },
+    values: {
+      Build: "A strict proxy cradle wires plain factories; registrations carry lifetime and request values.",
+      Test: "Call the plain factory with an object of fakes; the unit test does not need the container.",
+      Operate: "This lane injects Trace and wraps provision explicitly; container disposal remains a separate lifecycle edge.",
+    },
   },
   {
     id: "inversify",
     label: "Inversify",
-    model: "Decorator DI",
-    composition: "@injectable + Container",
-    request: "child-container bindings",
-    failure: "Outcome union",
-    cleanup: "singleton deactivation",
-    file: "/cases/account-onboarding/lanes/inversify.ts",
     source: "official monorepo",
     href: "https://github.com/inversify/monorepo/tree/7c605a9bd99e9cb8b611f65a53e6d940cb0f0e1e",
+    files: {
+      Build: "/cases/account-onboarding/lanes/inversify.ts",
+      Test: "/cases/account-onboarding/tests/inversify.test.ts",
+      Operate: "/cases/account-onboarding/operations/inversify.test.ts",
+    },
+    values: {
+      Build: "Decorated constructors and runtime identifiers form the graph; child containers carry request facts.",
+      Test: "Bind fakes in a fresh test container; identifiers and decorator metadata remain part of setup.",
+      Operate: "This lane binds Trace as a dependency and wraps the provision method explicitly.",
+    },
   },
   {
     id: "plain",
     label: "Plain TS",
-    model: "Closure baseline",
-    composition: "manual construction",
-    request: "function arguments",
-    failure: "Outcome union",
-    cleanup: "explicit close",
-    file: "/cases/account-onboarding/lanes/plain.ts",
     source: "control lane",
+    href: "https://www.typescriptlang.org/",
+    files: {
+      Build: "/cases/account-onboarding/lanes/plain.ts",
+      Test: "/cases/account-onboarding/tests/plain.test.ts",
+      Operate: "/cases/account-onboarding/operations/plain.test.ts",
+    },
+    values: {
+      Build: "Construction, request values, failure mapping, and cleanup are handwritten closures and calls.",
+      Test: "Pass a fake fixture directly; the seam stays simple because the application threads it manually.",
+      Operate: "Every operation boundary is explicit application code, including the Trace span around provision.",
+    },
   },
 ] as const
 
-const axes = [
-  { label: "Model", key: "model" },
-  { label: "Composition", key: "composition" },
-  { label: "Request facts", key: "request" },
-  { label: "Expected failure", key: "failure" },
-  { label: "Cleanup", key: "cleanup" },
-] as const
+const visibleFiles = lanes.flatMap((lane) => dimensions.map((dimension) => lane.files[dimension]))
 
-const steps = [
-  ["01", "Compose once", "One runtime per lane"],
-  ["02", "Provision", "Acquire once, return the user"],
-  ["03", "Duplicate", "Rollback with a typed outcome"],
-  ["04", "Fresh request", "Use new actor and request facts"],
-  ["05", "Close once", "Release the database"],
-] as const
+const grayscaleTheme = {
+  colors: {
+    surface1: "#ffffff",
+    surface2: "#f5f5f5",
+    surface3: "#e8e8e8",
+    disabled: "#a3a3a3",
+    base: "#1f1f1f",
+    clickable: "#404040",
+    hover: "#000000",
+    accent: "#000000",
+    error: "#242424",
+    errorSurface: "#eeeeee",
+    warning: "#3d3d3d",
+    warningSurface: "#f2f2f2",
+  },
+  syntax: {
+    plain: "#262626",
+    comment: { color: "#737373", fontStyle: "italic" },
+    keyword: "#000000",
+    definition: "#404040",
+    punctuation: "#525252",
+    property: "#171717",
+    tag: "#333333",
+    static: "#595959",
+    string: "#666666",
+  },
+  font: {
+    body: "ui-sans-serif, system-ui, sans-serif",
+    mono: "ui-monospace, SFMono-Regular, Consolas, monospace",
+    size: "14px",
+    lineHeight: "1.5",
+  },
+} as const
 
-function ComparisonGuide() {
+function Comparison() {
   const { sandpack } = useSandpack()
+  const selectedLane = lanes.find((lane) => dimensions.some((item) => lane.files[item] === sandpack.activeFile))!
+  const dimension = dimensions.find((item) => selectedLane.files[item] === sandpack.activeFile)!
+
+  function selectDimension(next: Dimension): void {
+    sandpack.openFile(selectedLane.files[next])
+  }
+
+  function selectLane(lane: (typeof lanes)[number]): void {
+    sandpack.openFile(lane.files[dimension])
+  }
 
   return (
     <>
-      <section className="scenario" aria-labelledby="scenario-title">
-        <div className="section-heading">
-          <p>Shared executable contract</p>
-          <h2 id="scenario-title">Account onboarding, including the lifecycle</h2>
-        </div>
-        <ol className="scenario-steps">
-          {steps.map(([number, title, detail]) => (
-            <li key={number}>
-              <span>{number}</span>
-              <strong>{title}</strong>
-              <small>{detail}</small>
-            </li>
+      <section className="comparison" aria-label="Five lane comparison">
+        <div className="dimension-tabs" aria-label="Comparison dimension">
+          {dimensions.map((item) => (
+            <button
+              aria-pressed={dimension === item}
+              key={item}
+              onClick={() => selectDimension(item)}
+              type="button"
+            >
+              {item}
+            </button>
           ))}
-        </ol>
-      </section>
-
-      <section className="comparison" aria-labelledby="comparison-title">
-        <div className="section-heading">
-          <p>Side by side</p>
-          <h2 id="comparison-title">Same behavior, native composition</h2>
-          <span>Choose a lane to open its exact checked-in source below.</span>
         </div>
-        <div className="matrix" role="table" aria-label="Dependency model comparison">
-          <div className="matrix-row matrix-header" role="row">
-            <div role="columnheader">Axis</div>
-            {lanes.map((lane) => (
-              <div role="columnheader" key={lane.id} data-active={sandpack.activeFile === lane.file}>
-                <button type="button" onClick={() => sandpack.openFile(lane.file)}>
-                  {lane.label}
-                </button>
-                {"href" in lane ? <a href={lane.href}>{lane.source}</a> : <span>{lane.source}</span>}
+        <div className="lane-grid">
+          {lanes.map((lane) => (
+            <article data-active={lane.id === selectedLane.id} key={lane.id}>
+              <button className="lane-name" onClick={() => selectLane(lane)} type="button">
+                {lane.label}
+              </button>
+              <p>{lane.values[dimension]}</p>
+              <div className="lane-meta">
+                <code>{lane.files[dimension]}</code>
+                <a href={lane.href}>{lane.source}</a>
               </div>
-            ))}
-          </div>
-          {axes.map((axis) => (
-            <div className="matrix-row" role="row" key={axis.key}>
-              <div role="rowheader">{axis.label}</div>
-              {lanes.map((lane) => <div role="cell" key={lane.id}>{lane[axis.key]}</div>)}
-            </div>
+            </article>
           ))}
         </div>
       </section>
 
-      <section className="workspace-heading" id="workspace" aria-labelledby="workspace-title">
-        <div className="section-heading">
-          <p>Editable proof</p>
-          <h2 id="workspace-title">Change a lane. Rerun the contract.</h2>
-          <span>The preview executes the same scenario module as the Node suite.</span>
-        </div>
+      <section className="source-heading" aria-labelledby="source-title">
+        <h2 id="source-title">{dimension}: {selectedLane.label}</h2>
+        <code>{selectedLane.files[dimension]}</code>
       </section>
     </>
   )
@@ -147,36 +186,28 @@ export function App() {
   return (
     <main>
       <header className="hero">
-        <p>pumped-fn comparison lab</p>
-        <h1>One contract.<br />Five dependency models.</h1>
-        <p>Inspect the wiring, run the same lifecycle, and decide from executable source—not a rewritten snippet.</p>
-        <div className="hero-proof">
-          <span>4 libraries + 1 control</span>
-          <span>3 requests per lane</span>
-          <span>1 acquire / 1 release</span>
-        </div>
+        <h1>Build, test, and operate the same account workflow.</h1>
+        <p>Five checked-in implementations. Select a dimension, inspect its source, edit it, and run the shared contract.</p>
+        <dl className="contract-strip">
+          <div><dt>Request 1</dt><dd>success</dd></div>
+          <div><dt>Request 2</dt><dd>typed duplicate · rollback</dd></div>
+          <div><dt>Request 3</dt><dd>new actor · success</dd></div>
+          <div><dt>Database</dt><dd>one acquire · one release</dd></div>
+        </dl>
       </header>
-      <section className="lab" aria-label="Comparison runtime">
+      <section className="lab" aria-label="Executable dependency comparison">
         <SandpackProvider
-          template="vanilla-ts"
-          files={sandboxFiles}
           customSetup={{ dependencies: sandboxDependencies, entry: "/sandbox/main.ts" }}
+          files={sandboxFiles}
           options={{
             activeFile: "/cases/account-onboarding/lanes/pumped.ts",
             initMode: "immediate",
-            visibleFiles: [
-              "/cases/account-onboarding/lanes/pumped.ts",
-              "/cases/account-onboarding/lanes/effect.ts",
-              "/cases/account-onboarding/lanes/awilix.ts",
-              "/cases/account-onboarding/lanes/inversify.ts",
-              "/cases/account-onboarding/lanes/plain.ts",
-              "/cases/account-onboarding/scenario.ts",
-              "/cases/account-onboarding/contract.ts",
-              "/cases/account-onboarding/fixture.ts",
-            ],
+            visibleFiles,
           }}
+          template="vanilla-ts"
+          theme={grayscaleTheme}
         >
-          <ComparisonGuide />
+          <Comparison />
           <SandpackLayout>
             <SandpackCodeEditor showLineNumbers />
             <SandpackPreview showOpenInCodeSandbox={false} showRefreshButton />

--- a/playground/compare/src/sandbox-files.ts
+++ b/playground/compare/src/sandbox-files.ts
@@ -5,7 +5,18 @@ import effect from "../cases/account-onboarding/lanes/effect.ts?raw"
 import inversify from "../cases/account-onboarding/lanes/inversify.ts?raw"
 import plain from "../cases/account-onboarding/lanes/plain.ts?raw"
 import pumped from "../cases/account-onboarding/lanes/pumped.ts?raw"
+import operateAwilix from "../cases/account-onboarding/operations/awilix.test.ts?raw"
+import operateEffect from "../cases/account-onboarding/operations/effect.test.ts?raw"
+import operateInversify from "../cases/account-onboarding/operations/inversify.test.ts?raw"
+import operatePlain from "../cases/account-onboarding/operations/plain.test.ts?raw"
+import operatePumped from "../cases/account-onboarding/operations/pumped.test.ts?raw"
 import scenario from "../cases/account-onboarding/scenario.ts?raw"
+import testAwilix from "../cases/account-onboarding/tests/awilix.test.ts?raw"
+import testEffect from "../cases/account-onboarding/tests/effect.test.ts?raw"
+import testInversify from "../cases/account-onboarding/tests/inversify.test.ts?raw"
+import testPlain from "../cases/account-onboarding/tests/plain.test.ts?raw"
+import testPumped from "../cases/account-onboarding/tests/pumped.test.ts?raw"
+import trace from "../cases/account-onboarding/trace.ts?raw"
 import index from "../sandbox/index.html?raw"
 import main from "../sandbox/main.ts?raw"
 import styles from "../sandbox/styles.css?raw"
@@ -21,7 +32,18 @@ export const sandboxFiles = {
   "/cases/account-onboarding/lanes/inversify.ts": inversify,
   "/cases/account-onboarding/lanes/plain.ts": plain,
   "/cases/account-onboarding/lanes/pumped.ts": pumped,
+  "/cases/account-onboarding/operations/awilix.test.ts": operateAwilix,
+  "/cases/account-onboarding/operations/effect.test.ts": operateEffect,
+  "/cases/account-onboarding/operations/inversify.test.ts": operateInversify,
+  "/cases/account-onboarding/operations/plain.test.ts": operatePlain,
+  "/cases/account-onboarding/operations/pumped.test.ts": operatePumped,
   "/cases/account-onboarding/scenario.ts": scenario,
+  "/cases/account-onboarding/tests/awilix.test.ts": testAwilix,
+  "/cases/account-onboarding/tests/effect.test.ts": testEffect,
+  "/cases/account-onboarding/tests/inversify.test.ts": testInversify,
+  "/cases/account-onboarding/tests/plain.test.ts": testPlain,
+  "/cases/account-onboarding/tests/pumped.test.ts": testPumped,
+  "/cases/account-onboarding/trace.ts": trace,
   "/sandbox/main.ts": main,
   "/sandbox/styles.css": styles,
 }

--- a/playground/compare/src/styles.css
+++ b/playground/compare/src/styles.css
@@ -1,8 +1,9 @@
 :root {
-  color: #162018;
-  background: #eee9dc;
-  font-family: "IBM Plex Sans", "Avenir Next", ui-sans-serif, system-ui, sans-serif;
+  color: #171717;
+  background: #ffffff;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
   font-synthesis: none;
+  color-scheme: light;
 }
 
 * {
@@ -11,66 +12,69 @@
 
 body {
   margin: 0;
-  background:
-    linear-gradient(90deg, rgb(22 32 24 / 0.045) 1px, transparent 1px),
-    linear-gradient(rgb(22 32 24 / 0.045) 1px, transparent 1px),
-    #eee9dc;
-  background-size: 32px 32px;
+  background: #ffffff;
+}
+
+button,
+a {
+  color: inherit;
 }
 
 main {
-  width: min(1380px, calc(100% - 40px));
+  width: min(1440px, calc(100% - 48px));
   margin: 0 auto;
-  padding: 72px 0 96px;
+  padding: 64px 0 96px;
 }
 
 .hero {
-  max-width: 980px;
-  padding: 32px 0 72px;
-}
-
-.hero > p:first-child,
-.section-heading > p {
-  margin: 0 0 14px;
-  color: #35624a;
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
+  max-width: 1040px;
+  padding: 24px 0 56px;
 }
 
 h1 {
-  max-width: 900px;
   margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: clamp(3.6rem, 9vw, 8rem);
-  font-weight: 500;
-  letter-spacing: -0.075em;
-  line-height: 0.78;
+  font-size: clamp(3rem, 7vw, 7rem);
+  font-weight: 520;
+  letter-spacing: -0.07em;
+  line-height: 0.92;
 }
 
-.hero > p:nth-of-type(2) {
-  max-width: 680px;
-  margin: 36px 0 0;
-  color: #405047;
-  font-size: clamp(1.05rem, 2vw, 1.35rem);
+.hero > p {
+  max-width: 690px;
+  margin: 28px 0 0;
+  color: #525252;
+  font-size: clamp(1rem, 1.8vw, 1.25rem);
   line-height: 1.55;
 }
 
-.hero-proof {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 28px;
+.contract-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 40px 0 0;
+  border-block: 1px solid #d4d4d4;
 }
 
-.hero-proof span {
-  padding: 8px 12px;
-  border: 1px solid #a9b2a8;
-  border-radius: 999px;
-  background: rgb(255 255 255 / 0.32);
-  color: #304339;
-  font-size: 0.8rem;
+.contract-strip div {
+  min-width: 0;
+  padding: 16px 18px;
+  border-left: 1px solid #e5e5e5;
+}
+
+.contract-strip div:first-child {
+  border-left: 0;
+}
+
+.contract-strip dt {
+  color: #737373;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.contract-strip dd {
+  margin: 6px 0 0;
+  font-size: 0.88rem;
   font-weight: 600;
 }
 
@@ -78,148 +82,116 @@ h1 {
   display: contents;
 }
 
-.scenario,
-.comparison,
-.workspace-heading {
-  margin-bottom: 72px;
-}
-
-.section-heading {
-  max-width: 720px;
-  margin-bottom: 28px;
-}
-
-.section-heading h2 {
-  margin: 0;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: clamp(2rem, 4vw, 3.6rem);
-  font-weight: 500;
-  letter-spacing: -0.045em;
-  line-height: 1;
-}
-
-.section-heading > span {
-  display: block;
-  margin-top: 14px;
-  color: #5a675f;
-}
-
-.scenario-steps {
-  display: grid;
-  grid-template-columns: repeat(5, minmax(150px, 1fr));
-  margin: 0;
-  padding: 0;
-  border-top: 1px solid #859087;
-  border-bottom: 1px solid #859087;
-  list-style: none;
-}
-
-.scenario-steps li {
-  display: grid;
-  min-height: 132px;
-  padding: 18px;
-  border-left: 1px solid #b9c0b8;
-}
-
-.scenario-steps li:first-child {
-  border-left: 0;
-}
-
-.scenario-steps span {
-  color: #557362;
-  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
-  font-size: 0.75rem;
-}
-
-.scenario-steps strong {
-  align-self: end;
-  font-size: 0.96rem;
-}
-
-.scenario-steps small {
-  margin-top: 5px;
-  color: #657169;
-  line-height: 1.35;
-}
-
-.matrix {
-  min-width: 1050px;
-  border-top: 1px solid #77837a;
-  border-bottom: 1px solid #77837a;
-}
-
 .comparison {
+  margin-bottom: 56px;
+}
+
+.dimension-tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.dimension-tabs button {
+  padding: 10px 18px;
+  border: 1px solid #d4d4d4;
+  border-radius: 999px;
+  background: #ffffff;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.dimension-tabs button[aria-pressed="true"] {
+  border-color: #171717;
+  background: #171717;
+  color: #ffffff;
+}
+
+.lane-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(210px, 1fr));
   overflow-x: auto;
+  border-block: 1px solid #a3a3a3;
 }
 
-.matrix-row {
+.lane-grid article {
   display: grid;
-  grid-template-columns: 150px repeat(5, minmax(170px, 1fr));
-  border-top: 1px solid #c0c6bf;
+  grid-template-rows: auto 1fr auto;
+  min-height: 250px;
+  padding: 20px;
+  border-left: 1px solid #d4d4d4;
+  background: #ffffff;
 }
 
-.matrix-row:first-child {
-  border-top: 0;
-}
-
-.matrix-row > div {
-  min-width: 0;
-  padding: 15px 14px;
-  border-left: 1px solid #c0c6bf;
-  font-size: 0.84rem;
-  line-height: 1.35;
-}
-
-.matrix-row > div:first-child {
+.lane-grid article:first-child {
   border-left: 0;
-  color: #526158;
-  font-size: 0.74rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
 }
 
-.matrix-header > div:not(:first-child) {
-  display: grid;
-  gap: 7px;
-  background: rgb(255 255 255 / 0.26);
+.lane-grid article[data-active="true"] {
+  background: #f5f5f5;
+  box-shadow: inset 0 3px #171717;
 }
 
-.matrix-header > div[data-active="true"] {
-  background: #d7e8d8;
-  box-shadow: inset 0 3px #25593b;
-}
-
-.matrix-header button {
+.lane-name {
   width: max-content;
   padding: 0;
   border: 0;
   background: transparent;
-  color: #162018;
   cursor: pointer;
   font: inherit;
-  font-family: Georgia, "Times New Roman", serif;
-  font-size: 1.15rem;
+  font-size: 1.12rem;
+  font-weight: 700;
 }
 
-.matrix-header a,
-.matrix-header span {
-  color: #557362;
+.lane-grid article > p {
+  margin: 24px 0;
+  color: #404040;
+  font-size: 0.86rem;
+  line-height: 1.55;
+}
+
+.lane-meta {
+  display: grid;
+  gap: 9px;
+}
+
+.lane-meta code,
+.source-heading code {
+  color: #737373;
   font-size: 0.68rem;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
+}
+
+.lane-meta a {
+  width: max-content;
+  color: #525252;
+  font-size: 0.7rem;
   text-underline-offset: 3px;
 }
 
-.workspace-heading {
-  margin-bottom: 22px;
-  scroll-margin-top: 24px;
+.source-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 16px;
+}
+
+.source-heading h2 {
+  margin: 0;
+  font-size: clamp(1.4rem, 2.6vw, 2.2rem);
+  letter-spacing: -0.035em;
 }
 
 .sp-layout {
   min-height: 620px;
-  border: 1px solid #79847b;
-  border-radius: 4px;
+  border: 1px solid #a3a3a3;
+  border-radius: 2px;
   overflow: hidden;
-  box-shadow: 0 24px 70px rgb(43 52 46 / 0.16);
+  box-shadow: 0 20px 60px rgb(0 0 0 / 0.08);
 }
 
 .sp-preview-container > .sp-loading {
@@ -232,27 +204,74 @@ h1 {
   height: 620px !important;
 }
 
-@media (max-width: 850px) {
+@media (max-width: 760px) {
   main {
-    width: min(100% - 24px, 1380px);
-    padding-top: 38px;
+    width: min(100% - 24px, 1440px);
+    padding-top: 32px;
   }
 
   .hero {
-    padding-bottom: 52px;
+    padding-bottom: 40px;
   }
 
-  .scenario-steps {
-    grid-template-columns: 1fr;
+  h1 {
+    font-size: clamp(2.8rem, 14vw, 5rem);
   }
 
-  .scenario-steps li {
-    min-height: 94px;
-    border-top: 1px solid #b9c0b8;
+  .contract-strip {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .contract-strip div:nth-child(3) {
     border-left: 0;
   }
 
-  .scenario-steps li:first-child {
+  .contract-strip div:nth-child(n + 3) {
+    border-top: 1px solid #e5e5e5;
+  }
+
+  .dimension-tabs {
+    position: sticky;
+    top: 8px;
+    z-index: 2;
+    padding: 6px;
+    border: 1px solid #e5e5e5;
+    border-radius: 999px;
+    background: #ffffff;
+  }
+
+  .dimension-tabs button {
+    flex: 1;
+  }
+
+  .lane-grid {
+    grid-template-columns: 1fr;
+    overflow: visible;
+  }
+
+  .lane-grid article {
+    min-height: 0;
+    border-top: 1px solid #d4d4d4;
+    border-left: 0;
+  }
+
+  .lane-grid article:first-child {
     border-top: 0;
+  }
+
+  .source-heading {
+    display: grid;
+    gap: 8px;
+  }
+
+  .sp-layout {
+    display: grid !important;
+    min-height: 1040px;
+  }
+
+  .sp-layout > .sp-stack,
+  .sp-preview-container,
+  .sp-preview-iframe {
+    height: 520px !important;
   }
 }


### PR DESCRIPTION
## Summary\n\n- make the Build/Test/Operate comparison the GitHub Pages root\n- add five native substitution tests and five executable operations proofs\n- replace the yellow treatment with a measured white grayscale surface\n- preserve 108 existing Pages paths byte-for-byte and redirect /compare/ to the root\n- add schema-v2 revision metadata, strict color/layout checks, and an exact baseline rollback mode\n\n## Verification\n\n- comparison lint: 39 files, 0 diagnostics\n- Vitest: 11 files, 15 tests\n- typecheck and production build\n- Sandpack: all five lanes, unchanged 17-event lifecycle\n- all 15 Build/Test/Operate selector cells at 375x812 and 1440x900\n- authored and computed non-grayscale colors: 0\n- horizontal-overflowing viewports: 0\n- Pages dry run: 108 preserved baseline digests, 8 homepage assets, root redirect, exact manifests\n- rollback dry run: exact 109-file baseline\n- actionlint and workflow job listing\n\n## Review note\n\nIndependent replay caught a 404 in the first local root server because the empty root path did not map to index.html. The fix is included, the first browser claim was invalidated, and the corrected exact Pages dry run exits 0 with bounded phase diagnostics.