### PR TITLE
feat(compare): live type intelligence, syntax palette, and three-proof preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ createScope({ presets, tags, extensions })
   -> scope-owned graph
   -> execution context per request, job, action, or test
   -> flows, resources, tags, and wrapped execution edges
+  -> module-level Model providers: Claude CLI, Codex CLI/ACP, or pi-ai
 ```
 
 ## Test without mocking modules
@@ -185,6 +186,7 @@ Read the checklist: [How to review pumped-fn code](docs/code-review-guide.md).
 | `pkg/sdk/claude` | `@pumped-fn/sdk-claude` | [README](pkg/sdk/claude/README.md) |
 | `pkg/sdk/codex` | `@pumped-fn/sdk-codex` | [README](pkg/sdk/codex/README.md) |
 | `pkg/sdk/core` | `@pumped-fn/sdk` | [README](pkg/sdk/core/README.md) |
+| `pkg/sdk/pi` | `@pumped-fn/sdk-pi` | [README](pkg/sdk/pi/README.md) |
 | `pkg/sdk/test` | `@pumped-fn/sdk-test` | [README](pkg/sdk/test/README.md) |
 | `pkg/tool/codemod` | `@pumped-fn/codemod` | [README](pkg/tool/codemod/README.md) |
 | `pkg/tool/lint` | `@pumped-fn/lite-lint` | [README](pkg/tool/lint/README.md) |

--- a/pkg/framework/pumped/README.md
+++ b/pkg/framework/pumped/README.md
@@ -39,9 +39,9 @@ like any other tag. Wiring a provider is a one-liner on the app config:
 
 ```ts
 // src/app.ts
-import { claude } from "@pumped-fn/sdk-claude"
+import { claude, claudeConfig } from "@pumped-fn/sdk-claude"
 
-export default { tags: [claude()] }
+export default { tags: [claude, claudeConfig({ auth: { kind: "global" } })] }
 ```
 
 ### One scope per process

--- a/pkg/sdk/README.md
+++ b/pkg/sdk/README.md
@@ -13,8 +13,9 @@ and runs them.
 | Directory | Package | Role |
 | --- | --- | --- |
 | `core/` | `@pumped-fn/sdk` | Durable workflows, sessions, materials, events, guards, sandboxes, CLI workers, eval harness, and the agent/tool/skill primitive family. |
-| `codex/` | `@pumped-fn/sdk-codex` | Codex CLI model provider tag. |
-| `claude/` | `@pumped-fn/sdk-claude` | Claude CLI model provider tag. |
+| `codex/` | `@pumped-fn/sdk-codex` | Module-level Codex CLI and ACP model providers. |
+| `claude/` | `@pumped-fn/sdk-claude` | Module-level Claude CLI model provider. |
+| `pi/` | `@pumped-fn/sdk-pi` | In-process pi-ai model provider with native tool calls. |
 | `bash/` | `@pumped-fn/sdk-just-bash` | just-bash sandbox provider tag. |
 | `test/` | `@pumped-fn/sdk-test` | In-memory logs, fake routing, and test helpers. |
 
@@ -26,7 +27,13 @@ should name the integration surface, while package names carry the `sdk` prefix.
 ## Content Rules
 
 SDK packages should compose through Lite scopes, tags, flows, resources, and extensions. Provider
-packages expose lazy provider tags and keep provider-specific setup out of the core package.
+packages expose module-level handles plus config tags and keep provider-specific setup out of the core package.
+
+## Testing
+
+Provider packages carry `*.integration.test.ts` suites that invoke the machine's authenticated
+CLIs and provider APIs. They skip unless `PUMPED_INTEGRATION=1` is set (pi additionally requires
+`ANTHROPIC_API_KEY`), so default `pnpm test` runs stay hermetic.
 
 ## Boundaries
 

--- a/pkg/sdk/claude/CHANGELOG.md
+++ b/pkg/sdk/claude/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pumped-fn/agent-sdk-claude
 
+## Unreleased
+
+### Major Changes
+
+- Replace the `claude(options)` factory and re-exported core harness constructors with `claude`, `claudeTurn`, `claudeRun`, and `claudeConfig` module-level exports.
+
 ## 2.0.0
 
 ### Major Changes

--- a/pkg/sdk/claude/README.md
+++ b/pkg/sdk/claude/README.md
@@ -2,21 +2,33 @@
 
 > **Status: experimental.** APIs change without notice; not recommended for production yet.
 
-Claude CLI model provider for `@pumped-fn/sdk`.
+Module-level Claude CLI model provider for `@pumped-fn/sdk`.
 
 ```ts
 import { createScope } from "@pumped-fn/lite"
 import { agent } from "@pumped-fn/sdk"
-import { claude } from "@pumped-fn/sdk-claude"
+import { claude, claudeConfig } from "@pumped-fn/sdk-claude"
 
 const triage = agent({ name: "triage" })
-const scope = createScope({ tags: [claude()] })
+const scope = createScope({
+  tags: [claude, claudeConfig({ auth: { kind: "global" } })],
+})
 const ctx = scope.createContext()
 
 await ctx.exec({ flow: triage.turn, input: { prompt: "Triage this ticket." } })
 ```
 
-`claude()` returns a lazy `model` tag. The Claude harness is created only when the model is first used, and the agent can be run with `codex()` or `model(fake)` instead without changing the graph.
+Global auth reuses the Claude CLI's writable `~/.claude` state. Token auth reads a long-lived token
+from the configured environment name and passes it to the subprocess as
+`CLAUDE_CODE_OAUTH_TOKEN`:
+
+```ts
+claudeConfig({ auth: { kind: "token", env: "MY_CLAUDE_TOKEN" } })
+```
+
+The stable handles are `claude`, `claudeTurn`, and `claudeRun`. Tests replace `claudeRun` with a
+scope preset. The removed `claude()`/`claudeHarness()`/`claudeCliWorker()` factories have no
+compatibility aliases.
 
 ---
 Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/sdk/claude/src/index.ts
+++ b/pkg/sdk/claude/src/index.ts
@@ -1,10 +1,79 @@
-import { claudeHarness, model, type CliHarnessOptions, type Model } from "@pumped-fn/sdk"
-import type { Lite } from "@pumped-fn/lite"
+import { atom, controller, flow, tag, tags, typed, type Lite } from "@pumped-fn/lite"
+import {
+  abortSignal,
+  formatModelPrompt,
+  model,
+  parseModelResponse,
+  runCli,
+  step,
+  type CliIsolateOptions,
+  type ModelRequest,
+  type PromptInput,
+} from "@pumped-fn/sdk"
 
-export type ClaudeOptions = CliHarnessOptions
+export type ClaudeAuth =
+  | { kind: "token"; env?: string }
+  | { kind: "global" }
 
-export function claude(options: ClaudeOptions = {}): Lite.Tagged<Model> {
-  return model(claudeHarness(options))
+export interface ClaudeConfig {
+  auth: ClaudeAuth
+  command?: string
+  extraArgs?: readonly string[]
+  isolate?: boolean | CliIsolateOptions
+  timeoutMs?: number
 }
 
-export { claudeCliWorker, claudeHarness, type ClaudeCliWorkerOptions, type CliHarnessOptions } from "@pumped-fn/sdk"
+export class ClaudeConfigError extends Error {
+  override readonly name = "ClaudeConfigError"
+}
+
+export const claudeConfig = tag<ClaudeConfig>({ label: "claude.config" })
+
+const environment = atom({
+  factory: () => process.env,
+})
+
+export const claudeRun = flow({
+  name: "claude.run",
+  parse: typed<PromptInput>(),
+  deps: {
+    config: tags.required(claudeConfig),
+    environment,
+    signal: tags.optional(abortSignal),
+  },
+  tags: [step({ workflow: true, kind: "llm" })],
+  factory: async (ctx, { config, environment, signal }) => {
+    if (config.extraArgs?.some((arg) => arg === "--")) throw new ClaudeConfigError("Claude extraArgs cannot include --")
+    if (config.extraArgs?.some((arg) => arg === "--bare" || arg.startsWith("--bare="))) {
+      throw new ClaudeConfigError("Claude provider must not use --bare")
+    }
+    const env = config.auth.kind === "token"
+      ? { CLAUDE_CODE_OAUTH_TOKEN: requiredEnvironment(environment, config.auth.env ?? "CLAUDE_CODE_OAUTH_TOKEN") }
+      : undefined
+    return (await runCli({
+      command: config.command ?? "claude",
+      args: ["-p", "--no-session-persistence", ...(config.extraArgs ?? []), "--", ctx.input.prompt],
+      env,
+      isolate: config.isolate,
+      timeoutMs: config.timeoutMs,
+      signal,
+    })).stdout.trim()
+  },
+})
+
+export const claudeTurn = flow({
+  name: "claude.complete",
+  parse: typed<ModelRequest>(),
+  deps: { run: controller(claudeRun) },
+  factory: async (ctx, { run }) => parseModelResponse(await run.exec({
+    input: { prompt: formatModelPrompt(ctx.input) },
+  })),
+})
+
+export const claude = model(claudeTurn)
+
+function requiredEnvironment(environment: NodeJS.ProcessEnv, name: string): string {
+  const value = environment[name]
+  if (!value) throw new ClaudeConfigError(`Claude token environment variable "${name}" is not set`)
+  return value
+}

--- a/pkg/sdk/claude/tests/claude.integration.test.ts
+++ b/pkg/sdk/claude/tests/claude.integration.test.ts
@@ -1,0 +1,27 @@
+import { createScope } from "@pumped-fn/lite"
+import { expect, it } from "vitest"
+import { claudeConfig, claudeTurn } from "../src/index"
+
+const integration = it.skipIf(process.env["PUMPED_INTEGRATION"] !== "1")
+
+integration("invokes the authenticated Claude CLI", async () => {
+  const scope = createScope({ tags: [claudeConfig({ auth: { kind: "global" }, isolate: false })] })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({
+    flow: claudeTurn,
+    input: {
+      agentName: "probe",
+      instructions: "Reply with the single word ready.",
+      messages: [{ role: "user", content: "ready?" }],
+      tools: [],
+      skills: [],
+      loadedSkills: [],
+      subagents: [],
+      round: 0,
+    },
+  })).resolves.toMatchObject({ content: expect.stringMatching(/ready/i) })
+
+  await ctx.close()
+  await scope.dispose()
+}, 120_000)

--- a/pkg/sdk/claude/tests/claude.test.ts
+++ b/pkg/sdk/claude/tests/claude.test.ts
@@ -1,66 +1,48 @@
-import { createScope, flow, typed } from "@pumped-fn/lite"
-import { agent, model, type Model, type ModelRequest } from "@pumped-fn/sdk"
-import { expect, it } from "vitest"
-import { claude } from "../src/index"
+import { createScope, flow, preset, typed } from "@pumped-fn/lite"
+import { agent, model, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
+import { expect, expectTypeOf, it } from "vitest"
+import { claude, claudeConfig, claudeRun, claudeTurn } from "../src/index"
 
-it("provides Claude through the agent model tag", async () => {
+const fake = flow({
+  name: "claude.fake",
+  parse: typed<PromptInput>(),
+  factory: (ctx) => JSON.stringify({ content: `provider=claude prompt=${ctx.input.prompt.includes("Agent: planner")}`, stop: true }),
+})
+
+it("provides Claude through stable module handles", async () => {
   const target = agent({ name: "planner" })
   const scope = createScope({
-    tags: [
-      claude({
-        command: "echo",
-        isolate: false,
-        prompt: (request) => `provider=claude agent=${request.agentName}`,
-      }),
-    ],
+    presets: [preset(claudeRun, fake)],
+    tags: [claude, claudeConfig({ auth: { kind: "global" } })],
   })
   const ctx = scope.createContext()
 
-  await expect(ctx.exec({
-    flow: target.turn,
-    input: { prompt: "plan" },
-  })).resolves.toMatchObject({
-    content: "-p --no-session-persistence -- provider=claude agent=planner",
+  await expect(ctx.exec({ flow: target.turn, input: { prompt: "plan" } })).resolves.toMatchObject({
+    content: "provider=claude prompt=true",
   })
+  expectTypeOf(claudeTurn).toMatchTypeOf<Model>()
 
   await ctx.close()
   await scope.dispose()
 })
 
-it("validates Claude harness configuration eagerly", () => {
-  expect(() => claude({ command: "echo", isolate: false, extraArgs: ["--bare"] })).toThrow(
-    "Claude harness must not use --bare"
-  )
-})
-
-it("can be replaced per execution context without rebuilding the agent", async () => {
+it("can replace the model tag per context", async () => {
   const target = agent({ name: "planner" })
   const replacement: Model = flow({
     parse: typed<ModelRequest>(),
     factory: () => ({ content: "provider=fake", stop: true }),
   })
   const scope = createScope({
-    tags: [
-      claude({
-        command: "echo",
-        isolate: false,
-        prompt: () => "provider=claude",
-      }),
-    ],
+    presets: [preset(claudeRun, fake)],
+    tags: [claude, claudeConfig({ auth: { kind: "global" } })],
   })
   const claudeCtx = scope.createContext()
   const fakeCtx = scope.createContext({ tags: [model(replacement)] })
 
-  await expect(claudeCtx.exec({
-    flow: target.turn,
-    input: { prompt: "plan" },
-  })).resolves.toMatchObject({
-    content: "-p --no-session-persistence -- provider=claude",
+  await expect(claudeCtx.exec({ flow: target.turn, input: { prompt: "plan" } })).resolves.toMatchObject({
+    content: "provider=claude prompt=true",
   })
-  await expect(fakeCtx.exec({
-    flow: target.turn,
-    input: { prompt: "plan" },
-  })).resolves.toMatchObject({
+  await expect(fakeCtx.exec({ flow: target.turn, input: { prompt: "plan" } })).resolves.toMatchObject({
     content: "provider=fake",
   })
 

--- a/pkg/sdk/codex/CHANGELOG.md
+++ b/pkg/sdk/codex/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pumped-fn/agent-sdk-codex
 
+## Unreleased
+
+### Major Changes
+
+- Replace the `codex(options)` factory and re-exported core harness constructors with stable CLI handles and config tags. Add the `codexAcp` model and its scope-owned ACP connection resource.
+
 ## 2.0.0
 
 ### Major Changes

--- a/pkg/sdk/codex/README.md
+++ b/pkg/sdk/codex/README.md
@@ -2,21 +2,40 @@
 
 > **Status: experimental.** APIs change without notice; not recommended for production yet.
 
-Codex CLI model provider for `@pumped-fn/sdk`.
+Module-level Codex CLI and ACP model providers for `@pumped-fn/sdk`.
 
 ```ts
 import { createScope } from "@pumped-fn/lite"
 import { agent } from "@pumped-fn/sdk"
-import { codex } from "@pumped-fn/sdk-codex"
+import { codex, codexConfig } from "@pumped-fn/sdk-codex"
 
 const triage = agent({ name: "triage" })
-const scope = createScope({ tags: [codex()] })
-const ctx = scope.createContext()
-
-await ctx.exec({ flow: triage.turn, input: { prompt: "Triage this ticket." } })
+const scope = createScope({
+  tags: [codex, codexConfig({ auth: { kind: "global" } })],
+})
 ```
 
-`codex()` returns a lazy `model` tag. The Codex harness is created only when the model is first used, and the agent can be run with `claude()` or `model(fake)` instead without changing the graph.
+Global auth reuses writable `CODEX_HOME` state. API-key auth reads the configured environment name
+and passes it to `codex exec` as `CODEX_API_KEY`:
+
+```ts
+codexConfig({ auth: { kind: "api-key", env: "MY_CODEX_KEY" } })
+```
+
+ACP uses `@agentclientprotocol/codex-acp` over stdio through the official TypeScript client. Permissions
+default to deny and every decision is recorded in the SDK event buffer.
+
+```ts
+import { codexAcp, codexAcpConfig } from "@pumped-fn/sdk-codex"
+
+const acpScope = createScope({
+  tags: [codexAcp, codexAcpConfig({ permission: "deny" })],
+})
+```
+
+The stable CLI handles are `codex`, `codexTurn`, and `codexRun`; ACP exports `codexAcp`,
+`codexAcpTurn`, and `acp`. The removed `codex()`/`codexHarness()`/`codexCliWorker()` factories have
+no compatibility aliases.
 
 ---
 Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/sdk/codex/src/adapters/process.ts
+++ b/pkg/sdk/codex/src/adapters/process.ts
@@ -1,0 +1,9 @@
+import { spawn } from "node:child_process"
+import { Readable, Writable } from "node:stream"
+import { atom } from "@pumped-fn/lite"
+
+export const spawnProcess = atom({ factory: () => spawn })
+
+export const webStreams = atom({
+  factory: () => ({ readable: Readable.toWeb, writable: Writable.toWeb }),
+})

--- a/pkg/sdk/codex/src/index.ts
+++ b/pkg/sdk/codex/src/index.ts
@@ -1,10 +1,212 @@
-import { codexHarness, model, type CodexHarnessOptions, type Model } from "@pumped-fn/sdk"
-import type { Lite } from "@pumped-fn/lite"
+import {
+  ClientSideConnection,
+  PROTOCOL_VERSION,
+  ndJsonStream,
+  type Client,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type SessionNotification,
+} from "@agentclientprotocol/sdk"
+import { atom, controller, flow, resource, tag, tags, typed } from "@pumped-fn/lite"
+import {
+  abortSignal,
+  events,
+  formatModelPrompt,
+  model,
+  parseModelResponse,
+  runCli,
+  step,
+  type CliIsolateOptions,
+  type ModelRequest,
+  type PromptInput,
+} from "@pumped-fn/sdk"
+import { spawnProcess, webStreams } from "./adapters/process"
 
-export type CodexOptions = CodexHarnessOptions
+export type CodexAuth =
+  | { kind: "api-key"; env?: string }
+  | { kind: "global" }
 
-export function codex(options: CodexOptions = {}): Lite.Tagged<Model> {
-  return model(codexHarness(options))
+export interface CodexConfig {
+  auth: CodexAuth
+  command?: string
+  sandbox?: "read-only" | "workspace-write" | "danger-full-access"
+  extraArgs?: readonly string[]
+  isolate?: boolean | CliIsolateOptions
+  timeoutMs?: number
 }
 
-export { codexCliWorker, codexHarness, type CodexCliWorkerOptions, type CodexHarnessOptions } from "@pumped-fn/sdk"
+export class CodexConfigError extends Error {
+  override readonly name = "CodexConfigError"
+}
+
+export const codexConfig = tag<CodexConfig>({ label: "codex.config" })
+
+const environment = atom({
+  factory: () => process.env,
+})
+
+const workingDirectory = atom({
+  factory: () => process.cwd(),
+})
+
+export const codexRun = flow({
+  name: "codex.run",
+  parse: typed<PromptInput>(),
+  deps: {
+    config: tags.required(codexConfig),
+    environment,
+    signal: tags.optional(abortSignal),
+  },
+  tags: [step({ workflow: true, kind: "llm" })],
+  factory: async (ctx, { config, environment, signal }) => {
+    if (config.extraArgs?.some((arg) => arg === "--")) throw new CodexConfigError("Codex extraArgs cannot include --")
+    const env = config.auth.kind === "api-key"
+      ? { CODEX_API_KEY: requiredEnvironment(environment, config.auth.env ?? "CODEX_API_KEY") }
+      : undefined
+    return (await runCli({
+      command: config.command ?? "codex",
+      args: [
+        "exec",
+        "-s",
+        config.sandbox ?? "read-only",
+        "--ephemeral",
+        "--ignore-user-config",
+        ...(config.extraArgs ?? []),
+        "--",
+        ctx.input.prompt,
+      ],
+      env,
+      isolate: config.isolate,
+      timeoutMs: config.timeoutMs,
+      signal,
+    })).stdout.trim()
+  },
+})
+
+export const codexTurn = flow({
+  name: "codex.complete",
+  parse: typed<ModelRequest>(),
+  deps: { run: controller(codexRun) },
+  factory: async (ctx, { run }) => parseModelResponse(await run.exec({
+    input: { prompt: formatModelPrompt(ctx.input) },
+  })),
+})
+
+export const codex = model(codexTurn)
+
+export interface CodexAcpConfig {
+  command?: string
+  args?: readonly string[]
+  cwd?: string
+  permission?: "grant" | "deny"
+}
+
+export const codexAcpConfig = tag<CodexAcpConfig>({ label: "codex.acp.config" })
+
+export const acp = resource({
+  name: "codex.acp",
+  ownership: "boundary",
+  deps: {
+    buffer: events,
+    config: tags.required(codexAcpConfig),
+    spawn: spawnProcess,
+    streams: webStreams,
+    workingDirectory,
+  },
+  tags: [step({ workflow: true, kind: "llm" })],
+  factory: async (ctx, { buffer, config, spawn, streams, workingDirectory }) => {
+    const sessions = new Map<string, string[]>()
+    const metadata = new Map<string, { agentName: string; round: number }>()
+    const child = spawn(config.command ?? "codex-acp", [...(config.args ?? [])], {
+      cwd: config.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    })
+    if (!child.stdin || !child.stdout) throw new CodexConfigError("ACP adapter requires piped stdio")
+    const client: Client = {
+      sessionUpdate: async (notification: SessionNotification) => {
+        const session = sessions.get(notification.sessionId)
+        if (
+          session
+          && notification.update.sessionUpdate === "agent_message_chunk"
+          && notification.update.content.type === "text"
+        ) {
+          session.push(notification.update.content.text)
+        }
+      },
+      requestPermission: async (request: RequestPermissionRequest): Promise<RequestPermissionResponse> => {
+        const meta = metadata.get(request.sessionId)
+        buffer.record({
+          type: "agent_tool_end",
+          agentName: meta?.agentName ?? "acp",
+          round: meta?.round,
+          targetName: "acp.permission",
+          input: request.options,
+          output: config.permission ?? "deny",
+        })
+        const granted = request.options.find((option) => option.kind === "allow_once" || option.kind === "allow_always")
+        if (config.permission === "grant" && granted) {
+          return { outcome: { outcome: "selected", optionId: granted.optionId } }
+        }
+        return { outcome: { outcome: "cancelled" } }
+      },
+    }
+    const connection = new ClientSideConnection(
+      () => client,
+      ndJsonStream(
+        streams.writable(child.stdin) as WritableStream<Uint8Array>,
+        streams.readable(child.stdout) as ReadableStream<Uint8Array>,
+      ),
+    )
+    await connection.initialize({
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {},
+    })
+    ctx.cleanup(() => {
+      child.kill()
+    })
+    return { connection, cwd: config.cwd ?? workingDirectory, sessions, metadata }
+  },
+})
+
+export const codexAcpPrompt = flow({
+  name: "codex.acp.prompt",
+  parse: typed<ModelRequest>(),
+  deps: {
+    acp,
+    config: tags.required(codexAcpConfig),
+    signal: tags.optional(abortSignal),
+  },
+  tags: [step({ workflow: true, kind: "llm" })],
+  factory: async (ctx, { acp, config, signal }) => {
+    const session = await acp.connection.newSession({ cwd: acp.cwd, mcpServers: [] })
+    const chunks: string[] = []
+    acp.sessions.set(session.sessionId, chunks)
+    acp.metadata.set(session.sessionId, { agentName: ctx.input.agentName, round: ctx.input.round })
+    const cancel = () => void acp.connection.cancel({ sessionId: session.sessionId })
+    signal?.addEventListener("abort", cancel, { once: true })
+    await acp.connection.prompt({
+      sessionId: session.sessionId,
+      prompt: [{ type: "text", text: formatModelPrompt(ctx.input) }],
+    }).finally(() => {
+      signal?.removeEventListener("abort", cancel)
+      acp.sessions.delete(session.sessionId)
+      acp.metadata.delete(session.sessionId)
+    })
+    return chunks.join("")
+  },
+})
+
+export const codexAcpTurn = flow({
+  name: "codex.acp.complete",
+  parse: typed<ModelRequest>(),
+  deps: { prompt: controller(codexAcpPrompt) },
+  factory: async (ctx, { prompt }) => parseModelResponse(await prompt.exec({ input: ctx.input })),
+})
+
+export const codexAcp = model(codexAcpTurn)
+
+function requiredEnvironment(environment: NodeJS.ProcessEnv, name: string): string {
+  const value = environment[name]
+  if (!value) throw new CodexConfigError(`Codex API key environment variable "${name}" is not set`)
+  return value
+}

--- a/pkg/sdk/codex/tests/codex.integration.test.ts
+++ b/pkg/sdk/codex/tests/codex.integration.test.ts
@@ -1,0 +1,49 @@
+import { createScope } from "@pumped-fn/lite"
+import { expect, it } from "vitest"
+import { codexAcpConfig, codexAcpTurn, codexConfig, codexTurn } from "../src/index"
+
+const integration = it.skipIf(process.env["PUMPED_INTEGRATION"] !== "1")
+
+integration("invokes the authenticated Codex CLI", async () => {
+  const scope = createScope({ tags: [codexConfig({ auth: { kind: "global" }, isolate: false })] })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({
+    flow: codexTurn,
+    input: {
+      agentName: "probe",
+      instructions: "Reply with the single word ready.",
+      messages: [{ role: "user", content: "ready?" }],
+      tools: [],
+      skills: [],
+      loadedSkills: [],
+      subagents: [],
+      round: 0,
+    },
+  })).resolves.toMatchObject({ content: expect.stringMatching(/ready/i) })
+
+  await ctx.close()
+  await scope.dispose()
+}, 120_000)
+
+integration("invokes Codex through ACP", async () => {
+  const scope = createScope({ tags: [codexAcpConfig({ permission: "deny" })] })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({
+    flow: codexAcpTurn,
+    input: {
+      agentName: "probe",
+      instructions: "Reply with JSON content containing the word ready.",
+      messages: [{ role: "user", content: "ready?" }],
+      tools: [],
+      skills: [],
+      loadedSkills: [],
+      subagents: [],
+      round: 0,
+    },
+  })).resolves.toMatchObject({ content: expect.stringMatching(/ready/i) })
+
+  await ctx.close()
+  await scope.dispose()
+}, 120_000)

--- a/pkg/sdk/codex/tests/codex.test.ts
+++ b/pkg/sdk/codex/tests/codex.test.ts
@@ -1,60 +1,78 @@
-import { createScope, flow, typed } from "@pumped-fn/lite"
-import { agent, model, type Model, type ModelRequest } from "@pumped-fn/sdk"
-import { expect, it } from "vitest"
-import { codex } from "../src/index"
+import { createScope, flow, preset, typed } from "@pumped-fn/lite"
+import { agent, model, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
+import { expect, expectTypeOf, it } from "vitest"
+import {
+  codex,
+  codexAcp,
+  codexAcpConfig,
+  codexAcpPrompt,
+  codexConfig,
+  codexRun,
+  codexTurn,
+} from "../src/index"
 
-it("provides Codex through the agent model tag", async () => {
+const fake = flow({
+  name: "codex.fake",
+  parse: typed<PromptInput>(),
+  factory: (ctx) => JSON.stringify({ content: `provider=codex prompt=${ctx.input.prompt.includes("Agent: review")}`, stop: true }),
+})
+
+const fakeAcp = flow({
+  name: "codex.acp.fake",
+  parse: typed<ModelRequest>(),
+  factory: () => JSON.stringify({ content: "provider=codex-acp", stop: true }),
+})
+
+it("provides Codex through stable module handles", async () => {
   const target = agent({ name: "review" })
   const scope = createScope({
-    tags: [
-      codex({
-        command: "echo",
-        isolate: false,
-        prompt: (request) => `provider=codex agent=${request.agentName}`,
-      }),
-    ],
+    presets: [preset(codexRun, fake)],
+    tags: [codex, codexConfig({ auth: { kind: "global" } })],
   })
   const ctx = scope.createContext()
 
-  await expect(ctx.exec({
-    flow: target.turn,
-    input: { prompt: "check" },
-  })).resolves.toMatchObject({
-    content: "exec -s read-only --ephemeral --ignore-user-config -- provider=codex agent=review",
+  await expect(ctx.exec({ flow: target.turn, input: { prompt: "check" } })).resolves.toMatchObject({
+    content: "provider=codex prompt=true",
+  })
+  expectTypeOf(codexTurn).toMatchTypeOf<Model>()
+
+  await ctx.close()
+  await scope.dispose()
+})
+
+it("provides ACP through a preset prompt edge", async () => {
+  const target = agent({ name: "review" })
+  const scope = createScope({
+    presets: [preset(codexAcpPrompt, fakeAcp)],
+    tags: [codexAcp, codexAcpConfig({ permission: "deny" })],
+  })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({ flow: target.turn, input: { prompt: "check" } })).resolves.toMatchObject({
+    content: "provider=codex-acp",
   })
 
   await ctx.close()
   await scope.dispose()
 })
 
-it("can be replaced per execution context without rebuilding the agent", async () => {
+it("can replace the model tag per context", async () => {
   const target = agent({ name: "review" })
   const replacement: Model = flow({
     parse: typed<ModelRequest>(),
     factory: () => ({ content: "provider=fake", stop: true }),
   })
   const scope = createScope({
-    tags: [
-      codex({
-        command: "echo",
-        isolate: false,
-        prompt: () => "provider=codex",
-      }),
-    ],
+    presets: [preset(codexRun, fake)],
+    tags: [codex, codexConfig({ auth: { kind: "global" } })],
   })
   const codexCtx = scope.createContext()
   const fakeCtx = scope.createContext({ tags: [model(replacement)] })
 
-  await expect(codexCtx.exec({
-    flow: target.turn,
-    input: { prompt: "check" },
-  })).resolves.toMatchObject({
-    content: "exec -s read-only --ephemeral --ignore-user-config -- provider=codex",
+  await expect(codexCtx.exec({ flow: target.turn, input: { prompt: "check" } })).resolves.toMatchObject({
+    content: "provider=codex prompt=true",
   })
-  await expect(fakeCtx.exec({
-    flow: target.turn,
-    input: { prompt: "check" },
-  })).resolves.toMatchObject({
+  await expect(fakeCtx.exec({ flow: target.turn, input: { prompt: "check" } })).resolves.toMatchObject({
     content: "provider=fake",
   })
 

--- a/pkg/sdk/core/CHANGELOG.md
+++ b/pkg/sdk/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @pumped-fn/agent-sdk
 
+## Unreleased
+
+### Major Changes
+
+- Remove `claudeCliWorker`, `codexCliWorker`, `claudeHarness`, `codexHarness`, and their provider-specific option types. Provider packages now own stable module-level handles and config tags. Add `formatModelPrompt` and `parseModelResponse` as reference-level building blocks.
+
 ## 2.0.0
 
 ### Major Changes

--- a/pkg/sdk/core/PATTERNS.md
+++ b/pkg/sdk/core/PATTERNS.md
@@ -332,25 +332,25 @@ Use provider packages when the runtime must call real local tools like Claude or
 
 ```ts
 import { createScope } from "@pumped-fn/lite"
-import { agent, guard, model } from "@pumped-fn/sdk"
-import { claude } from "@pumped-fn/sdk-claude"
-import { codex } from "@pumped-fn/sdk-codex"
-
-const shared = guard("review-guard")
+import { agent, model } from "@pumped-fn/sdk"
+import { claude, claudeConfig } from "@pumped-fn/sdk-claude"
+import { codex, codexConfig } from "@pumped-fn/sdk-codex"
 
 const reviewer = agent({
   name: "reviewer",
 })
 
-const codexScope = createScope({ tags: [codex({ sandbox: "read-only", guard: shared })] })
-const claudeScope = createScope({ tags: [claude({ guard: shared })] })
+const codexScope = createScope({
+  tags: [codex, codexConfig({ auth: { kind: "global" }, sandbox: "read-only" })],
+})
+const claudeScope = createScope({
+  tags: [claude, claudeConfig({ auth: { kind: "global" } })],
+})
 ```
 
-`codex()` and `claude()` are lazy `model` tags. Tagging a scope is configuration only; the CLI harness is built on first model use. Replace either provider with `model(fake)` at the same seam for tests.
+`codex` and `claude` are stable module-level `model` tags. Their config is explicit through `codexConfig` and `claudeConfig`. Replace either provider with `model(fake)` at the same seam for tests, or preset the provider's effect flow for a narrower unit test.
 
-`codexHarness()` runs `codex exec --ephemeral --ignore-user-config`. `claudeHarness()` runs `claude -p --no-session-persistence` and rejects `--bare`. Harness prompts request JSON with `content`, optional `guard`, and optional skill/tool/subagent calls. `guard` is the anti-goal; the first value collected from a run is kept in material state and injected into later prompts.
-
-Harnesses default to bwrap isolation with network enabled. The default sandbox mounts only the workspace, temporary home, minimal runtime/cert/DNS paths, and explicit credential directories such as `codexHome`. Keep CLI workers at the edge. Stable domain tests should use provider state and presets.
+The providers run `codex exec --ephemeral --ignore-user-config` and `claude -p --no-session-persistence`; Claude rejects `--bare`. Keep CLI workers at the edge and bind writable auth state when isolation is enabled.
 
 ## 11. Durable Step
 

--- a/pkg/sdk/core/README.md
+++ b/pkg/sdk/core/README.md
@@ -16,7 +16,7 @@ Primitive families in this package:
 - **Event buffers** — `events`, `inspect()`, `RunLog` for per-run and per-boundary inspection.
 - **Guards** — `guard()` for anti-goal state shared across runs.
 - **Sandboxes** — `sandbox` tag and CLI harness bwrap isolation.
-- **CLI workers** — `cliWorker()`, `claudeCliWorker()`, `codexCliWorker()`, `WorkerRegistry`.
+- **CLI workers** — `cliWorker()` and `WorkerRegistry`; provider-specific workers live in provider packages.
 - **Eval harness** — `suite()`, `runEval()`, deterministic checks, judge quorum, `summary()`.
 - **Agents and models** — `agent()`, `tool()`, `skill()`, `sub()`, `model` tag: one family of primitives, built on the same `ctx.exec()` seam as everything else.
 
@@ -45,10 +45,10 @@ flowchart TD
   Config --> Local["otherwise run next()"]
   Local --> Tool["tool or subagent flow"]
   Local --> Model["model tag provider"]
-  Model --> CLI["optional Codex/Claude CLI worker"]
+  Model --> Provider["Claude CLI, Codex CLI/ACP, or pi-ai"]
   Tool --> Events["events resource"]
   Model --> Events
-  CLI --> Events
+  Provider --> Events
   Events --> Log["write completed"]
   Remote --> Log
 ```
@@ -76,8 +76,8 @@ flowchart TD
 - `summary()` for JSON-safe eval reports.
 - `http()` for Fetch request adapters.
 - `material()`, `patchMaterial()`, and `derivedMaterial()` for small task-scoped JSON materials.
-- `cliWorker()`, `claudeCliWorker()`, and `codexCliWorker()` for real CLI-backed work.
-- `claudeHarness()` and `codexHarness()` for non-interactive CLI model adapters with optional bwrap isolation.
+- `cliWorker()` for generic real CLI-backed work.
+- `formatModelPrompt()` and `parseModelResponse()` as reference-level provider building blocks.
 
 `step()` is one defaulted config tag. Flow tags set defaults. Exec tags override per call.
 
@@ -465,11 +465,9 @@ The CLI helpers are convenience adapters. Harnesses turn popular local CLIs into
 
 ```ts
 import { createScope } from "@pumped-fn/lite"
-import { agent, guard } from "@pumped-fn/sdk"
-import { claude } from "@pumped-fn/sdk-claude"
-import { codex } from "@pumped-fn/sdk-codex"
-
-const shared = guard("review-guard")
+import { agent } from "@pumped-fn/sdk"
+import { claude, claudeConfig } from "@pumped-fn/sdk-claude"
+import { codex, codexConfig } from "@pumped-fn/sdk-codex"
 
 const reviewer = agent({
   name: "reviewer",
@@ -477,22 +475,21 @@ const reviewer = agent({
 
 const scope = createScope({
   tags: [
-    codex({
+    codex,
+    codexConfig({
+      auth: { kind: "global" },
       sandbox: "read-only",
-      guard: shared,
       timeoutMs: 120_000,
     }),
   ],
 })
 
-const otherScope = createScope({ tags: [claude({ guard: shared })] })
+const otherScope = createScope({ tags: [claude, claudeConfig({ auth: { kind: "global" } })] })
 ```
 
-`@pumped-fn/sdk-codex` and `@pumped-fn/sdk-claude` return lazy `model` tags. Tagging a scope does not create the CLI harness; first model use does. Replace them with each other or `model(fake)` at `createScope` or `createContext` without changing the agent graph.
+`@pumped-fn/sdk-codex`, `@pumped-fn/sdk-claude`, and `@pumped-fn/sdk-pi` export stable module-level `model` tags. Their sibling config tags carry auth and provider settings. Replace a provider with another provider tag or `model(fake)` at `createScope` or `createContext` without changing the agent graph.
 
-`codexHarness()` uses `codex exec --ephemeral --ignore-user-config`. `claudeHarness()` uses `claude -p --no-session-persistence` and rejects `--bare`; pass explicit `extraArgs` for other CLI flags. The default prompt asks for JSON with `content`, optional `guard`, and optional skill/tool/subagent calls. `guard` is the anti-goal; the first non-empty value is stored in material state and injected into later prompts. Pass a shared `guard("name")` atom when multiple harnesses should see the same anti-goal.
-
-Harnesses default to bwrap isolation with network enabled because the CLIs need provider access. The sandbox mounts the workspace read-only by default, a temporary home, minimal runtime/cert/DNS paths, and only explicit credential directories such as `isolate: { network: true, codexHome: process.env.CODEX_HOME }`. Use `isolate: false` only when another trusted boundary already isolates the process.
+The CLI providers run `codex exec --ephemeral --ignore-user-config` and `claude -p --no-session-persistence`. Claude rejects `--bare`. Explicit isolation remains available through config; global auth directories must be writable when isolated.
 
 For stable tests, prefer provider state plus presets.
 

--- a/pkg/sdk/core/src/index.ts
+++ b/pkg/sdk/core/src/index.ts
@@ -812,151 +812,10 @@ export function guard(name: string, text = ""): Lite.Atom<MaterialState<GuardSta
   })
 }
 
-export interface ClaudeCliWorkerOptions {
-  name?: string
-  command?: string
-  extraArgs?: readonly string[]
-  isolate?: boolean | CliIsolateOptions
-  timeoutMs?: number
-  tags?: Lite.Tagged<any>[]
-}
-
-export function claudeCliWorker(options: ClaudeCliWorkerOptions = {}): Lite.Flow<string, PromptInput> {
-  assertNoClaudeBare(options.extraArgs ?? [])
-  return cliWorker({
-    name: options.name ?? "claude",
-    command: options.command ?? "claude",
-    args: (input) => cliPromptArgs(["-p", ...(options.extraArgs ?? [])], input.prompt),
-    isolate: options.isolate,
-    timeoutMs: options.timeoutMs,
-    kind: "llm",
-    tags: options.tags,
-  })
-}
-
-export interface CodexCliWorkerOptions {
-  name?: string
-  command?: string
-  sandbox?: "read-only" | "workspace-write" | "danger-full-access"
-  extraArgs?: readonly string[]
-  isolate?: boolean | CliIsolateOptions
-  timeoutMs?: number
-  tags?: Lite.Tagged<any>[]
-}
-
-export function codexCliWorker(options: CodexCliWorkerOptions = {}): Lite.Flow<string, PromptInput> {
-  return cliWorker({
-    name: options.name ?? "codex",
-    command: options.command ?? "codex",
-    args: (input) => cliPromptArgs([
-      "exec",
-      "-s",
-      options.sandbox ?? "read-only",
-      ...(options.extraArgs ?? []),
-    ], input.prompt),
-    isolate: options.isolate,
-    timeoutMs: options.timeoutMs,
-    kind: "llm",
-    tags: options.tags,
-  })
-}
-
-export interface CliHarnessOptions {
-  name?: string
-  command?: string
-  extraArgs?: readonly string[]
-  isolate?: boolean | CliIsolateOptions
-  timeoutMs?: number
-  guard?: Lite.Atom<MaterialState<GuardState>> | false
-  prompt?: (request: ModelRequest, guard: GuardState) => string
-  parse?: (output: string) => ModelResponse
-  tags?: Lite.Tagged<any>[]
-}
-
-export interface CodexHarnessOptions extends CliHarnessOptions {
-  sandbox?: "read-only" | "workspace-write" | "danger-full-access"
-}
-
-export function claudeHarness(options: CliHarnessOptions = {}): Model {
-  const worker = claudeCliWorker({
-    name: options.name ?? "claude-harness",
-    command: options.command,
-    extraArgs: ["--no-session-persistence", ...(options.extraArgs ?? [])],
-    isolate: options.isolate ?? { network: true },
-    timeoutMs: options.timeoutMs,
-    tags: options.tags,
-  })
-  return cliHarnessModel(worker, {
-    guard: options.guard === undefined ? guard(`${options.name ?? "claude-harness"}-guard`) : options.guard,
-    prompt: options.prompt,
-    parse: options.parse,
-  })
-}
-
-export function codexHarness(options: CodexHarnessOptions = {}): Model {
-  const worker = codexCliWorker({
-    name: options.name ?? "codex-harness",
-    command: options.command,
-    sandbox: options.sandbox,
-    extraArgs: ["--ephemeral", "--ignore-user-config", ...(options.extraArgs ?? [])],
-    isolate: options.isolate ?? { network: true },
-    timeoutMs: options.timeoutMs,
-    tags: options.tags,
-  })
-  return cliHarnessModel(worker, {
-    guard: options.guard === undefined ? guard(`${options.name ?? "codex-harness"}-guard`) : options.guard,
-    prompt: options.prompt,
-    parse: options.parse,
-  })
-}
-
-interface CliHarnessConfig {
-  guard: Lite.Atom<MaterialState<GuardState>> | false
-  prompt?: (request: ModelRequest, guard: GuardState) => string
-  parse?: (output: string) => ModelResponse
-}
-
-function cliHarnessModel(
-  worker: Lite.Flow<string, PromptInput>,
-  config: CliHarnessConfig
-): Model {
-  return flow({
-    name: worker.name,
-    parse: typed<ModelRequest>(),
-    deps: { worker },
-    factory: async (ctx, { worker }) => {
-      const current = config.guard ? await ctx.resolve(config.guard) : undefined
-      const state = current?.state ?? { text: "" }
-      const output = await worker.exec({
-        input: { prompt: config.prompt ? config.prompt(ctx.input, state) : modelPrompt(ctx.input, state) },
-      })
-      const response = config.parse ? config.parse(output) : parseModelOutput(output)
-      if (config.guard && current) await collectGuard(ctx, config.guard, current, response)
-      return response
-    },
-  })
-}
-
-async function collectGuard(
-  ctx: Lite.ExecutionContext,
-  store: Lite.Atom<MaterialState<GuardState>>,
-  current: MaterialState<GuardState>,
-  response: ModelResponse
-): Promise<void> {
-  const text = guardTextOf(response.guard)
-  if (!text || current.state.text) return
-  await patchMaterial(ctx, store, [
-    { op: "replace", path: "/text", value: text },
-  ], { expectedRevision: current.revision })
-}
-
-function modelPrompt(request: ModelRequest, guard: GuardState): string {
+export function formatModelPrompt(request: ModelRequest): string {
   return [
     "Return JSON only.",
-    "Schema: {\"content\":string,\"stop\"?:boolean,\"guard\"?:string,\"skillCalls\"?:array,\"toolCalls\"?:array,\"subagentCalls\"?:array}.",
-    guard.text
-      ? `Guard:\n${guard.text}`
-      : "First run only: set guard to the anti-goal that should prevent this agent from drifting.",
+    "Schema: {\"content\":string,\"stop\"?:boolean,\"skillCalls\"?:array,\"toolCalls\"?:array,\"subagentCalls\"?:array}.",
     `Agent: ${request.agentName}`,
     request.instructions ? `Instructions:\n${request.instructions}` : undefined,
     request.skills.length ? `Available skills:\n${request.skills.map(formatCapability).join("\n")}` : undefined,
@@ -968,7 +827,7 @@ function modelPrompt(request: ModelRequest, guard: GuardState): string {
   ].filter((item) => item !== undefined).join("\n\n")
 }
 
-function parseModelOutput(output: string): ModelResponse {
+export function parseModelResponse(output: string): ModelResponse {
   const value = readJson(output)
   if (!isRecord(value)) return { content: output, stop: true }
   const response: ModelResponse = {
@@ -1062,15 +921,6 @@ function formatMessage(message: Message): string {
   return message.name ? `${message.role}(${message.name}): ${message.content}` : `${message.role}: ${message.content}`
 }
 
-function assertNoClaudeBare(args: readonly string[]): void {
-  if (args.some((arg) => arg === "--bare" || arg.startsWith("--bare="))) throw new Error("Claude harness must not use --bare")
-}
-
-function cliPromptArgs(args: readonly string[], prompt: string): string[] {
-  if (args.includes("--")) throw new Error("CLI helper extraArgs cannot include --")
-  return [...args, "--", prompt]
-}
-
 type MaybePromise<T> = T | Promise<T>
 
 export type Role = "system" | "user" | "assistant" | "tool" | "subagent" | "skill"
@@ -1079,6 +929,8 @@ export interface Message {
   role: Role
   content: string
   name?: string
+  id?: string
+  input?: unknown
 }
 
 export interface ToolCall {
@@ -1712,6 +1564,7 @@ async function executeAgentTurn(
         role: "skill",
         name: result.name,
         content: result.content,
+        ...(result.id ? { id: result.id, input: { name: result.name } } : {}),
       })
     }
 
@@ -1722,6 +1575,7 @@ async function executeAgentTurn(
         role: "tool",
         name: result.name,
         content: stringifyAgentValue(result.output),
+        ...(result.id ? { id: result.id, input: result.input } : {}),
       })
     }
 
@@ -1732,6 +1586,7 @@ async function executeAgentTurn(
         role: "subagent",
         name: result.name,
         content: result.output.content,
+        ...(result.id ? { id: result.id, input: result.input } : {}),
       })
     }
   }

--- a/pkg/sdk/pi/CHANGELOG.md
+++ b/pkg/sdk/pi/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @pumped-fn/sdk-pi
+
+## Unreleased
+
+### Minor Changes
+
+- Add an in-process pi-ai model provider with catalog validation, native tool mapping, usage events, and supported-model discovery.

--- a/pkg/sdk/pi/LICENSE
+++ b/pkg/sdk/pi/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) pumped-fn contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/sdk/pi/README.md
+++ b/pkg/sdk/pi/README.md
@@ -1,0 +1,24 @@
+# @pumped-fn/sdk-pi
+
+> **Status: experimental.** APIs change without notice; not recommended for production yet.
+
+In-process `@earendil-works/pi-ai` provider for `@pumped-fn/sdk`.
+
+```ts
+import { createScope } from "@pumped-fn/lite"
+import { agent } from "@pumped-fn/sdk"
+import { pi, piConfig } from "@pumped-fn/sdk-pi"
+
+const triage = agent({ name: "triage" })
+const scope = createScope({
+  tags: [pi, piConfig({ provider: "anthropic", modelId: "claude-sonnet-4-5" })],
+})
+```
+
+Set `apiKeyEnv` to resolve an explicit provider key through the environment adapter. Without it,
+pi-ai uses its provider auth chain. `supportedModels` lists the catalog, while `models` is the
+scope-owned collection edge. Native model tool calls become SDK tool, skill, and subagent calls;
+usage and cost are copied to the SDK event buffer.
+
+---
+Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/sdk/pi/package.json
+++ b/pkg/sdk/pi/package.json
@@ -1,22 +1,16 @@
 {
-  "name": "@pumped-fn/sdk-codex",
+  "name": "@pumped-fn/sdk-pi",
   "version": "2.0.0",
   "private": false,
-  "description": "Codex CLI model provider for @pumped-fn/sdk",
+  "description": "In-process pi-ai model provider for @pumped-fn/sdk",
   "type": "module",
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
-  "types": "./dist/index.d.cts",
+  "types": "./dist/index.d.mts",
   "exports": {
     ".": {
-      "import": {
-        "types": "./dist/index.d.mts",
-        "default": "./dist/index.mjs"
-      },
-      "require": {
-        "types": "./dist/index.d.cts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.d.mts",
+      "default": "./dist/index.mjs"
     }
   },
   "files": [
@@ -38,8 +32,7 @@
     "@pumped-fn/lite": "^3.1.0"
   },
   "dependencies": {
-    "@agentclientprotocol/sdk": "catalog:",
-    "@agentclientprotocol/codex-acp": "catalog:"
+    "@earendil-works/pi-ai": "catalog:"
   },
   "devDependencies": {
     "@pumped-fn/sdk": "workspace:*",
@@ -51,10 +44,13 @@
     "vite": "catalog:",
     "vitest": "catalog:"
   },
+  "engines": {
+    "node": ">=22.19.0"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "directory": "pkg/sdk/codex",
+    "directory": "pkg/sdk/pi",
     "url": "git+https://github.com/pumped-fn/pumped-fn.git"
   }
 }

--- a/pkg/sdk/pi/src/index.ts
+++ b/pkg/sdk/pi/src/index.ts
@@ -1,0 +1,275 @@
+import {
+  StringEnum,
+  Type,
+  getSupportedThinkingLevels,
+  validateToolCall,
+  type AssistantMessage,
+  type Api,
+  type Context,
+  type Message as PiMessage,
+  type Model as PiModel,
+  type Models,
+  type Tool,
+  type ToolCall as PiToolCall,
+} from "@earendil-works/pi-ai"
+import { builtinModels } from "@earendil-works/pi-ai/providers/all"
+import { atom, flow, resource, tag, tags, typed } from "@pumped-fn/lite"
+import {
+  abortSignal,
+  events,
+  model,
+  step,
+  type Capability,
+  type Message,
+  type ModelRequest,
+  type ModelResponse,
+} from "@pumped-fn/sdk"
+
+export interface PiConfig {
+  provider: string
+  modelId: string
+  thinking?: "minimal" | "low" | "medium" | "high" | "xhigh"
+  apiKeyEnv?: string
+}
+
+export class PiProviderError extends Error {
+  override readonly name = "PiProviderError"
+
+  constructor(
+    message: string,
+    readonly provider: string,
+    readonly modelId: string,
+  ) {
+    super(message)
+  }
+}
+
+export const piConfig = tag<PiConfig>({ label: "pi.config" })
+
+const environment = atom({
+  factory: () => process.env,
+})
+
+const clock = atom({
+  factory: () => Date.now,
+})
+
+export const models = resource({
+  name: "pi.models",
+  ownership: "boundary",
+  factory: (ctx) => {
+    const collection = builtinModels()
+    ctx.cleanup(() => collection.clearProviders())
+    return collection
+  },
+})
+
+export const supportedModels = flow({
+  name: "pi.supported-models",
+  parse: typed<{ provider?: string }>(),
+  deps: { models },
+  factory: (ctx, { models }) => models.getModels(ctx.input.provider),
+})
+
+export const piTurn = flow({
+  name: "pi.complete",
+  parse: typed<ModelRequest>(),
+  deps: {
+    buffer: events,
+    clock,
+    config: tags.required(piConfig),
+    environment,
+    models,
+    signal: tags.optional(abortSignal),
+  },
+  tags: [step({ workflow: true, kind: "llm" })],
+  factory: async (ctx, { buffer, clock, config, environment, models, signal }) => {
+    const selected = requireModel(models, config)
+    if (config.thinking && !getSupportedThinkingLevels(selected).includes(config.thinking)) {
+      throw new PiProviderError(
+        `Unsupported thinking level "${config.thinking}" for "${config.provider}/${config.modelId}". Supported: ${getSupportedThinkingLevels(selected).join(", ")}`,
+        config.provider,
+        config.modelId,
+      )
+    }
+    const tools = toolsOf(ctx.input)
+    const context: Context = {
+      systemPrompt: ctx.input.instructions || undefined,
+      messages: ctx.input.messages.flatMap((message, index) => messagesOf(message, selected, clock(), index)),
+      ...(tools.length ? { tools } : {}),
+    }
+    const apiKey = config.apiKeyEnv ? requireEnvironment(environment, config.apiKeyEnv, config) : undefined
+    const response = config.thinking
+      ? await models.completeSimple(selected, context, { reasoning: config.thinking, apiKey, signal })
+      : await models.complete(selected, context, { apiKey, signal })
+    if (response.stopReason === "error" || response.stopReason === "aborted") {
+      throw new PiProviderError(response.errorMessage ?? `pi-ai ${response.stopReason}`, config.provider, config.modelId)
+    }
+    buffer.record({
+      type: "agent_model_end",
+      agentName: ctx.input.agentName,
+      round: ctx.input.round,
+      output: {
+        provider: config.provider,
+        modelId: config.modelId,
+        usage: response.usage,
+      },
+    })
+    return responseOf(response, tools)
+  },
+})
+
+export const pi = model(piTurn)
+
+function requireModel(models: Models, config: PiConfig): PiModel<Api> {
+  const selected = models.getModel(config.provider, config.modelId)
+  if (selected) return selected
+  const supported = models.getModels(config.provider).map((model) => model.id)
+  throw new PiProviderError(
+    `Unsupported pi-ai model "${config.provider}/${config.modelId}". Supported: ${supported.join(", ") || "none"}`,
+    config.provider,
+    config.modelId,
+  )
+}
+
+function requireEnvironment(environment: NodeJS.ProcessEnv, name: string, config: PiConfig): string {
+  const value = environment[name]
+  if (value) return value
+  throw new PiProviderError(`pi-ai API key environment variable "${name}" is not set`, config.provider, config.modelId)
+}
+
+function toolsOf(request: ModelRequest): Tool[] {
+  return [
+    ...request.tools.map(capabilityTool),
+    ...(request.skills.length ? [skillTool(request.skills)] : []),
+    ...(request.subagents.length ? [subagentTool(request.subagents)] : []),
+  ]
+}
+
+function capabilityTool(capability: Capability): Tool {
+  return {
+    name: capability.name,
+    description: capability.description,
+    parameters: Type.Object({}, { additionalProperties: true }),
+  }
+}
+
+function skillTool(skills: readonly Capability[]): Tool {
+  return {
+    name: "load_skill",
+    description: "Load one available skill into the next model round.",
+    parameters: Type.Object({ name: StringEnum(skills.map((skill) => skill.name)) }),
+  }
+}
+
+function subagentTool(subagents: readonly Capability[]): Tool {
+  return {
+    name: "call_subagent",
+    description: "Delegate a prompt to one available subagent.",
+    parameters: Type.Object({
+      name: StringEnum(subagents.map((subagent) => subagent.name)),
+      prompt: Type.String(),
+    }),
+  }
+}
+
+function messagesOf(message: Message, model: PiModel<Api>, timestamp: number, index: number): PiMessage[] {
+  if (message.role === "assistant") {
+    return [{
+      role: "assistant",
+      content: [{ type: "text", text: message.content }],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: emptyUsage(),
+      stopReason: "stop",
+      timestamp,
+    }]
+  }
+  if (message.role === "tool" || message.role === "skill" || message.role === "subagent") {
+    const name = message.role === "skill"
+      ? "load_skill"
+      : message.role === "subagent"
+        ? "call_subagent"
+        : message.name ?? "tool"
+    const id = message.id ?? `${name}-${index}`
+    return [{
+      role: "assistant",
+      content: [{ type: "toolCall", id, name, arguments: inputOf(message) }],
+      api: model.api,
+      provider: model.provider,
+      model: model.id,
+      usage: emptyUsage(),
+      stopReason: "toolUse",
+      timestamp,
+    }, {
+      role: "toolResult",
+      toolCallId: id,
+      toolName: name,
+      content: [{ type: "text", text: message.content }],
+      isError: false,
+      timestamp,
+    }]
+  }
+  return [{
+    role: "user",
+    content: message.name ? `${message.role}(${message.name}): ${message.content}` : message.content,
+    timestamp,
+  }]
+}
+
+function inputOf(message: Message): Record<string, unknown> {
+  if (message.role === "skill") return { name: message.name }
+  if (message.role === "subagent") {
+    const prompt = isRecord(message.input) && typeof message.input["prompt"] === "string"
+      ? message.input["prompt"]
+      : message.content
+    return { name: message.name, prompt }
+  }
+  return isRecord(message.input) ? message.input : { input: message.input }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function emptyUsage(): AssistantMessage["usage"] {
+  return {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+  }
+}
+
+function responseOf(response: AssistantMessage, tools: Tool[]): ModelResponse {
+  const calls = response.content.filter((item): item is PiToolCall => item.type === "toolCall")
+  for (const call of calls) validateToolCall(tools, call)
+  const toolCalls = calls.filter((call) => call.name !== "load_skill" && call.name !== "call_subagent")
+  const skillCalls = calls.filter((call) => call.name === "load_skill")
+  const subagentCalls = calls.filter((call) => call.name === "call_subagent")
+  return {
+    content: response.content
+      .filter((item) => item.type === "text")
+      .map((item) => item.text)
+      .join(""),
+    ...(toolCalls.length ? { toolCalls: toolCalls.map((call) => ({ name: call.name, input: call.arguments, id: call.id })) } : {}),
+    ...(skillCalls.length ? { skillCalls: skillCalls.map((call) => ({ name: stringArgument(call, "name"), id: call.id })) } : {}),
+    ...(subagentCalls.length ? {
+      subagentCalls: subagentCalls.map((call) => ({
+        name: stringArgument(call, "name"),
+        input: { prompt: stringArgument(call, "prompt") },
+        id: call.id,
+      })),
+    } : {}),
+    stop: response.stopReason === "stop" && calls.length === 0,
+  }
+}
+
+function stringArgument(call: PiToolCall, name: string): string {
+  const value: unknown = call.arguments[name]
+  if (typeof value === "string") return value
+  throw new PiProviderError(`pi-ai tool "${call.name}" requires string argument "${name}"`, call.name, name)
+}

--- a/pkg/sdk/pi/tests/pi.integration.test.ts
+++ b/pkg/sdk/pi/tests/pi.integration.test.ts
@@ -1,0 +1,33 @@
+import { getBuiltinModels } from "@earendil-works/pi-ai/providers/all"
+import { createScope } from "@pumped-fn/lite"
+import { expect, it } from "vitest"
+import { piConfig, piTurn } from "../src/index"
+
+const selected = getBuiltinModels("anthropic")[0]
+const integration = it.skipIf(
+  process.env["PUMPED_INTEGRATION"] !== "1" || !process.env["ANTHROPIC_API_KEY"] || !selected,
+)
+
+integration("invokes pi-ai with a configured provider key", async () => {
+  const scope = createScope({
+    tags: [piConfig({ provider: "anthropic", modelId: selected!.id, apiKeyEnv: "ANTHROPIC_API_KEY" })],
+  })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({
+    flow: piTurn,
+    input: {
+      agentName: "probe",
+      instructions: "Reply with the single word ready.",
+      messages: [{ role: "user", content: "ready?" }],
+      tools: [],
+      skills: [],
+      loadedSkills: [],
+      subagents: [],
+      round: 0,
+    },
+  })).resolves.toMatchObject({ content: expect.stringMatching(/ready/i) })
+
+  await ctx.close()
+  await scope.dispose()
+}, 120_000)

--- a/pkg/sdk/pi/tests/pi.test.ts
+++ b/pkg/sdk/pi/tests/pi.test.ts
@@ -1,0 +1,134 @@
+import type {
+  AssistantMessage,
+  AssistantMessageEventStream,
+  Api,
+  Model as PiModel,
+  MutableModels,
+} from "@earendil-works/pi-ai"
+import { createScope, preset } from "@pumped-fn/lite"
+import { events, type Model } from "@pumped-fn/sdk"
+import { expect, expectTypeOf, it } from "vitest"
+import { models, piConfig, piTurn, supportedModels } from "../src/index"
+
+const selected: PiModel<Api> = {
+  id: "test-model",
+  name: "Test model",
+  api: "openai-responses",
+  provider: "test",
+  baseUrl: "https://example.invalid",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 1_000,
+  maxTokens: 100,
+}
+
+const response: AssistantMessage = {
+  role: "assistant",
+  content: [
+    { type: "text", text: "working" },
+    { type: "toolCall", id: "tool-1", name: "lookup", arguments: { id: 7 } },
+    { type: "toolCall", id: "skill-1", name: "load_skill", arguments: { name: "search" } },
+    { type: "toolCall", id: "sub-1", name: "call_subagent", arguments: { name: "reviewer", prompt: "check" } },
+  ],
+  api: selected.api,
+  provider: selected.provider,
+  model: selected.id,
+  usage: {
+    input: 10,
+    output: 5,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 15,
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.01 },
+  },
+  stopReason: "toolUse",
+  timestamp: 1,
+}
+
+function collection(result = response): MutableModels {
+  return {
+    getProviders: () => [],
+    getProvider: () => undefined,
+    getModels: (provider?: string) => provider === undefined || provider === "test" ? [selected] : [],
+    getModel: (provider, id) => provider === "test" && id === selected.id ? selected : undefined,
+    refresh: async () => undefined,
+    getAuth: async () => undefined,
+    stream: () => unavailable(),
+    complete: async () => result,
+    streamSimple: () => unavailable(),
+    completeSimple: async () => result,
+    setProvider: () => undefined,
+    deleteProvider: () => undefined,
+    clearProviders: () => undefined,
+  }
+}
+
+function unavailable(): AssistantMessageEventStream {
+  throw new Error("stream unavailable")
+}
+
+it("maps native pi-ai tool calls and records usage", async () => {
+  const scope = createScope({
+    presets: [preset(models, collection())],
+    tags: [piConfig({ provider: "test", modelId: "test-model" })],
+  })
+  const ctx = scope.createContext()
+
+  const result = await ctx.exec({
+    flow: piTurn,
+    input: {
+      agentName: "planner",
+      instructions: "Plan.",
+      messages: [{ role: "user", content: "start" }],
+      tools: [{ name: "lookup", description: "Look up a value." }],
+      skills: [{ name: "search", description: "Search sources." }],
+      loadedSkills: [],
+      subagents: [{ name: "reviewer", description: "Review the plan." }],
+      round: 0,
+    },
+  })
+
+  expect(result).toEqual({
+    content: "working",
+    toolCalls: [{ name: "lookup", input: { id: 7 }, id: "tool-1" }],
+    skillCalls: [{ name: "search", id: "skill-1" }],
+    subagentCalls: [{ name: "reviewer", input: { prompt: "check" }, id: "sub-1" }],
+    stop: false,
+  })
+  expect((await ctx.resolve(events)).events.at(-1)?.output).toMatchObject({
+    provider: "test",
+    modelId: "test-model",
+    usage: { totalTokens: 15, cost: { total: 0.01 } },
+  })
+  expectTypeOf(piTurn).toMatchTypeOf<Model>()
+
+  await ctx.close()
+  await scope.dispose()
+})
+
+it("lists models and rejects unsupported selections", async () => {
+  const scope = createScope({
+    presets: [preset(models, collection())],
+    tags: [piConfig({ provider: "test", modelId: "missing" })],
+  })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({ flow: supportedModels, input: { provider: "test" } })).resolves.toEqual([selected])
+  await expect(ctx.exec({
+    flow: piTurn,
+    input: {
+      agentName: "planner",
+      instructions: "",
+      messages: [],
+      tools: [],
+      skills: [],
+      loadedSkills: [],
+      subagents: [],
+      round: 0,
+    },
+  })).rejects.toThrow('Unsupported pi-ai model "test/missing". Supported: test-model')
+
+  await ctx.close({ ok: false, error: new Error("expected") })
+  await scope.dispose()
+})

--- a/pkg/sdk/pi/tsconfig.json
+++ b/pkg/sdk/pi/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src", "tests", "tsdown.config.ts", "vitest.config.ts"]
+}

--- a/pkg/sdk/pi/tsdown.config.ts
+++ b/pkg/sdk/pi/tsdown.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "tsdown"
+
+export default defineConfig({ entry: ["src/index.ts"], dts: true, format: ["esm"] })

--- a/pkg/sdk/pi/vitest.config.ts
+++ b/pkg/sdk/pi/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({ test: { include: ["tests/**/*.test.ts"] } })

--- a/pkg/sdk/test/tests/cli.test.ts
+++ b/pkg/sdk/test/tests/cli.test.ts
@@ -1,19 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
 import { createScope } from "@pumped-fn/lite"
 import {
   CliWorkerError,
-  claudeHarness,
-  claudeCliWorker,
   cliWorker,
-  codexHarness,
-  codexCliWorker,
-  guard,
   runCli,
   step,
-  type ModelRequest,
 } from "@pumped-fn/sdk"
 
 describe("CLI workers", () => {
@@ -30,44 +21,8 @@ describe("CLI workers", () => {
     await ctx.close()
   })
 
-  it("marks CLI-backed LLM helpers as LLM workers", () => {
+  it("marks generic CLI workers", () => {
     expect(step.find(cliWorker({ name: "x", command: "printf" })).kind).toBe("cli")
-    expect(step.find(claudeCliWorker()).kind).toBe("llm")
-    expect(step.find(codexCliWorker()).kind).toBe("llm")
-  })
-
-  it("passes LLM helper prompts after one argv terminator", async () => {
-    const scope = createScope()
-    const ctx = scope.createContext()
-
-    expect(await ctx.exec({
-      flow: claudeCliWorker({ command: "echo", extraArgs: ["--verbose"] }),
-      input: { prompt: "--help" },
-    })).toBe("-p --verbose -- --help")
-    expect(await ctx.exec({
-      flow: codexCliWorker({ command: "echo", extraArgs: ["--verbose"] }),
-      input: { prompt: "--help" },
-    })).toBe("exec -s read-only --verbose -- --help")
-
-    await ctx.close()
-  })
-
-  it("rejects argv terminators in LLM helper extra args", async () => {
-    const scope = createScope()
-    const ctx = scope.createContext()
-
-    await expect(ctx.exec({
-      flow: claudeCliWorker({ command: "echo", extraArgs: ["--"] }),
-      input: { prompt: "x" },
-    })).rejects.toThrow("CLI helper extraArgs cannot include --")
-
-    await ctx.close({ ok: false, error: new Error("expected") })
-  })
-
-  it("rejects bare Claude harness args", () => {
-    expect(() => claudeCliWorker({ extraArgs: ["--bare"] })).toThrow("Claude harness must not use --bare")
-    expect(() => claudeCliWorker({ extraArgs: ["--bare=true"] })).toThrow("Claude harness must not use --bare")
-    expect(() => claudeHarness({ extraArgs: ["--bare"] })).toThrow("Claude harness must not use --bare")
   })
 
   it("wraps isolated CLI runs with bubblewrap args", async () => {
@@ -97,105 +52,6 @@ describe("CLI workers", () => {
     })).resolves.toMatchObject({
       stdout: expect.stringContaining("--bind /source /target"),
     })
-  })
-
-  it("collects the first harness guard into material state", async () => {
-    const dir = await mkdtemp(join(tmpdir(), "pumped-fn-model-"))
-    const command = join(dir, "model")
-    await writeFile(command, "#!/bin/sh\nprintf '%s' '{\"content\":\"ready\",\"guard\":\"Keep changes scoped\"}'\n")
-    await chmod(command, 0o755)
-    const store = guard("review-guard")
-    const scope = createScope()
-    const ctx = scope.createContext()
-    const request = {
-      agentName: "review",
-      instructions: "Review the change.",
-      messages: [{ role: "user", content: "hello" }],
-      tools: [],
-      skills: [],
-      loadedSkills: [],
-      subagents: [],
-      round: 0,
-    } satisfies ModelRequest
-
-    await expect(ctx.exec({ flow: codexHarness({ command, isolate: false, guard: store }), input: request }))
-      .resolves.toMatchObject({
-        content: "ready",
-        guard: "Keep changes scoped",
-        stop: true,
-      })
-    await expect(ctx.resolve(store)).resolves.toMatchObject({
-      state: { text: "Keep changes scoped" },
-    })
-
-    await ctx.close()
-    await scope.dispose()
-    await rm(dir, { recursive: true, force: true })
-  })
-
-  it("passes collected guards to later harness prompts", async () => {
-    const store = guard("planner-guard")
-    const scope = createScope()
-    const ctx = scope.createContext()
-    const seen: string[] = []
-    const request = {
-      agentName: "planner",
-      instructions: "Plan the work.",
-      messages: [{ role: "user", content: "hello" }],
-      tools: [],
-      skills: [],
-      loadedSkills: [],
-      subagents: [],
-      round: 0,
-    } satisfies ModelRequest
-    const model = claudeHarness({
-      command: "echo",
-      isolate: false,
-      guard: store,
-      prompt: (_request, guard) => {
-        seen.push(guard.text)
-        return `guard=${guard.text}`
-      },
-      parse: () => seen.length === 1
-        ? { content: "ready", guard: "Avoid single-model truth", stop: true }
-        : { content: "ready", stop: true },
-    })
-
-    await ctx.exec({ flow: model, input: request })
-    await ctx.exec({ flow: model, input: request })
-    expect(seen).toEqual(["", "Avoid single-model truth"])
-
-    await ctx.close()
-    await scope.dispose()
-  })
-
-  it("adapts Codex and Claude CLI harnesses into models", async () => {
-    const scope = createScope()
-    const ctx = scope.createContext()
-    const request = {
-      agentName: "review",
-      instructions: "Review the change.",
-      messages: [{ role: "user", content: "hello" }],
-      tools: [],
-      skills: [],
-      loadedSkills: [],
-      subagents: [],
-      round: 0,
-    } satisfies ModelRequest
-
-    await expect(ctx.exec({ flow: claudeHarness({ command: "echo", isolate: false }), input: request }))
-      .resolves.toMatchObject({
-        content: expect.stringContaining("-p --no-session-persistence -- Return JSON only."),
-        stop: true,
-      })
-    await expect(ctx.exec({ flow: codexHarness({ command: "echo", isolate: false }), input: request }))
-      .resolves.toMatchObject({
-        content: expect.stringContaining("exec -s read-only --ephemeral --ignore-user-config -- Return JSON only."),
-        stop: true,
-      })
-
-    await ctx.close()
-    await scope.dispose()
   })
 
   it("reports CLI failures with captured stderr", async () => {

--- a/pkg/tool/lint/README.md
+++ b/pkg/tool/lint/README.md
@@ -43,6 +43,8 @@ pumped-lite-lint --json src tests
 | `pumped/no-untyped-throw` (warn) | `throw new Error(...)` and other builtin error constructors (`TypeError`, `RangeError`, etc.) inside atom/flow/resource factories; throw a domain error class carrying structured fields (kind/op/entity) so traces and edges can discriminate planned vs unplanned failures. Rethrow of a caught identifier (`throw error`) and user-defined error classes both pass. |
 | `pumped/no-swallowed-error` (warn) | Catch clauses inside atom/flow/resource factories that neither rethrow nor reference the caught error (empty catch bodies, `catch {}` with no throw, or bodies that discard the binding); swallowing the error here blinds the trace seam. Wrapping with a cause (`throw new StoreError(msg, error)`), rethrowing, or passing the error to a dep (e.g. logging) all pass. |
 | `pumped/no-handle-spread` (warn) | Object literals that spread a lite handle (`{ ...sharedFlow, tags: [...] }`), detected conservatively — the spread identifier is a same-file `atom`/`flow`/`resource`/... creator result, or the object literal also sets a `tags` property alongside any spread (the retrofit fingerprint); spreads fork node identity and silently miss presets targeting the original. Wrap the shared flow in a thin entry flow (`deps: { run: controller(sharedFlow) }`, `factory: (ctx, { run }) => run.exec(...)`) instead. Plain data object spreads are not flagged. |
+| `pumped/no-handle-factory` | Exported function declarations and exported arrow/function expressions that directly return an `atom`/`flow`/`resource`/`material`/`tag`, return one through a wrapper such as `model(...)`, or return a same-function local handle. Configure documented core constructors with `allowHandleFactories`; composition roots remain unrestricted because they return scopes, not handles. Known syntactic false negatives: handles routed through helper calls, assignments, collections, or cross-function aliases. |
+| `pumped/config-via-tags` (warn) | A graph factory that reads a direct identifier parameter from its enclosing function. Provider configuration belongs in a module-level tag declared through `deps`. Configure documented low-level constructors with `allowHandleFactories`. Known syntactic false negatives: destructured parameters, aliases, and values forwarded through helpers. |
 | `pumped/no-unattributed-await` | Inside an atom/flow/resource factory, an awaited (or `.then()`-chained) call rooted at the factory's deps parameter, unless it's graph machinery (`exec`/`execStream`/`prepare` by method name; `resolve` only when the dep's initializer is a `controller(...)` call) or the enclosing flow's `tags` array carries a `step(...)` tag imported from `@pumped-fn/sdk`; awaited foreign calls only happen inside declared spans. `for await` iteration and sync calls on deps are not flagged, and a nested function parameter that shadows the deps binding name is respected. Known false negatives, accepted for a syntactic rule: `exec`/`execStream`/`prepare` name collisions on non-handle deps, aliased bindings, rest/nested deps patterns, spread-built tags arrays, and un-awaited returned promises. |
 
 The default path walk skips `before.*` example files, generated output, lockfiles, and dependency
@@ -52,7 +54,7 @@ directories where examples intentionally contain bad shapes or third-party code.
 
 Every diagnostic carries a `severity` of `"error"` or `"warn"`.
 
-> **Note:** The CLI exits nonzero only when at least one `"error"` diagnostic is found. `"warn"` diagnostics still print and appear in `--json`, but they do not fail the process; `pumped/no-implicit-tag-read`, `pumped/no-naked-globals`, `pumped/no-module-state`, `pumped/prefer-destructured-deps`, `pumped/no-untyped-throw`, `pumped/no-swallowed-error`, and `pumped/no-handle-spread` default to `"warn"` as an incremental cleanup inventory, while all other rules default to `"error"`.
+> **Note:** The CLI exits nonzero only when at least one `"error"` diagnostic is found. `"warn"` diagnostics still print and appear in `--json`, but they do not fail the process; `pumped/config-via-tags`, `pumped/no-implicit-tag-read`, `pumped/no-naked-globals`, `pumped/no-module-state`, `pumped/prefer-destructured-deps`, `pumped/no-untyped-throw`, `pumped/no-swallowed-error`, and `pumped/no-handle-spread` default to `"warn"` as an incremental cleanup inventory, while all other rules default to `"error"`.
 
 ## Config
 
@@ -65,6 +67,7 @@ const result = await scanPaths(["src", "tests"], {
   rules: {
     "pumped/no-implicit-tag-read": { allowImplicit: ["requestId"] },
     "pumped/no-naked-globals": { allowGlobals: ["fetch"] },
+    "pumped/no-handle-factory": { allowHandleFactories: ["cliWorker"] },
   },
 })
 ```
@@ -76,6 +79,9 @@ const result = await scanPaths(["src", "tests"], {
 (`JSON`, `Math`, `Object`, `Array`, `String`, `Number`, `structuredClone`, `URL`).
 `allowBuiltins` lists builtin error constructor names (e.g. `"TypeError"`) that are exempt from
 `no-untyped-throw`; empty by default.
+`allowHandleFactories` lists documented low-level constructors such as `agent`, `tool`, `skill`,
+`sub`, `session`, `guard`, `material`, `channel`, `schedule`, or `cliWorker`. Use the same list for
+`no-handle-factory` and `config-via-tags` when a constructor intentionally captures its inputs.
 
 ## API
 

--- a/pkg/tool/lint/src/index.ts
+++ b/pkg/tool/lint/src/index.ts
@@ -3,11 +3,13 @@ import { basename, extname, resolve } from "node:path"
 import ts from "typescript"
 
 export type RuleId =
+  | "pumped/config-via-tags"
   | "pumped/no-ambient-io-outside-boundary"
   | "pumped/no-ctx-argument"
   | "pumped/no-definition-handle-suffix"
   | "pumped/no-direct-flow-composition"
   | "pumped/no-handle-spread"
+  | "pumped/no-handle-factory"
   | "pumped/no-implicit-tag-read"
   | "pumped/no-internal-example-label"
   | "pumped/no-jsdom-backend"
@@ -49,9 +51,10 @@ export interface ScanResult {
  * `allowGlobals` list identifiers that are exempt from their rule's checks
  * (tag labels for no-implicit-tag-read, global names for no-naked-globals).
  * `allowBuiltins` lists builtin error constructor names exempt from
- * no-untyped-throw. `severity` overrides a rule's default severity ("error",
- * "warn", or "off" to disable it entirely). Seven dependency-graph and
- * error-taxonomy rules — no-implicit-tag-read, no-naked-globals,
+ * no-untyped-throw. `allowHandleFactories` lists documented low-level handle
+ * constructors. `severity` overrides a rule's default severity ("error",
+ * "warn", or "off" to disable it entirely). Eight dependency-graph and
+ * error-taxonomy rules — config-via-tags, no-implicit-tag-read, no-naked-globals,
  * no-module-state, prefer-destructured-deps, no-untyped-throw,
  * no-swallowed-error, and no-handle-spread — default to "warn" severity (see `defaultSeverity`) so
  * they surface in `--json` output and local runs without failing the root
@@ -66,6 +69,7 @@ export interface RuleConfig {
   allowImplicit?: string[]
   allowGlobals?: string[]
   allowBuiltins?: string[]
+  allowHandleFactories?: string[]
 }
 
 export type RuleOptions = Partial<Record<RuleId, RuleConfig>>
@@ -76,6 +80,7 @@ export interface ScanOptions {
 }
 
 const defaultSeverity: Partial<Record<RuleId, Severity>> = {
+  "pumped/config-via-tags": "warn",
   "pumped/no-handle-spread": "warn",
   "pumped/no-implicit-tag-read": "warn",
   "pumped/no-naked-globals": "warn",
@@ -134,9 +139,9 @@ type Imports = {
   viObjects: Set<string>
 }
 
-type CreatorKind = "atom" | "flow" | "resource" | "tag" | "scopedValue"
+type CreatorKind = "atom" | "flow" | "material" | "resource" | "tag" | "scopedValue"
 
-const creatorNames = new Set(["atom", "flow", "resource", "tag", "scopedValue"])
+const creatorNames = new Set(["atom", "flow", "material", "resource", "tag", "scopedValue"])
 const graphNodeCreatorKinds = new Set<CreatorKind>(["atom", "flow", "resource"])
 const sourceExtensions = new Set([".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs"])
 const textExtensions = new Set([...sourceExtensions, ".json", ".md", ".mdx"])
@@ -362,6 +367,10 @@ function collectImports(sourceFile: ts.SourceFile): Imports {
         imports.creators.add(local)
         imports.creatorKinds.set(local, imported as CreatorKind)
       }
+      if (moduleName === "@pumped-fn/sdk" && imported === "material") {
+        imports.creators.add(local)
+        imports.creatorKinds.set(local, "material")
+      }
       if (moduleName === "@testing-library/react" && imported === "render") {
         imports.render.add(local)
       }
@@ -440,6 +449,86 @@ function returnsCreateScope(node: ts.FunctionDeclaration | ts.ArrowFunction | ts
     && ts.isCallExpression(statement.expression)
     && isCreateScopeCall(statement.expression.expression, imports)
   )
+}
+
+function returnedExpressions(node: ts.FunctionDeclaration | ts.ArrowFunction | ts.FunctionExpression): ts.Expression[] {
+  if (!node.body) return []
+  if (!ts.isBlock(node.body)) return [node.body]
+  const expressions: ts.Expression[] = []
+  function walk(current: ts.Node): void {
+    if (current !== node.body && (ts.isFunctionDeclaration(current) || ts.isFunctionExpression(current) || ts.isArrowFunction(current))) return
+    if (ts.isReturnStatement(current) && current.expression) expressions.push(current.expression)
+    ts.forEachChild(current, walk)
+  }
+  walk(node.body)
+  return expressions
+}
+
+function localCreatorNames(node: ts.FunctionDeclaration | ts.ArrowFunction | ts.FunctionExpression, imports: Imports): Set<string> {
+  const names = new Set<string>()
+  if (!node.body) return names
+  function walk(current: ts.Node): void {
+    if (current !== node.body && (ts.isFunctionDeclaration(current) || ts.isFunctionExpression(current) || ts.isArrowFunction(current))) return
+    if (
+      ts.isVariableDeclaration(current)
+      && ts.isIdentifier(current.name)
+      && current.initializer
+      && ts.isCallExpression(current.initializer)
+      && isCreatorCall(current.initializer.expression, imports)
+    ) {
+      names.add(current.name.text)
+    }
+    ts.forEachChild(current, walk)
+  }
+  walk(node.body)
+  return names
+}
+
+function expressionReturnsHandle(expression: ts.Expression, imports: Imports, locals: Set<string>): boolean {
+  if (ts.isIdentifier(expression) && locals.has(expression.text)) return true
+  let found = false
+  function walk(current: ts.Node): void {
+    if (found) return
+    if (ts.isCallExpression(current) && isCreatorCall(current.expression, imports)) {
+      found = true
+      return
+    }
+    if (ts.isIdentifier(current) && locals.has(current.text)) {
+      found = true
+      return
+    }
+    ts.forEachChild(current, walk)
+  }
+  walk(expression)
+  return found
+}
+
+function returnsHandle(node: ts.FunctionDeclaration | ts.ArrowFunction | ts.FunctionExpression, imports: Imports): boolean {
+  const locals = localCreatorNames(node, imports)
+  return returnedExpressions(node).some((expression) => expressionReturnsHandle(expression, imports, locals))
+}
+
+function enclosingParameterClosures(
+  node: ts.CallExpression,
+  imports: Imports,
+): Array<{ name: ts.Identifier; owner: ts.FunctionDeclaration | ts.ArrowFunction | ts.FunctionExpression }> {
+  const config = unitCallObject(node, imports)
+  const factory = config && objectProperty(config, "factory")
+  if (!factory || (!ts.isArrowFunction(factory.initializer) && !ts.isFunctionExpression(factory.initializer))) return []
+  let current: ts.Node | undefined = node.parent
+  while (current) {
+    if (ts.isFunctionDeclaration(current) || ts.isArrowFunction(current) || ts.isFunctionExpression(current)) {
+      const references = collectIdentifierReferences(factory.initializer.body)
+      const owner = current
+      return current.parameters.flatMap((parameter) =>
+        ts.isIdentifier(parameter.name) && references.has(parameter.name.text)
+          ? [{ name: parameter.name, owner }]
+          : []
+      )
+    }
+    current = current.parent
+  }
+  return []
 }
 
 function exported(node: ts.Node): boolean {
@@ -984,6 +1073,10 @@ function addAstDiagnostics(source: string, filePath: string, diagnostics: Diagno
   const allowImplicit = new Set(options?.rules?.["pumped/no-implicit-tag-read"]?.allowImplicit ?? [])
   const allowGlobals = new Set([...nakedGlobalDefaultAllow, ...(options?.rules?.["pumped/no-naked-globals"]?.allowGlobals ?? [])])
   const allowBuiltins = new Set(options?.rules?.["pumped/no-untyped-throw"]?.allowBuiltins ?? [])
+  const allowHandleFactories = new Set([
+    ...(options?.rules?.["pumped/no-handle-factory"]?.allowHandleFactories ?? []),
+    ...(options?.rules?.["pumped/config-via-tags"]?.allowHandleFactories ?? []),
+  ])
   const unitFactoryNodes = collectUnitFactoryNodes(sourceFile, imports)
   const hasGraphNodes = unitFactoryNodes.length > 0
   const creatorHandleNames = collectCreatorHandleNames(sourceFile, imports)
@@ -1153,6 +1246,20 @@ function addAstDiagnostics(source: string, filePath: string, diagnostics: Diagno
 
     if (ts.isCallExpression(node)) {
       const name = calledName(node.expression)
+      if (isCreatorCall(node.expression, imports)) {
+        for (const closure of enclosingParameterClosures(node, imports)) {
+          const ownerName = closure.owner.name && ts.isIdentifier(closure.owner.name) ? closure.owner.name.text : null
+          if (ownerName && allowHandleFactories.has(ownerName)) continue
+          pushNodeDiagnostic(
+            diagnostics,
+            sourceFile,
+            filePath,
+            "pumped/config-via-tags",
+            closure.name,
+            `Configuration parameter "${closure.name.text}" is closed over by a graph factory; declare configuration as a tag dependency instead.`,
+          )
+        }
+      }
       if (
         ts.isPropertyAccessExpression(node.expression)
         && ts.isIdentifier(node.expression.expression)
@@ -1616,6 +1723,16 @@ function addAstDiagnostics(source: string, filePath: string, diagnostics: Diagno
     }
 
     if (ts.isFunctionDeclaration(node) && exported(node)) {
+      if (node.name && !allowHandleFactories.has(node.name.text) && returnsHandle(node, imports)) {
+        pushNodeDiagnostic(
+          diagnostics,
+          sourceFile,
+          filePath,
+          "pumped/no-handle-factory",
+          node.name,
+          "Export stable module-level handles instead of a function that constructs and returns a handle.",
+        )
+      }
       if (allowScopeArgument && isCompositionPath(filePath) && hasScopeOrExecutionContextParameter(node.parameters)) {
         pushNodeDiagnostic(
           diagnostics,
@@ -1643,6 +1760,20 @@ function addAstDiagnostics(source: string, filePath: string, diagnostics: Diagno
       && (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
       && exported(variableStatement(node) ?? node)
     ) {
+      if (
+        ts.isIdentifier(node.name)
+        && !allowHandleFactories.has(node.name.text)
+        && returnsHandle(node.initializer, imports)
+      ) {
+        pushNodeDiagnostic(
+          diagnostics,
+          sourceFile,
+          filePath,
+          "pumped/no-handle-factory",
+          node.name,
+          "Export stable module-level handles instead of a function that constructs and returns a handle.",
+        )
+      }
       if (allowScopeArgument && isCompositionPath(filePath) && hasScopeOrExecutionContextParameter(node.initializer.parameters)) {
         pushNodeDiagnostic(
           diagnostics,

--- a/pkg/tool/lint/tests/scanner.test.ts
+++ b/pkg/tool/lint/tests/scanner.test.ts
@@ -975,6 +975,63 @@ describe("lite lint scanner", () => {
     `)).toEqual([])
   })
 
+  it("finds exported handle factories through direct, wrapped, and local returns", () => {
+    expect(ids(`
+      import { flow } from "@pumped-fn/lite"
+      import { model } from "@pumped-fn/sdk"
+
+      export function direct() {
+        return flow({ factory: () => "ok" })
+      }
+
+      export const wrapped = () => model(flow({ factory: () => "ok" }))
+
+      export function local() {
+        const run = flow({ factory: () => "ok" })
+        return model(run)
+      }
+
+      function internal() {
+        return flow({ factory: () => "ok" })
+      }
+    `)).toEqual([
+      "pumped/no-handle-factory",
+      "pumped/no-handle-factory",
+      "pumped/no-handle-factory",
+    ])
+  })
+
+  it("allows configured core handle constructors", () => {
+    expect(ids(`
+      import { flow } from "@pumped-fn/lite"
+
+      export function cliWorker(options: { name: string }) {
+        return flow({ name: options.name, factory: () => "ok" })
+      }
+    `, "src/example.ts", {
+      rules: {
+        "pumped/no-handle-factory": { allowHandleFactories: ["cliWorker"] },
+        "pumped/config-via-tags": { allowHandleFactories: ["cliWorker"] },
+      },
+    })).toEqual([])
+  })
+
+  it("finds provider options closed over by graph factories", () => {
+    const found = diagnostics(`
+      import { flow } from "@pumped-fn/lite"
+
+      export function provider(options: { model: string }) {
+        return flow({ factory: () => options.model })
+      }
+    `)
+    expect(found.map((diagnostic) => diagnostic.ruleId)).toEqual([
+      "pumped/no-handle-factory",
+      "pumped/config-via-tags",
+    ])
+    expect(found[0]?.severity).toBe("error")
+    expect(found[1]?.severity).toBe("warn")
+  })
+
   function unattributedAwaitCount(source: string, filePath = "src/example.ts") {
     return ids(source, filePath).filter((id) => id === "pumped/no-unattributed-await").length
   }

--- a/playground/compare/README.md
+++ b/playground/compare/README.md
@@ -4,6 +4,8 @@ One account-onboarding contract runs through pumped-fn, Effect, Awilix, Inversif
 
 The account domain and Effect composition start from Effect's official HTTP server example. `sources.lock.json` pins each external source and the browser-safe adaptation boundary.
 
+The editor carries live type intelligence: a web worker hosts a TypeScript virtual environment seeded with the checked-in case files and the real `.d.ts` surface of every lane dependency, so hover, completion, and diagnostics reflect the same types the repository compiles against. The Sandpack preview runs three proofs — the lifecycle contract, a throughput benchmark executed on the visitor's machine, and a live `@pumped-fn/lite` reactivity demo.
+
 ## Verify
 
 ```sh
@@ -22,3 +24,8 @@ The browser opens all fifteen checked-in Build, Test, and Operate proof files in
 - All lanes satisfy the same black-box contract, but their internal file shape remains idiomatic.
 - Operations wording describes the checked-in lane. It does not claim a product cannot be instrumented.
 - `examples/invoice-triage` remains the canonical pumped-fn application. This package is a comparison and verification surface.
+
+## Color policy
+
+- Page chrome is grayscale, enforced by the authored and computed audits in `scripts/adapters/color-audit.mjs`.
+- Syntax tokens inside the editor may use only the fixed palette declared as `editorSyntaxPalette` in the audit; `src/editor/code-theme.ts` must conform, and the computed audit exempts exactly those values on `sp-syntax-*` spans.

--- a/playground/compare/index.html
+++ b/playground/compare/index.html
@@ -4,6 +4,23 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Build, test, and operate | pumped-fn</title>
+    <meta
+      name="description"
+      content="Five checked-in implementations of one account workflow — pumped-fn, Effect, Awilix, Inversify, and plain TypeScript. Read, edit, and execute each one in your browser with live type intelligence."
+    />
+    <meta property="og:title" content="Build, test, and operate the same account workflow" />
+    <meta
+      property="og:description"
+      content="pumped-fn vs Effect vs Awilix vs Inversify vs plain TypeScript — one contract, five executable implementations, live in the browser."
+    />
+    <meta property="og:type" content="website" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%23171717'/%3E%3Ctext x='16' y='22' font-family='monospace' font-size='15' font-weight='bold' fill='%23ffffff' text-anchor='middle'%3Efn%3C/text%3E%3C/svg%3E"
+    />
+    <link rel="preconnect" href="https://sandpack-bundler.codesandbox.io" />
+    <link rel="dns-prefetch" href="https://data.jsdelivr.com" />
+    <link rel="dns-prefetch" href="https://cdn.jsdelivr.net" />
   </head>
   <body>
     <div id="app"></div>

--- a/playground/compare/package.json
+++ b/playground/compare/package.json
@@ -3,9 +3,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "build:pages": "PUMPED_COMPARE_BASE_PATH=/pumped-fn/ vite build",
+    "dev": "pnpm -F @pumped-fn/lite build && vite",
+    "build": "pnpm -F @pumped-fn/lite build && vite build",
+    "build:pages": "pnpm -F @pumped-fn/lite build && PUMPED_COMPARE_BASE_PATH=/pumped-fn/ vite build",
     "test": "vitest run",
     "typecheck": "tsgo --noEmit",
     "lint": "pnpm -F @pumped-fn/lite-lint build && node ../../pkg/tool/lint/dist/cli.mjs README.md cases src sandbox scripts vite.config.ts",
@@ -22,8 +22,15 @@
     "verify": "pnpm lint && pnpm test && pnpm typecheck && pnpm build && pnpm browser:smoke"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "catalog:",
+    "@codemirror/lint": "catalog:",
+    "@codemirror/state": "catalog:",
+    "@codemirror/view": "catalog:",
     "@codesandbox/sandpack-react": "catalog:",
     "@pumped-fn/lite": "workspace:*",
+    "@typescript/vfs": "catalog:",
+    "@valtown/codemirror-ts": "catalog:",
+    "comlink": "catalog:",
     "awilix": "catalog:",
     "effect": "catalog:",
     "inversify": "catalog:",

--- a/playground/compare/sandbox/lifecycle.ts
+++ b/playground/compare/sandbox/lifecycle.ts
@@ -1,0 +1,80 @@
+import type { Event } from "../cases/account-onboarding/contract"
+import type { ScenarioResult } from "../cases/account-onboarding/scenario"
+
+const markers: Record<Event, string> = {
+  "database.acquire": "◆",
+  "database.release": "◇",
+  "database.transaction.begin": "○",
+  "database.transaction.commit": "●",
+  "database.transaction.rollback": "✕",
+  "database.users.insert": "+",
+  "database.users.duplicate": "!",
+  "clock.now": "·",
+  "uuid.next": "·",
+}
+
+const requestLabels = ["request 1 — inserted", "request 2 — duplicate, rolled back", "request 3 — inserted"]
+
+type Segment = { label: string; entries: { position: number; name: Event }[] }
+
+function segment(events: Event[]): Segment[] {
+  const segments: Segment[] = [{ label: "lease", entries: [] }]
+  let request = 0
+  events.forEach((name, position) => {
+    if (name === "uuid.next") {
+      segments.push({ label: requestLabels[request] ?? `request ${request + 1}`, entries: [] })
+      request += 1
+    } else if (name === "database.release") {
+      segments.push({ label: "lease returned", entries: [] })
+    }
+    segments[segments.length - 1]!.entries.push({ position, name })
+  })
+  return segments
+}
+
+const count = (events: Event[], needle: Event) => events.filter((event) => event === needle).length
+
+export function renderLifecycle(root: HTMLElement, results: ScenarioResult[]) {
+  const events = results[0]!.events
+  root.innerHTML = `
+    <header class="view-head">
+      <p class="micro">Executable lifecycle</p>
+      <h1>Success · duplicate rollback · success</h1>
+      <p class="lede">Five containers ran the same three provisioning requests over a single database lease. Every lane emitted the identical ${events.length}-event sequence.</p>
+    </header>
+    <div class="cards">
+      ${results.map((result) => `
+        <article class="card">
+          <div class="card-head">
+            <h2>${result.lane}</h2>
+            <span class="badge">passed</span>
+          </div>
+          <dl class="figures">
+            <dt>requests</dt><dd>3</dd>
+            <dt>commits</dt><dd>${count(result.events, "database.transaction.commit")}</dd>
+            <dt>rollbacks</dt><dd>${count(result.events, "database.transaction.rollback")}</dd>
+            <dt>acquire / release</dt><dd>1 / 1</dd>
+            <dt>events</dt><dd>${result.events.length}</dd>
+          </dl>
+        </article>
+      `).join("")}
+    </div>
+    <section class="timeline">
+      <p class="micro">Shared event timeline — identical across all five lanes</p>
+      ${segment(events).map((part) => `
+        <div class="timeline-segment">
+          <p class="timeline-label">${part.label}</p>
+          <ol class="timeline-rows">
+            ${part.entries.map(({ position, name }) => `
+              <li class="timeline-row is-${name.split(".").pop()}">
+                <span class="timeline-index">${String(position + 1).padStart(2, "0")}</span>
+                <span class="timeline-marker">${markers[name]}</span>
+                <span class="timeline-name">${name}</span>
+              </li>
+            `).join("")}
+          </ol>
+        </div>
+      `).join("")}
+    </section>
+  `
+}

--- a/playground/compare/sandbox/main.ts
+++ b/playground/compare/sandbox/main.ts
@@ -5,35 +5,49 @@ import { effect } from "../cases/account-onboarding/lanes/effect"
 import { inversify } from "../cases/account-onboarding/lanes/inversify"
 import { plain } from "../cases/account-onboarding/lanes/plain"
 import { pumped } from "../cases/account-onboarding/lanes/pumped"
-import { runScenario } from "../cases/account-onboarding/scenario"
+import { runScenario, type ScenarioResult } from "../cases/account-onboarding/scenario"
+import { renderLifecycle } from "./lifecycle"
+import { mountReactivity } from "./reactivity"
+import { mountThroughput } from "./throughput"
 
 const lanes: Lane[] = [pumped, effect, awilix, inversify, plain]
 
+const views = [
+  { id: "lifecycle", label: "Lifecycle" },
+  { id: "throughput", label: "Throughput" },
+  { id: "reactivity", label: "Reactivity" },
+]
+
 async function run() {
-  const results = await Promise.all(lanes.map(runScenario))
   const root = document.querySelector<HTMLElement>("#app")!
+  const results: ScenarioResult[] = []
+  for (const lane of lanes) {
+    root.textContent = `running ${lane.id}…`
+    results.push(await runScenario(lane))
+  }
   root.dataset.results = JSON.stringify(results)
   root.dataset.comparisonReady = "true"
   root.innerHTML = `
-    <header>
-      <p>Executable lifecycle</p>
-      <h1>Success · duplicate rollback · success</h1>
-    </header>
-    <div class="results">
-      ${results.map((result) => `
-        <article>
-          <span>passed</span>
-          <h2>${result.lane}</h2>
-          <dl>
-            <dt>requests</dt><dd>3</dd>
-            <dt>commits</dt><dd>${result.events.filter((event) => event === "database.transaction.commit").length}</dd>
-            <dt>rollbacks</dt><dd>${result.events.filter((event) => event === "database.transaction.rollback").length}</dd>
-            <dt>acquire / release</dt><dd>1 / 1</dd>
-          </dl>
-        </article>
+    <nav class="tabs">
+      ${views.map((view, index) => `
+        <button type="button" class="tab${index === 0 ? " is-active" : ""}" data-view="${view.id}">${view.label}</button>
       `).join("")}
-    </div>
+    </nav>
+    ${views.map((view, index) => `<section class="view" data-view="${view.id}"${index === 0 ? "" : " hidden"}></section>`).join("")}
   `
+  const section = (id: string) => root.querySelector<HTMLElement>(`section[data-view="${id}"]`)!
+  renderLifecycle(section("lifecycle"), results)
+  mountThroughput(section("throughput"), lanes)
+  mountReactivity(section("reactivity"))
+  const tabs = [...root.querySelectorAll<HTMLButtonElement>(".tab")]
+  for (const tab of tabs) {
+    tab.addEventListener("click", () => {
+      for (const other of tabs) other.classList.toggle("is-active", other === tab)
+      for (const view of root.querySelectorAll<HTMLElement>("section.view")) {
+        view.hidden = view.dataset.view !== tab.dataset.view
+      }
+    })
+  }
 }
 
 void run()

--- a/playground/compare/sandbox/reactivity.ts
+++ b/playground/compare/sandbox/reactivity.ts
@@ -1,0 +1,144 @@
+import { atom, controller, createScope } from "@pumped-fn/lite"
+
+const windowSize = 60
+
+const feed = atom({ factory: () => 50 })
+const history = atom({ factory: (): number[] => [] })
+const recomputeCount = atom({ factory: () => 0 })
+
+const stats = atom({
+  deps: {
+    feed: controller(feed, { resolve: true, watch: true }),
+    history: controller(history, { resolve: true }),
+    recomputeCount: controller(recomputeCount, { resolve: true }),
+  },
+  factory: (_, { feed, history, recomputeCount }) => {
+    recomputeCount.update((total) => total + 1)
+    const values = [...history.get().slice(1 - windowSize), feed.get()]
+    history.set(values)
+    const sum = values.reduce((total, value) => total + value, 0)
+    return {
+      samples: values.length,
+      mean: sum / values.length,
+      low: Math.min(...values),
+      high: Math.max(...values),
+    }
+  },
+})
+
+const readout = atom({
+  deps: { stats: controller(stats, { resolve: true, watch: true }) },
+  factory: (_, { stats }) => {
+    const { samples, mean, low, high } = stats.get()
+    return `${mean.toFixed(1)} mean · ${low.toFixed(1)} low · ${high.toFixed(1)} high · ${samples} samples`
+  },
+})
+
+type Session = {
+  push: () => void
+  dispose: () => Promise<void>
+}
+
+export function mountReactivity(root: HTMLElement) {
+  root.innerHTML = `
+    <header class="view-head">
+      <p class="micro">@pumped-fn/lite reactivity</p>
+      <h1>Feed → rolling stats → readout</h1>
+      <p class="lede">A numeric feed atom drives two chained derived atoms via <span class="mono">controller(dep, { resolve, watch })</span>. The DOM paints from one <span class="mono">scope.changes</span> loop.</p>
+      <div class="controls">
+        <button type="button" class="action" data-control="toggle">Start feed</button>
+        <button type="button" class="action" data-control="burst">Burst 10,000</button>
+      </div>
+    </header>
+    <div class="stats">
+      <div class="stat"><span class="stat-value" data-stat="pushes">0</span><span class="micro">updates pushed</span></div>
+      <div class="stat"><span class="stat-value" data-stat="recomputes">0</span><span class="micro">derived recomputes</span></div>
+      <div class="stat"><span class="stat-value" data-stat="paints">0</span><span class="micro">DOM paints</span></div>
+    </div>
+    <p class="readout" data-stat="readout">feed stopped — start it or fire a burst</p>
+    <p class="footnote">a 10,000-update synchronous burst lands as a handful of recomputes and paints — changes conflate to latest and derived atoms recompute glitch-free</p>
+  `
+  const toggle = root.querySelector<HTMLButtonElement>('[data-control="toggle"]')!
+  const burst = root.querySelector<HTMLButtonElement>('[data-control="burst"]')!
+  const field = (name: string) => root.querySelector<HTMLElement>(`[data-stat="${name}"]`)!
+  const pushed = field("pushes")
+  const recomputed = field("recomputes")
+  const painted = field("paints")
+  const readoutLine = field("readout")
+
+  let session: Session | null = null
+  let timer: number | null = null
+  let pushes = 0
+  let paints = 0
+  let phase = 0
+
+  const nextRandomSample = () => {
+    phase += 1
+    return 50 + Math.sin(phase / 9) * 24 + (Math.random() - 0.5) * 6
+  }
+
+  const openSession = async (): Promise<Session> => {
+    pushes = 0
+    paints = 0
+    pushed.textContent = "0"
+    recomputed.textContent = "0"
+    painted.textContent = "0"
+    const scope = createScope()
+    const feedCtrl = await scope.controller(feed, { resolve: true })
+    const recomputeCtrl = await scope.controller(recomputeCount, { resolve: true })
+    const painting = (async () => {
+      for await (const line of scope.changes(readout)) {
+        paints += 1
+        readoutLine.textContent = line
+        pushed.textContent = String(pushes)
+        recomputed.textContent = String(recomputeCtrl.get())
+        painted.textContent = String(paints)
+      }
+    })()
+    return {
+      push: () => {
+        pushes += 1
+        feedCtrl.set(nextRandomSample())
+      },
+      dispose: async () => {
+        await scope.dispose()
+        await painting
+      },
+    }
+  }
+
+  const ensureSession = async () => {
+    if (!session) session = await openSession()
+    return session
+  }
+
+  const startFeedTimer = (live: Session) => {
+    timer = window.setInterval(() => live.push(), 8)
+  }
+
+  const stopFeedTimer = () => {
+    if (timer !== null) window.clearInterval(timer)
+    timer = null
+  }
+
+  toggle.addEventListener("click", async () => {
+    if (timer !== null) {
+      stopFeedTimer()
+      toggle.textContent = "Start feed"
+      const closing = session
+      session = null
+      if (closing) await closing.dispose()
+      return
+    }
+    startFeedTimer(await ensureSession())
+    toggle.textContent = "Stop"
+  })
+
+  burst.addEventListener("click", async () => {
+    burst.disabled = true
+    const live = await ensureSession()
+    for (let i = 0; i < 10000; i += 1) live.push()
+    pushed.textContent = String(pushes)
+    burst.disabled = false
+  })
+}

--- a/playground/compare/sandbox/styles.css
+++ b/playground/compare/sandbox/styles.css
@@ -1,68 +1,369 @@
 :root {
-  color: #1f1f1f;
+  color: #171717;
   background: #ffffff;
-  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-family: ui-sans-serif, system-ui, sans-serif;
   color-scheme: light;
 }
 
 body {
   margin: 0;
-  padding: 24px;
+  padding: 28px 28px 48px;
   background: #ffffff;
+  line-height: 1.5;
 }
 
-#app > header p {
-  margin: 0 0 8px;
+button {
+  font: inherit;
+  cursor: pointer;
+}
+
+.micro {
+  margin: 0;
   color: #737373;
-  font-size: 0.7rem;
-  letter-spacing: 0.12em;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.14em;
   text-transform: uppercase;
 }
 
+.mono {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.86em;
+  background: #f5f5f5;
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.tabs {
+  display: flex;
+  gap: 6px;
+  margin: 0 0 28px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid #d4d4d4;
+}
+
+.tab {
+  padding: 6px 14px;
+  border: 1px solid #d4d4d4;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #525252;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.tab:hover {
+  border-color: #737373;
+  color: #171717;
+}
+
+.tab.is-active {
+  border-color: #171717;
+  background: #171717;
+  color: #ffffff;
+}
+
+.view-head {
+  margin-bottom: 28px;
+}
+
+.view-head .micro {
+  margin-bottom: 10px;
+}
+
 h1 {
-  margin: 0 0 24px;
-  font-family: ui-sans-serif, system-ui, sans-serif;
-  font-size: 1.5rem;
+  margin: 0 0 10px;
+  font-size: 1.45rem;
+  font-weight: 650;
+  letter-spacing: -0.015em;
 }
 
-.results {
+.lede {
+  margin: 0;
+  max-width: 58ch;
+  color: #525252;
+  font-size: 0.86rem;
+}
+
+.action {
+  margin-top: 18px;
+  padding: 9px 18px;
+  border: 1px solid #171717;
+  border-radius: 3px;
+  background: #171717;
+  color: #ffffff;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.action:hover {
+  background: #404040;
+  border-color: #404040;
+}
+
+.action:disabled {
+  background: #ffffff;
+  border-color: #d4d4d4;
+  color: #a3a3a3;
+  cursor: default;
+}
+
+.cards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 10px;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 12px;
+  margin-bottom: 36px;
 }
 
-article {
-  padding: 16px;
+.card {
+  padding: 16px 16px 14px;
+  border: 1px solid #d4d4d4;
+  border-radius: 4px;
+  background: #ffffff;
+}
+
+.card-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 14px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid #ededed;
+}
+
+h2 {
+  margin: 0;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.badge {
+  padding: 2px 8px;
+  border: 1px solid #a3a3a3;
+  border-radius: 999px;
+  color: #404040;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.62rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.figures {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 6px 12px;
+  margin: 0;
+  font-size: 0.72rem;
+}
+
+.figures dt {
+  color: #737373;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.66rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.figures dd {
+  margin: 0;
+  color: #171717;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.timeline {
+  max-width: 440px;
+  padding: 18px 20px;
   border: 1px solid #d4d4d4;
   border-radius: 4px;
   background: #fafafa;
 }
 
-article span {
-  display: inline-block;
+.timeline > .micro {
   margin-bottom: 16px;
-  padding: 4px 7px;
-  border: 1px solid #a3a3a3;
-  border-radius: 999px;
-  color: #404040;
-  font-size: 0.68rem;
 }
 
-h2 {
-  margin: 0 0 14px;
-  font-size: 1rem;
+.timeline-segment {
+  margin-bottom: 14px;
 }
 
-dl {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 7px;
+.timeline-segment:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-label {
+  margin: 0 0 6px;
+  color: #525252;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.64rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.timeline-rows {
   margin: 0;
+  padding: 0 0 0 6px;
+  list-style: none;
+  border-left: 1px solid #d4d4d4;
+}
+
+.timeline-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 2px 0 2px 8px;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.74rem;
+  color: #525252;
+}
+
+.timeline-index {
+  color: #a3a3a3;
+  font-size: 0.64rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.timeline-marker {
+  width: 1.1em;
+  text-align: center;
   color: #737373;
-  font-size: 0.7rem;
 }
 
-dd {
+.timeline-row.is-commit .timeline-marker,
+.timeline-row.is-acquire .timeline-marker,
+.timeline-row.is-release .timeline-marker {
+  color: #171717;
+}
+
+.timeline-row.is-commit,
+.timeline-row.is-insert {
+  color: #171717;
+  font-weight: 600;
+}
+
+.timeline-row.is-rollback,
+.timeline-row.is-duplicate {
+  color: #171717;
+}
+
+.timeline-row.is-rollback .timeline-name,
+.timeline-row.is-duplicate .timeline-name {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: #a3a3a3;
+}
+
+.bench {
+  display: grid;
+  gap: 12px;
+  max-width: 640px;
+  margin-bottom: 20px;
+}
+
+.bench-row {
+  display: grid;
+  grid-template-columns: 92px 1fr 132px;
+  align-items: center;
+  gap: 14px;
+}
+
+.bench-lane {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+  color: #404040;
+}
+
+.bench-track {
+  display: block;
+  height: 28px;
+  border-radius: 2px;
+  background: #f0f0f0;
+  overflow: hidden;
+}
+
+.bench-fill {
+  display: block;
+  width: 0%;
+  height: 100%;
+  background: #171717;
+  transition: width 0.25s ease;
+}
+
+.bench-value {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.72rem;
+  font-variant-numeric: tabular-nums;
+  color: #171717;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.footnote {
   margin: 0;
-  color: #262626;
+  max-width: 58ch;
+  color: #737373;
+  font-size: 0.74rem;
+}
+
+.controls {
+  display: flex;
+  gap: 10px;
+}
+
+.controls .action {
+  margin-top: 18px;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 180px));
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.stat {
+  display: grid;
+  gap: 6px;
+  padding: 16px;
+  border: 1px solid #d4d4d4;
+  border-radius: 4px;
+}
+
+.stat-value {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 1.7rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.02em;
+}
+
+.readout {
+  margin: 0 0 18px;
+  padding: 14px 16px;
+  max-width: 640px;
+  border: 1px solid #d4d4d4;
+  border-radius: 4px;
+  background: #fafafa;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+  color: #171717;
+}
+
+@media (max-width: 560px) {
+  .stats {
+    grid-template-columns: 1fr;
+  }
+
+  .bench-row {
+    grid-template-columns: 72px 1fr 110px;
+  }
 }

--- a/playground/compare/sandbox/throughput.ts
+++ b/playground/compare/sandbox/throughput.ts
@@ -1,0 +1,80 @@
+import type { Lane } from "../cases/account-onboarding/contract"
+import { runScenario } from "../cases/account-onboarding/scenario"
+
+const warmupRuns = 15
+const timedWindowMs = 300
+const batchSize = 5
+const opsFormat = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 })
+
+const nextTimerTick = () => new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+type Row = { fill: HTMLElement; value: HTMLElement }
+
+export function mountThroughput(root: HTMLElement, lanes: Lane[]) {
+  root.innerHTML = `
+    <header class="view-head">
+      <p class="micro">Full-scenario throughput</p>
+      <h1>Start · three provisions · close</h1>
+      <p class="lede">One run is the entire lifecycle: container start, three provisioning requests, teardown. ${warmupRuns} warm-up runs, then ~${timedWindowMs}ms of timed batches per lane.</p>
+      <button type="button" class="action">Run benchmark</button>
+    </header>
+    <div class="bench">
+      ${lanes.map((lane) => `
+        <div class="bench-row" data-lane="${lane.id}">
+          <span class="bench-lane">${lane.id}</span>
+          <span class="bench-track"><span class="bench-fill"></span></span>
+          <span class="bench-value">—</span>
+        </div>
+      `).join("")}
+    </div>
+    <p class="footnote">measured in this tab, on your machine — re-run any time</p>
+  `
+  const button = root.querySelector<HTMLButtonElement>(".action")!
+  const rows = new Map<Lane["id"], Row>(lanes.map((lane) => {
+    const row = root.querySelector<HTMLElement>(`.bench-row[data-lane="${lane.id}"]`)!
+    return [lane.id, {
+      fill: row.querySelector<HTMLElement>(".bench-fill")!,
+      value: row.querySelector<HTMLElement>(".bench-value")!,
+    }]
+  }))
+  const scores = new Map<Lane["id"], number>()
+
+  const rescale = () => {
+    const top = Math.max(...scores.values())
+    for (const [id, score] of scores) {
+      rows.get(id)!.fill.style.width = `${(score / top) * 100}%`
+    }
+  }
+
+  const measure = async (lane: Lane, row: Row) => {
+    row.value.textContent = "warming up"
+    for (let i = 0; i < warmupRuns; i += 1) await runScenario(lane)
+    let completed = 0
+    let timed = 0
+    while (timed < timedWindowMs) {
+      const batchStart = performance.now()
+      for (let i = 0; i < batchSize; i += 1) await runScenario(lane)
+      timed += performance.now() - batchStart
+      completed += batchSize
+      scores.set(lane.id, completed / (timed / 1000))
+      row.value.textContent = `${opsFormat.format(scores.get(lane.id)!)} ops/s…`
+      rescale()
+      await nextTimerTick()
+    }
+    row.value.textContent = `${opsFormat.format(scores.get(lane.id)!)} scenarios/s`
+  }
+
+  button.addEventListener("click", async () => {
+    button.disabled = true
+    button.textContent = "Running…"
+    scores.clear()
+    for (const row of rows.values()) {
+      row.fill.style.width = "0%"
+      row.value.textContent = "queued"
+    }
+    for (const lane of lanes) await measure(lane, rows.get(lane.id)!)
+    rescale()
+    button.disabled = false
+    button.textContent = "Run again"
+  })
+}

--- a/playground/compare/scripts/adapters/color-audit.check.mjs
+++ b/playground/compare/scripts/adapters/color-audit.check.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import test from "node:test"
-import { auditAuthoredSource } from "./color-audit.mjs"
+import { auditAuthoredSource, auditEditorTheme, editorSyntaxPalette } from "./color-audit.mjs"
 
 test("accepts grayscale authored colors", () => {
   assert.equal(auditAuthoredSource("a { color: #333; box-shadow: 0 1px rgb(9 9 9 / 0.2); }", "fixture.css"), 2)
@@ -16,4 +16,12 @@ test("rejects unsupported modern color syntax", () => {
 
 test("rejects unequal RGB channels", () => {
   assert.throws(() => auditAuthoredSource("a { color: rgb(1 2 1); }", "fixture.css"), /non-grayscale authored color/)
+})
+
+test("accepts palette and grayscale tokens in the editor theme", () => {
+  assert.equal(auditEditorTheme(`keyword: "${editorSyntaxPalette[0]}", plain: "#1f1f1f"`), 2)
+})
+
+test("rejects off-palette chromatic tokens in the editor theme", () => {
+  assert.throws(() => auditEditorTheme('keyword: "#ff8800"'), /non-grayscale authored color/)
 })

--- a/playground/compare/scripts/adapters/color-audit.mjs
+++ b/playground/compare/scripts/adapters/color-audit.mjs
@@ -7,6 +7,7 @@ const authoredFiles = [
   "src/styles.css",
   "sandbox/styles.css",
 ]
+export const editorSyntaxPalette = ["#cf222e", "#8250df", "#0550ae", "#116329", "#0a3069"]
 const unsupportedColorFunction = /\b(?:color|color-mix|hsl|hsla|hwb|lab|lch|oklab|oklch)\s*\(/gi
 const colorToken = /#[\da-fA-F]{3,8}\b|rgba?\([^)]*\)/g
 
@@ -41,7 +42,20 @@ export async function auditAuthoredGrayscale() {
     const source = await readFile(join(compareRoot, relativePath), "utf8")
     checkedColorCount += auditAuthoredSource(source, relativePath)
   }
+  checkedColorCount += auditEditorTheme(await readFile(join(compareRoot, "src/editor/code-theme.ts"), "utf8"))
   if (checkedColorCount === 0) throw new Error("authored grayscale audit found no color tokens")
+  return checkedColorCount
+}
+
+export function auditEditorTheme(source) {
+  const unsupported = [...source.matchAll(unsupportedColorFunction)].map(([match]) => match)
+  if (unsupported.length > 0) throw new Error(`unsupported editor theme color syntax: ${unsupported.join(", ")}`)
+  let checkedColorCount = 0
+  for (const [token] of source.matchAll(colorToken)) {
+    if (!editorSyntaxPalette.includes(token.toLowerCase())) assertGrayscale(token, "src/editor/code-theme.ts")
+    checkedColorCount += 1
+  }
+  if (checkedColorCount === 0) throw new Error("editor theme audit found no color tokens")
   return checkedColorCount
 }
 
@@ -57,6 +71,7 @@ export function auditAuthoredSource(source, relativePath) {
     for (const [, property, rawValue] of source.matchAll(/(?:^|[;{\n])\s*([\w-]+)\s*:\s*([^;{}]+);/g)) {
       if (property === "color-scheme" || !/(?:color|background|border|outline|shadow|fill|stroke)/i.test(property)) continue
       const remainder = rawValue
+        .replace(/!important/gi, " ")
         .replace(colorToken, " ")
         .replace(/-?\d*\.?\d+(?:px|rem|em|%|s|deg)?/gi, " ")
         .replace(/\b(?:solid|none|transparent|currentcolor|inherit|initial|unset|revert|inset|outset)\b/gi, " ")
@@ -65,23 +80,17 @@ export function auditAuthoredSource(source, relativePath) {
       if (remainder !== "") throw new Error(`unsupported authored color syntax in ${relativePath}: ${property}: ${rawValue.trim()}`)
     }
   }
-  if (relativePath === "src/app.tsx") {
-    const theme = source.match(/const grayscaleTheme = \{\s*colors:\s*\{([\s\S]*?)\n\s*},\s*syntax:\s*\{([\s\S]*?)\n\s*},\s*font:/)
-    if (!theme) throw new Error("grayscaleTheme colors and syntax blocks are missing")
-    for (const block of theme.slice(1)) {
-      for (const [, token] of block.matchAll(/"([^"]+)"/g)) {
-        if (token === "italic") continue
-        assertGrayscale(token, "src/app.tsx grayscaleTheme")
-      }
-    }
-  }
   return checkedColorCount
 }
 
 export async function auditComputedGrayscale(page) {
   const findings = []
+  const paletteRgb = editorSyntaxPalette.map((token) => {
+    const [red, green, blue] = hexChannels(token)
+    return `rgb(${red}, ${green}, ${blue})`
+  })
   for (const frame of page.frames()) {
-    findings.push(...await frame.evaluate(() => {
+    findings.push(...await frame.evaluate((syntaxPalette) => {
       const properties = [
         "background-color",
         "background-image",
@@ -102,11 +111,26 @@ export async function auditComputedGrayscale(page) {
       const unsupported = /\b(?:color|color-mix|hsl|hsla|hwb|lab|lch|oklab|oklch)\s*\(/i
       const rgb = /rgba?\(\s*(\d+(?:\.\d+)?)\s*(?:,|\s)\s*(\d+(?:\.\d+)?)\s*(?:,|\s)\s*(\d+(?:\.\d+)?)(?:\s*(?:,|\/)\s*[\d.]+)?\s*\)/g
       const localFindings = []
+      const syntaxProperties = new Set([
+        "color",
+        "caret-color",
+        "text-decoration-color",
+        "text-emphasis-color",
+        "border-bottom-color",
+        "border-left-color",
+        "border-right-color",
+        "border-top-color",
+        "column-rule-color",
+        "outline-color",
+      ])
       for (const element of document.querySelectorAll("*")) {
+        const isSyntaxToken = [...element.classList].some((name) => name.startsWith("sp-syntax-")) ||
+          element.closest?.('[class*="sp-syntax-"], .cm-tooltip') !== null
         for (const pseudo of [null, "::before", "::after"]) {
           const style = getComputedStyle(element, pseudo)
           for (const property of properties) {
             const value = style.getPropertyValue(property)
+            if (isSyntaxToken && syntaxProperties.has(property) && syntaxPalette.includes(value)) continue
             if (unsupported.test(value)) {
               localFindings.push(`${element.tagName}${pseudo ?? ""} ${property} unsupported ${value}`)
               continue
@@ -121,7 +145,7 @@ export async function auditComputedGrayscale(page) {
         }
       }
       return localFindings
-    }))
+    }, paletteRgb))
   }
   if (findings.length > 0) throw new Error(`computed non-grayscale colors\n${findings.join("\n")}`)
   return 0

--- a/playground/compare/src/app.tsx
+++ b/playground/compare/src/app.tsx
@@ -5,11 +5,20 @@ import {
   SandpackProvider,
   useSandpack,
 } from "@codesandbox/sandpack-react"
+import { useEffect } from "react"
+import { codeTheme } from "./editor/code-theme"
+import { useTypeIntel } from "./editor/type-intel"
 import { sandboxDependencies, sandboxFiles } from "./sandbox-files"
 
 type Dimension = "Build" | "Test" | "Operate"
 
 const dimensions: Dimension[] = ["Build", "Test", "Operate"]
+
+const dimensionLead: Record<Dimension, string> = {
+  Build: "How the object graph is declared and wired.",
+  Test: "How one dependency is replaced without patching a module.",
+  Operate: "How execution is observed without instrumenting call sites.",
+}
 
 const lanes = [
   {
@@ -96,44 +105,20 @@ const lanes = [
 
 const visibleFiles = lanes.flatMap((lane) => dimensions.map((dimension) => lane.files[dimension]))
 
-const grayscaleTheme = {
-  colors: {
-    surface1: "#ffffff",
-    surface2: "#f5f5f5",
-    surface3: "#e8e8e8",
-    disabled: "#a3a3a3",
-    base: "#1f1f1f",
-    clickable: "#404040",
-    hover: "#000000",
-    accent: "#000000",
-    error: "#242424",
-    errorSurface: "#eeeeee",
-    warning: "#3d3d3d",
-    warningSurface: "#f2f2f2",
-  },
-  syntax: {
-    plain: "#262626",
-    comment: { color: "#737373", fontStyle: "italic" },
-    keyword: "#000000",
-    definition: "#404040",
-    punctuation: "#525252",
-    property: "#171717",
-    tag: "#333333",
-    static: "#595959",
-    string: "#666666",
-  },
-  font: {
-    body: "ui-sans-serif, system-ui, sans-serif",
-    mono: "ui-monospace, SFMono-Regular, Consolas, monospace",
-    size: "14px",
-    lineHeight: "1.5",
-  },
-} as const
+const lineCounts = Object.fromEntries(
+  Object.entries(sandboxFiles).map(([path, source]) => [path, source.trimEnd().split("\n").length]),
+)
+
+function wireShortcutBoundary(handler: (event: KeyboardEvent) => void): () => void {
+  window.addEventListener("keydown", handler)
+  return () => window.removeEventListener("keydown", handler)
+}
 
 function Comparison() {
   const { sandpack } = useSandpack()
   const selectedLane = lanes.find((lane) => dimensions.some((item) => lane.files[item] === sandpack.activeFile))!
   const dimension = dimensions.find((item) => selectedLane.files[item] === sandpack.activeFile)!
+  const intel = useTypeIntel(sandpack.activeFile)
 
   function selectDimension(next: Dimension): void {
     sandpack.openFile(selectedLane.files[next])
@@ -143,27 +128,42 @@ function Comparison() {
     sandpack.openFile(lane.files[dimension])
   }
 
+  useEffect(() => {
+    return wireShortcutBoundary((event) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) return
+      if (event.target instanceof HTMLElement && event.target.closest(".cm-editor, input, textarea, select")) return
+      const next = dimensions[Number.parseInt(event.key, 10) - 1]
+      if (next) sandpack.openFile(selectedLane.files[next])
+    })
+  }, [sandpack, selectedLane])
+
   return (
     <>
       <section className="comparison" aria-label="Five lane comparison">
-        <div className="dimension-tabs" aria-label="Comparison dimension">
-          {dimensions.map((item) => (
-            <button
-              aria-pressed={dimension === item}
-              key={item}
-              onClick={() => selectDimension(item)}
-              type="button"
-            >
-              {item}
-            </button>
-          ))}
+        <div className="dimension-bar">
+          <div className="dimension-tabs" aria-label="Comparison dimension">
+            {dimensions.map((item) => (
+              <button
+                aria-pressed={dimension === item}
+                key={item}
+                onClick={() => selectDimension(item)}
+                type="button"
+              >
+                {item}
+              </button>
+            ))}
+          </div>
+          <p className="dimension-lead">{dimensionLead[dimension]}</p>
         </div>
         <div className="lane-grid">
           {lanes.map((lane) => (
             <article data-active={lane.id === selectedLane.id} key={lane.id}>
-              <button className="lane-name" onClick={() => selectLane(lane)} type="button">
-                {lane.label}
-              </button>
+              <div className="lane-head">
+                <button className="lane-name" onClick={() => selectLane(lane)} type="button">
+                  {lane.label}
+                </button>
+                <span className="lane-lines">{lineCounts[lane.files[dimension]]} lines</span>
+              </div>
               <p>{lane.values[dimension]}</p>
               <div className="lane-meta">
                 <code>{lane.files[dimension]}</code>
@@ -175,45 +175,85 @@ function Comparison() {
       </section>
 
       <section className="source-heading" aria-labelledby="source-title">
-        <h2 id="source-title">{dimension}: {selectedLane.label}</h2>
-        <code>{selectedLane.files[dimension]}</code>
+        <div>
+          <h2 id="source-title">{dimension}: {selectedLane.label}</h2>
+          <p className="source-hint">
+            Edit anything — the preview re-runs the shared contract. Hover a symbol for its inferred type,
+            Ctrl-Space completes, keys 1·2·3 switch dimension.
+          </p>
+        </div>
+        <div className="source-status">
+          <span className="intel-status" data-live={intel !== undefined}>
+            {intel === undefined ? "type intelligence warming" : "type intelligence live"}
+          </span>
+          <code>{selectedLane.files[dimension]}</code>
+        </div>
       </section>
+
+      <SandpackLayout>
+        <SandpackCodeEditor extensions={intel} key={sandpack.activeFile} showLineNumbers showTabs={false} />
+        <SandpackPreview showOpenInCodeSandbox={false} showRefreshButton />
+      </SandpackLayout>
     </>
   )
 }
 
 export function App() {
   return (
-    <main>
-      <header className="hero">
-        <h1>Build, test, and operate the same account workflow.</h1>
-        <p>Five checked-in implementations. Select a dimension, inspect its source, edit it, and run the shared contract.</p>
-        <dl className="contract-strip">
-          <div><dt>Request 1</dt><dd>success</dd></div>
-          <div><dt>Request 2</dt><dd>typed duplicate · rollback</dd></div>
-          <div><dt>Request 3</dt><dd>new actor · success</dd></div>
-          <div><dt>Database</dt><dd>one acquire · one release</dd></div>
-        </dl>
-      </header>
-      <section className="lab" aria-label="Executable dependency comparison">
-        <SandpackProvider
-          customSetup={{ dependencies: sandboxDependencies, entry: "/sandbox/main.ts" }}
-          files={sandboxFiles}
-          options={{
-            activeFile: "/cases/account-onboarding/lanes/pumped.ts",
-            initMode: "immediate",
-            visibleFiles,
-          }}
-          template="vanilla-ts"
-          theme={grayscaleTheme}
-        >
-          <Comparison />
-          <SandpackLayout>
-            <SandpackCodeEditor showLineNumbers />
-            <SandpackPreview showOpenInCodeSandbox={false} showRefreshButton />
-          </SandpackLayout>
-        </SandpackProvider>
-      </section>
-    </main>
+    <>
+      <nav className="topbar" aria-label="Site">
+        <a className="wordmark" href="https://github.com/pumped-fn/pumped-fn">
+          pumped-fn<span>/compare</span>
+        </a>
+        <div className="topbar-links">
+          <a href="https://www.npmjs.com/package/@pumped-fn/lite">npm</a>
+          <a href="https://github.com/pumped-fn/pumped-fn">GitHub</a>
+        </div>
+      </nav>
+      <main>
+        <header className="hero">
+          <h1>Build, test, and operate the same account workflow.</h1>
+          <p>
+            Five checked-in implementations of one contract — pumped-fn, Effect, Awilix, Inversify, and plain
+            TypeScript. Read each source with live type intelligence, edit it, and watch the shared lifecycle,
+            throughput, and reactivity proofs run in your browser.
+          </p>
+          <dl className="contract-strip">
+            <div><dt>Request 1</dt><dd>success</dd></div>
+            <div><dt>Request 2</dt><dd>typed duplicate · rollback</dd></div>
+            <div><dt>Request 3</dt><dd>new actor · success</dd></div>
+            <div><dt>Database</dt><dd>one acquire · one release</dd></div>
+          </dl>
+        </header>
+        <section className="lab" aria-label="Executable dependency comparison">
+          <SandpackProvider
+            customSetup={{ dependencies: sandboxDependencies, entry: "/sandbox/main.ts" }}
+            files={sandboxFiles}
+            options={{
+              activeFile: "/cases/account-onboarding/lanes/pumped.ts",
+              initMode: "immediate",
+              visibleFiles,
+            }}
+            template="vanilla-ts"
+            theme={codeTheme}
+          >
+            <Comparison />
+          </SandpackProvider>
+        </section>
+        <footer className="footer">
+          <p>
+            Same black-box contract, idiomatic internals. Sources are pinned in{" "}
+            <a href="https://github.com/pumped-fn/pumped-fn/blob/main/playground/compare/sources.lock.json">
+              sources.lock.json
+            </a>
+            ; benchmarks run in this tab, on your machine.
+          </p>
+          <div className="footer-links">
+            <a href="https://github.com/pumped-fn/pumped-fn">github.com/pumped-fn</a>
+            <a href="https://www.npmjs.com/package/@pumped-fn/lite">@pumped-fn/lite</a>
+          </div>
+        </footer>
+      </main>
+    </>
   )
 }

--- a/playground/compare/src/editor/code-theme.ts
+++ b/playground/compare/src/editor/code-theme.ts
@@ -1,0 +1,33 @@
+export const codeTheme = {
+  colors: {
+    surface1: "#ffffff",
+    surface2: "#f6f6f6",
+    surface3: "#ebebeb",
+    disabled: "#a3a3a3",
+    base: "#1f1f1f",
+    clickable: "#404040",
+    hover: "#000000",
+    accent: "#000000",
+    error: "#242424",
+    errorSurface: "#eeeeee",
+    warning: "#3d3d3d",
+    warningSurface: "#f2f2f2",
+  },
+  syntax: {
+    plain: "#1f1f1f",
+    comment: { color: "#737373", fontStyle: "italic" as const },
+    keyword: "#cf222e",
+    definition: "#8250df",
+    punctuation: "#525252",
+    property: "#0550ae",
+    tag: "#116329",
+    static: "#0550ae",
+    string: "#0a3069",
+  },
+  font: {
+    body: "Inter, ui-sans-serif, system-ui, sans-serif",
+    mono: "ui-monospace, SFMono-Regular, Consolas, monospace",
+    size: "13.5px",
+    lineHeight: "1.6",
+  },
+} as const

--- a/playground/compare/src/editor/editor-types.d.ts
+++ b/playground/compare/src/editor/editor-types.d.ts
@@ -1,0 +1,7 @@
+declare module "virtual:editor-types" {
+  const payload: {
+    libs: Record<string, string>
+    files: Record<string, string>
+  }
+  export default payload
+}

--- a/playground/compare/src/editor/type-intel.ts
+++ b/playground/compare/src/editor/type-intel.ts
@@ -1,0 +1,57 @@
+import { autocompletion } from "@codemirror/autocomplete"
+import type { Extension } from "@codemirror/state"
+import {
+  tsAutocompleteWorker,
+  tsFacetWorker,
+  tsHoverWorker,
+  tsLinterWorker,
+  tsSyncWorker,
+} from "@valtown/codemirror-ts"
+import type { WorkerShape } from "@valtown/codemirror-ts/worker"
+import * as Comlink from "comlink"
+import { useEffect, useMemo, useState } from "react"
+
+let workerPromise: Promise<WorkerShape> | undefined
+
+function startWorker(): Promise<WorkerShape> {
+  workerPromise ??= (async () => {
+    const proxy = Comlink.wrap<WorkerShape>(
+      new Worker(new URL("./worker.ts", import.meta.url), { type: "module" }),
+    )
+    await proxy.initialize()
+    return {
+      initialize: () => proxy.initialize(),
+      updateFile: (input: { path: string; code: string }) => proxy.updateFile(input),
+      getLints: (input: { path: string; diagnosticCodesToIgnore: number[] }) => proxy.getLints(input),
+      getAutocompletion: (input: Parameters<WorkerShape["getAutocompletion"]>[0]) => proxy.getAutocompletion(input),
+      getHover: (input: { path: string; pos: number }) => proxy.getHover(input),
+    } as WorkerShape
+  })()
+  return workerPromise
+}
+
+export function useTypeIntel(path: string): Extension[] | undefined {
+  const [worker, setWorker] = useState<WorkerShape>()
+  useEffect(() => {
+    let cancelled = false
+    const idle = requestIdleCallback(() => {
+      void startWorker().then((ready) => {
+        if (!cancelled) setWorker(() => ready)
+      })
+    }, { timeout: 2500 })
+    return () => {
+      cancelled = true
+      cancelIdleCallback(idle)
+    }
+  }, [])
+  return useMemo(() => {
+    if (worker === undefined) return undefined
+    return [
+      tsFacetWorker.of({ worker, path }),
+      tsSyncWorker(),
+      tsLinterWorker(),
+      autocompletion({ override: [tsAutocompleteWorker()] }),
+      tsHoverWorker(),
+    ]
+  }, [worker, path])
+}

--- a/playground/compare/src/editor/worker.ts
+++ b/playground/compare/src/editor/worker.ts
@@ -1,0 +1,30 @@
+import { createSystem, createVirtualTypeScriptEnvironment } from "@typescript/vfs"
+import { createWorker } from "@valtown/codemirror-ts/worker"
+import * as Comlink from "comlink"
+import ts from "typescript"
+import payload from "virtual:editor-types"
+import { sandboxFiles } from "../sandbox-files"
+
+Comlink.expose(
+  createWorker(async () => {
+    const fsMap = new Map<string, string>()
+    for (const [path, source] of Object.entries(payload.libs)) fsMap.set(path, source)
+    for (const [path, source] of Object.entries(payload.files)) fsMap.set(path, source)
+    const rootFiles: string[] = []
+    for (const [path, source] of Object.entries(sandboxFiles)) {
+      if (!path.endsWith(".ts")) continue
+      fsMap.set(path, source)
+      rootFiles.push(path)
+    }
+    return createVirtualTypeScriptEnvironment(createSystem(fsMap), rootFiles, ts, {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Bundler,
+      strict: true,
+      esModuleInterop: true,
+      experimentalDecorators: true,
+      emitDecoratorMetadata: true,
+      skipLibCheck: true,
+    })
+  }),
+)

--- a/playground/compare/src/sandbox-files.ts
+++ b/playground/compare/src/sandbox-files.ts
@@ -18,8 +18,11 @@ import testPlain from "../cases/account-onboarding/tests/plain.test.ts?raw"
 import testPumped from "../cases/account-onboarding/tests/pumped.test.ts?raw"
 import trace from "../cases/account-onboarding/trace.ts?raw"
 import index from "../sandbox/index.html?raw"
+import lifecycle from "../sandbox/lifecycle.ts?raw"
 import main from "../sandbox/main.ts?raw"
+import reactivity from "../sandbox/reactivity.ts?raw"
 import styles from "../sandbox/styles.css?raw"
+import throughput from "../sandbox/throughput.ts?raw"
 import tsconfig from "../sandbox/tsconfig.json?raw"
 
 export const sandboxFiles = {
@@ -44,8 +47,11 @@ export const sandboxFiles = {
   "/cases/account-onboarding/tests/plain.test.ts": testPlain,
   "/cases/account-onboarding/tests/pumped.test.ts": testPumped,
   "/cases/account-onboarding/trace.ts": trace,
+  "/sandbox/lifecycle.ts": lifecycle,
   "/sandbox/main.ts": main,
+  "/sandbox/reactivity.ts": reactivity,
   "/sandbox/styles.css": styles,
+  "/sandbox/throughput.ts": throughput,
 }
 
 export const sandboxDependencies = {

--- a/playground/compare/src/styles.css
+++ b/playground/compare/src/styles.css
@@ -4,6 +4,7 @@
   font-family: Inter, ui-sans-serif, system-ui, sans-serif;
   font-synthesis: none;
   color-scheme: light;
+  -webkit-font-smoothing: antialiased;
 }
 
 * {
@@ -20,10 +21,54 @@ a {
   color: inherit;
 }
 
+a {
+  text-underline-offset: 3px;
+  text-decoration-thickness: 1px;
+}
+
+:focus-visible {
+  outline: 2px solid #171717;
+  outline-offset: 2px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 24px;
+  border-bottom: 1px solid #e5e5e5;
+}
+
+.wordmark {
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.92rem;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.wordmark span {
+  color: #737373;
+  font-weight: 400;
+}
+
+.topbar-links {
+  display: flex;
+  gap: 20px;
+}
+
+.topbar-links a {
+  color: #525252;
+  font-size: 0.82rem;
+}
+
+.topbar-links a:hover {
+  color: #000000;
+}
+
 main {
   width: min(1440px, calc(100% - 48px));
   margin: 0 auto;
-  padding: 64px 0 96px;
+  padding: 56px 0 0;
 }
 
 .hero {
@@ -37,10 +82,11 @@ h1 {
   font-weight: 520;
   letter-spacing: -0.07em;
   line-height: 0.92;
+  text-wrap: balance;
 }
 
 .hero > p {
-  max-width: 690px;
+  max-width: 720px;
   margin: 28px 0 0;
   color: #525252;
   font-size: clamp(1rem, 1.8vw, 1.25rem);
@@ -83,13 +129,19 @@ h1 {
 }
 
 .comparison {
-  margin-bottom: 56px;
+  margin-bottom: 48px;
+}
+
+.dimension-bar {
+  display: flex;
+  align-items: baseline;
+  gap: 20px;
+  margin-bottom: 18px;
 }
 
 .dimension-tabs {
   display: flex;
   gap: 8px;
-  margin-bottom: 18px;
 }
 
 .dimension-tabs button {
@@ -101,12 +153,23 @@ h1 {
   font: inherit;
   font-size: 0.86rem;
   font-weight: 650;
+  transition: border-color 120ms ease, background-color 120ms ease, color 120ms ease;
+}
+
+.dimension-tabs button:hover {
+  border-color: #171717;
 }
 
 .dimension-tabs button[aria-pressed="true"] {
   border-color: #171717;
   background: #171717;
   color: #ffffff;
+}
+
+.dimension-lead {
+  margin: 0;
+  color: #737373;
+  font-size: 0.88rem;
 }
 
 .lane-grid {
@@ -119,19 +182,31 @@ h1 {
 .lane-grid article {
   display: grid;
   grid-template-rows: auto 1fr auto;
-  min-height: 250px;
+  min-height: 240px;
   padding: 20px;
   border-left: 1px solid #d4d4d4;
   background: #ffffff;
+  transition: background-color 120ms ease;
 }
 
 .lane-grid article:first-child {
   border-left: 0;
 }
 
+.lane-grid article:hover {
+  background: #fafafa;
+}
+
 .lane-grid article[data-active="true"] {
   background: #f5f5f5;
   box-shadow: inset 0 3px #171717;
+}
+
+.lane-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
 }
 
 .lane-name {
@@ -145,8 +220,20 @@ h1 {
   font-weight: 700;
 }
 
+.lane-name:hover {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+}
+
+.lane-lines {
+  color: #a3a3a3;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.68rem;
+  white-space: nowrap;
+}
+
 .lane-grid article > p {
-  margin: 24px 0;
+  margin: 22px 0;
   color: #404040;
   font-size: 0.86rem;
   line-height: 1.55;
@@ -158,7 +245,7 @@ h1 {
 }
 
 .lane-meta code,
-.source-heading code {
+.source-status code {
   color: #737373;
   font-size: 0.68rem;
   line-height: 1.4;
@@ -169,12 +256,11 @@ h1 {
   width: max-content;
   color: #525252;
   font-size: 0.7rem;
-  text-underline-offset: 3px;
 }
 
 .source-heading {
   display: flex;
-  align-items: baseline;
+  align-items: flex-end;
   justify-content: space-between;
   gap: 24px;
   margin-bottom: 16px;
@@ -186,8 +272,62 @@ h1 {
   letter-spacing: -0.035em;
 }
 
+.source-hint {
+  margin: 8px 0 0;
+  max-width: 640px;
+  color: #737373;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.source-status {
+  display: grid;
+  justify-items: end;
+  gap: 6px;
+  text-align: right;
+}
+
+.intel-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  color: #737373;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.intel-status::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: #a3a3a3;
+  animation: intel-pulse 1.4s ease-in-out infinite;
+}
+
+.intel-status[data-live="true"] {
+  color: #171717;
+}
+
+.intel-status[data-live="true"]::before {
+  background: #171717;
+  animation: none;
+}
+
+@keyframes intel-pulse {
+  0%, 100% {
+    opacity: 0.35;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
 .sp-layout {
-  min-height: 620px;
+  min-height: 680px;
   border: 1px solid #a3a3a3;
   border-radius: 2px;
   overflow: hidden;
@@ -201,13 +341,88 @@ h1 {
 .sp-layout > .sp-stack,
 .sp-preview-container,
 .sp-preview-iframe {
-  height: 620px !important;
+  height: 680px !important;
+}
+
+.cm-tooltip {
+  max-width: min(560px, 80vw);
+  border: 1px solid #a3a3a3 !important;
+  border-radius: 2px;
+  background: #ffffff !important;
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.12);
+  color: #171717;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.76rem;
+  line-height: 1.5;
+}
+
+.cm-tooltip-hover {
+  padding: 8px 10px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected] {
+  background: #171717 !important;
+  color: #ffffff !important;
+}
+
+.footer {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-top: 64px;
+  padding: 24px 0 48px;
+  border-top: 1px solid #e5e5e5;
+}
+
+.footer p {
+  max-width: 640px;
+  margin: 0;
+  color: #737373;
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.footer-links {
+  display: grid;
+  justify-items: end;
+  gap: 8px;
+}
+
+.footer-links a {
+  color: #525252;
+  font-family: ui-monospace, "SFMono-Regular", Consolas, monospace;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 980px) {
+  .dimension-bar {
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .source-heading {
+    display: grid;
+    gap: 10px;
+  }
+
+  .source-status {
+    justify-items: start;
+    text-align: left;
+  }
 }
 
 @media (max-width: 760px) {
   main {
     width: min(100% - 24px, 1440px);
     padding-top: 32px;
+  }
+
+  .topbar {
+    padding: 12px 14px;
   }
 
   .hero {
@@ -238,6 +453,7 @@ h1 {
     border: 1px solid #e5e5e5;
     border-radius: 999px;
     background: #ffffff;
+    width: 100%;
   }
 
   .dimension-tabs button {
@@ -259,19 +475,23 @@ h1 {
     border-top: 0;
   }
 
-  .source-heading {
-    display: grid;
-    gap: 8px;
-  }
-
   .sp-layout {
     display: grid !important;
-    min-height: 1040px;
+    min-height: 1080px;
   }
 
   .sp-layout > .sp-stack,
   .sp-preview-container,
   .sp-preview-iframe {
-    height: 520px !important;
+    height: 540px !important;
+  }
+
+  .footer {
+    display: grid;
+    justify-items: start;
+  }
+
+  .footer-links {
+    justify-items: start;
   }
 }

--- a/playground/compare/vite.config.ts
+++ b/playground/compare/vite.config.ts
@@ -1,16 +1,95 @@
 import react from "@vitejs/plugin-react"
+import { readFileSync, readdirSync, realpathSync, statSync } from "node:fs"
+import { dirname, join, relative } from "node:path"
 import { fileURLToPath } from "node:url"
-import { defineConfig } from "vite"
+import { defineConfig, type Plugin } from "vite"
+
+const compareDir = dirname(fileURLToPath(import.meta.url))
+const liteDir = join(compareDir, "../../pkg/core/lite")
+const excludedLibs = /^lib\.(webworker|scripthost)/
+
+function resolvePackageDir(name: string, fromDir: string): string {
+  let dir = fromDir
+  while (true) {
+    const candidate = join(dir, "node_modules", name)
+    try {
+      statSync(join(candidate, "package.json"))
+      return realpathSync(candidate)
+    } catch {
+      const parent = dirname(dir)
+      if (parent === dir) throw new Error(`cannot resolve ${name} from ${fromDir}`)
+      dir = parent
+    }
+  }
+}
+
+function collectPackage(files: Record<string, string>, name: string, packageDir: string): void {
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        if (entry !== "node_modules") walk(full)
+      } else if (/\.d\.(ts|mts|cts)$/.test(entry) || entry === "package.json") {
+        files[`/node_modules/${name}/${relative(packageDir, full).replaceAll("\\", "/")}`] = readFileSync(full, "utf8")
+      }
+    }
+  }
+  walk(packageDir)
+}
+
+function buildEditorTypesPayload(): string {
+  const libs: Record<string, string> = {}
+  const typescriptLib = dirname(resolvePackageDir("typescript", compareDir)) + "/typescript/lib"
+  for (const entry of readdirSync(typescriptLib)) {
+    if (entry.startsWith("lib.") && entry.endsWith(".d.ts") && !excludedLibs.test(entry)) {
+      libs[`/${entry}`] = readFileSync(join(typescriptLib, entry), "utf8")
+    }
+  }
+  const files: Record<string, string> = {}
+  for (const name of ["effect", "awilix", "inversify", "reflect-metadata"]) {
+    collectPackage(files, name, resolvePackageDir(name, compareDir))
+  }
+  const vitestDir = resolvePackageDir("vitest", compareDir)
+  collectPackage(files, "vitest", vitestDir)
+  for (const name of ["@vitest/expect", "@vitest/runner", "@vitest/spy", "@vitest/utils"]) {
+    collectPackage(files, name, resolvePackageDir(name, vitestDir))
+  }
+  files["/node_modules/@pumped-fn/lite/package.json"] = readFileSync(join(liteDir, "package.json"), "utf8")
+  files["/node_modules/@pumped-fn/lite/dist/index.d.mts"] = readFileSync(join(liteDir, "dist/index.d.mts"), "utf8")
+  files["/node_modules/@pumped-fn/lite/dist/index.d.cts"] = readFileSync(join(liteDir, "dist/index.d.cts"), "utf8")
+  return JSON.stringify({ libs, files })
+}
+
+function editorTypes(): Plugin {
+  const virtualId = "virtual:editor-types"
+  const resolvedId = `\0${virtualId}`
+  let payload: string | undefined
+  return {
+    name: "compare-editor-types",
+    resolveId(id) {
+      return id === virtualId ? resolvedId : undefined
+    },
+    load(id) {
+      if (id !== resolvedId) return undefined
+      payload ??= buildEditorTypesPayload()
+      return `export default ${payload}`
+    },
+  }
+}
 
 export default defineConfig({
   base: process.env.PUMPED_COMPARE_BASE_PATH ?? "/",
-  plugins: [react()],
+  plugins: [react(), editorTypes()],
   resolve: {
     alias: {
-      "@pumped-fn/lite": fileURLToPath(new URL("../../pkg/core/lite/src/index.ts", import.meta.url)),
+      "@pumped-fn/lite": join(liteDir, "src/index.ts"),
     },
   },
   server: {
     port: 4178,
+  },
+  worker: {
+    format: "es",
+    plugins: () => [editorTypes()],
   },
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,12 @@ settings:
 
 catalogs:
   default:
+    '@agentclientprotocol/codex-acp':
+      specifier: 1.1.0
+      version: 1.1.0
+    '@agentclientprotocol/sdk':
+      specifier: 1.2.1
+      version: 1.2.1
     '@changesets/changelog-github':
       specifier: 0.7.0
       version: 0.7.0
@@ -15,6 +21,9 @@ catalogs:
     '@codesandbox/sandpack-react':
       specifier: 2.20.0
       version: 2.20.0
+    '@earendil-works/pi-ai':
+      specifier: 0.80.3
+      version: 0.80.3
     '@electric-sql/pglite':
       specifier: 0.3.14
       version: 0.3.14
@@ -903,6 +912,13 @@ importers:
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/sdk/codex:
+    dependencies:
+      '@agentclientprotocol/codex-acp':
+        specifier: 'catalog:'
+        version: 1.1.0
+      '@agentclientprotocol/sdk':
+        specifier: 'catalog:'
+        version: 1.2.1(zod@4.4.3)
     devDependencies:
       '@pumped-fn/lite':
         specifier: workspace:*
@@ -956,6 +972,37 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
+  pkg/sdk/pi:
+    dependencies:
+      '@earendil-works/pi-ai':
+        specifier: 'catalog:'
+        version: 0.80.3(ws@8.21.0)(zod@4.4.3)
+    devDependencies:
+      '@pumped-fn/lite':
+        specifier: workspace:*
+        version: link:../../core/lite
+      '@pumped-fn/sdk':
+        specifier: workspace:*
+        version: link:../core
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.9.1
+      '@typescript/native-preview':
+        specifier: 'catalog:'
+        version: 7.0.0-dev.20260526.1
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   pkg/sdk/test:
     dependencies:
@@ -1092,6 +1139,24 @@ packages:
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
 
+  '@agentclientprotocol/codex-acp@1.1.0':
+    resolution: {integrity: sha512-EdUwW6n12yy4khxS6YpOgT8dd4JbVeOP8qPLdCEj795kp85qVI6369EWUXHq1CrnvOmGVwieUMvnrMlsqJaRWg==}
+    hasBin: true
+
+  '@agentclientprotocol/sdk@1.2.1':
+    resolution: {integrity: sha512-jwYUdOQR7tc+Zfch53VL4JJyUNK/46q03uUTYb+PjECsmnNl94XFXOfYLJ8RBpMNidXd1rpOAVgb0vqD98xImA==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@asamuzakjp/css-color@5.1.11':
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -1106,6 +1171,103 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.28':
+    resolution: {integrity: sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.54':
+    resolution: {integrity: sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.56':
+    resolution: {integrity: sha512-PiwHgEK2srdfi/lFveyQ+3w/qikyh6MKvuZAdlMC+dwQi4K5iVBr32oh7cugnYw+jA8iGtnQMhCGvLm/mqplmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.61':
+    resolution: {integrity: sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.60':
+    resolution: {integrity: sha512-Ak6OOrCbXvACyxLFIP1mcS+JTLS9ZpW1ZqyBtqu6axvdpsbG1gVNhUlAfQq8TK/gar/h2w35LrzlQU0PcUzJpw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.63':
+    resolution: {integrity: sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.54':
+    resolution: {integrity: sha512-UNmUjtTnp3wH3YTZcctN7yK17S2AdaJpiNIdIf0l70hHOdGuDfdMxk62P5rt64GwGm6qkFOYG0js/cU6cdZDdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.60':
+    resolution: {integrity: sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.60':
+    resolution: {integrity: sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.25':
+    resolution: {integrity: sha512-df7HN1ozwMrB9+59re9PM7tSLxLAcheMWc5u/KyfCPCAWtN/vP7y7RTUZOy48uT1K9MESisVeOPPzF3O1AW01A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.21':
+    resolution: {integrity: sha512-HvLgDnxBLaHi9E5K++6Vuk+1+qqn7Pmn8zrlzd+NXH3jBzwujnuzZtAR9WHPkbUGPO92FkoQWj/M1IsdxTlBmQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.36':
+    resolution: {integrity: sha512-BD8tYKNAc8dyN7q4NU1wsA1ZgRTBAjbqH04I5SfoqJaOmwlUab6AI7GRapSt8fxf9sq3GyAhioK0qHLCTnuZ9A==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.28':
+    resolution: {integrity: sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1080.0':
+    resolution: {integrity: sha512-8PufAQvncWXvdZUvODbuyXa8l3aszefEzwSMBUcgheNbZOmJMcNn388Ebt/piVrUHyxKN1MlxnR2OonzTyZaGw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.15':
+    resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.33':
+    resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1471,6 +1633,11 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
+  '@earendil-works/pi-ai@0.80.3':
+    resolution: {integrity: sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
   '@electric-sql/pglite@0.3.14':
     resolution: {integrity: sha512-3DB258dhqdsArOI1fIt7cb9RpUOgcDg5hXWVgVHAeqVQ/qxtFy605QKs4gx6mFq3jWsSPqDN8TgSEsqC3OfV9Q==}
 
@@ -1656,6 +1823,15 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hono/node-server@2.0.6':
     resolution: {integrity: sha512-7DeRlKG57JDBNZ5Qj2jwVdgwQy4b0tLubRLl3zCf91/rCf9i7p1V5FtW/yWibm1uUHE493ts9ZXH/7g/LQWl+g==}
     engines: {node: '>=20'}
@@ -1760,6 +1936,14 @@ packages:
   '@marijn/find-cluster-break@1.0.2':
     resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
+  '@mistralai/mistralai@2.2.6':
+    resolution: {integrity: sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
@@ -1828,9 +2012,58 @@ packages:
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
+  '@openai/codex@0.142.5':
+    resolution: {integrity: sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.142.5-darwin-arm64':
+    resolution: {integrity: sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.142.5-darwin-x64':
+    resolution: {integrity: sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.142.5-linux-arm64':
+    resolution: {integrity: sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.142.5-linux-x64':
+    resolution: {integrity: sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.142.5-win32-arm64':
+    resolution: {integrity: sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.142.5-win32-x64':
+    resolution: {integrity: sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/semantic-conventions@1.42.0':
+    resolution: {integrity: sha512-icc5xCzndZfhuJMy5oqk5AvloWquR7jtae74qzpkKkhGp8BivK+oCcEXgGnjCdTfp8hA44l+w8gE8yYJbocJJw==}
+    engines: {node: '>=14'}
 
   '@oxc-project/types@0.132.0':
     resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
@@ -1840,6 +2073,36 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.1':
+    resolution: {integrity: sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==}
+
+  '@protobufjs/fetch@1.1.1':
+    resolution: {integrity: sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.2':
+    resolution: {integrity: sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.2':
+    resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -1951,6 +2214,46 @@ packages:
 
   '@rolldown/pluginutils@1.0.1':
     resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@smithy/core@3.29.1':
+    resolution: {integrity: sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.6':
+    resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.3':
+    resolution: {integrity: sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.3':
+    resolution: {integrity: sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.2':
+    resolution: {integrity: sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.15.1':
+    resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -2159,6 +2462,9 @@ packages:
   '@types/react@19.2.15':
     resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/whatwg-mimetype@3.0.2':
     resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
 
@@ -2283,6 +2589,10 @@ packages:
     resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
     engines: {node: '>=12.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   anser@2.3.5:
     resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
 
@@ -2364,11 +2674,17 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@5.0.6:
     resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
@@ -2383,6 +2699,9 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
@@ -2391,6 +2710,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
 
   cac@7.0.0:
     resolution: {integrity: sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==}
@@ -2462,6 +2785,10 @@ packages:
     resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
     engines: {node: '>=0.12'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
@@ -2489,6 +2816,18 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -2506,6 +2845,10 @@ packages:
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dir-glob@3.0.1:
@@ -2631,6 +2974,9 @@ packages:
       oxc-resolver:
         optional: true
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   effect@3.21.3:
     resolution: {integrity: sha512-RqwU7WnJ6CqYhyjpOVJA5vh1Sgkn6eVECO6mnD0EjlbWcC2M3LJaPglXXr13Rdo/Y+B+wTEPzGRYFNL2xKxNeQ==}
 
@@ -2716,6 +3062,9 @@ packages:
   ext@1.7.0:
     resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
@@ -2746,6 +3095,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fetchdts@0.1.7:
     resolution: {integrity: sha512-YoZjBdafyLIop9lSxXVI33oLD5kN31q4Td+CasofLLYeLXRFeOsuOw0Uo+XNRi9PZlbfdlN2GmRtm4tCEQ9/KA==}
 
@@ -2773,6 +3126,10 @@ packages:
     resolution: {integrity: sha512-ayvpVFL/wibphkhjaz6PwL/F+Vz9lZB7qwFIHvsFiPQMfKmrqRXp1UyJgxMqyanW6QQDvsB12MLWFCc2cYBOtw==}
     engines: {node: '>=0.4.0'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
@@ -2793,6 +3150,14 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  gaxios@7.1.6:
+    resolution: {integrity: sha512-aIQ0QL8Or8vsUhHyXGA6AohOFRrAAiHhrvsAG6myzcSlfhxSXtnwXA/pRuQTilFgjhLe30swK5rg1d7E1f8Izw==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2820,6 +3185,14 @@ packages:
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  google-auth-library@10.9.0:
+    resolution: {integrity: sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2855,6 +3228,14 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -2900,6 +3281,11 @@ packages:
   inversify@8.1.2:
     resolution: {integrity: sha512-iTKz3FysgfL3X6CsVzixdJ8UZCcPk49EqSspl+PXsds+TtAdlIEQHMGDqNal+R3zNIk+WtP4ct2Wg44HgJDvLQ==}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2907,6 +3293,15 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-in-ssh@1.0.0:
+    resolution: {integrity: sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==}
+    engines: {node: '>=20'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -2929,6 +3324,10 @@ packages:
   is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isbot@5.1.43:
     resolution: {integrity: sha512-drJhFmibra4LO6Wd7D3Oi6UICRK9244vSZkmxzhlZP0TTdwCA2ueK4PEkUkzPYeuqug9+cqqdWPgihjk5+83Cg==}
@@ -2991,6 +3390,13 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -3002,6 +3408,12 @@ packages:
   just-bash@3.0.2:
     resolution: {integrity: sha512-uY8LMD2NpADp1HlYUcZSw9ffuq0tRhW76sg8xkeo+ZRDMu7mbekWbKbYDWquazVVi7pqpGZlic/liMFktQKy6w==}
     hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
@@ -3091,6 +3503,9 @@ packages:
 
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   lru-cache@11.4.0:
     resolution: {integrity: sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==}
@@ -3195,6 +3610,11 @@ packages:
     resolution: {integrity: sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==}
     engines: {node: ^18 || ^20 || >= 21}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
     engines: {node: 4.x || >=6.0.0}
@@ -3203,6 +3623,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
@@ -3226,6 +3650,22 @@ packages:
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  open@11.0.0:
+    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+    engines: {node: '>=20'}
+
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: 8.21.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -3253,6 +3693,10 @@ packages:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
     engines: {node: '>=6'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
@@ -3265,6 +3709,9 @@ packages:
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -3390,6 +3837,10 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  powershell-utils@0.1.0:
+    resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
@@ -3412,6 +3863,10 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+    engines: {node: '>=12.0.0'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -3505,6 +3960,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3535,6 +3994,10 @@ packages:
 
   rou3@0.8.1:
     resolution: {integrity: sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA==}
+
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3779,6 +4242,9 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
+
   tsdown@0.22.0:
     resolution: {integrity: sha512-FgW0hHb27nGQA/+F3d5+U9wKXkfilk9DVkc5+7x/ZqF03g+Hoz/eeApT32jqxATt9eRoR+1jxk7MUMON+O4CXw==}
     engines: {node: ^22.18.0 || >=24.0.0}
@@ -3833,6 +4299,9 @@ packages:
 
   type@2.7.3:
     resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
+
+  typebox@1.1.38:
+    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -3980,12 +4449,20 @@ packages:
       jsdom:
         optional: true
 
+  vscode-jsonrpc@9.0.1:
+    resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
+    engines: {node: '>=14.0.0'}
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -4041,6 +4518,10 @@ packages:
       utf-8-validate:
         optional: true
 
+  wsl-utils@0.3.1:
+    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+    engines: {node: '>=20'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -4072,6 +4553,11 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -4081,6 +4567,25 @@ packages:
 snapshots:
 
   '@adobe/css-tools@4.5.0': {}
+
+  '@agentclientprotocol/codex-acp@1.1.0':
+    dependencies:
+      '@agentclientprotocol/sdk': 1.2.1(zod@4.4.3)
+      '@openai/codex': 0.142.5
+      diff: 9.0.0
+      open: 11.0.0
+      vscode-jsonrpc: 9.0.1
+      zod: 4.4.3
+
+  '@agentclientprotocol/sdk@1.2.1(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
+  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
 
   '@asamuzakjp/css-color@5.1.11':
     dependencies:
@@ -4105,6 +4610,220 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9':
     optional: true
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/util-locate-window': 3.965.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.15
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/credential-provider-node': 3.972.63
+      '@aws-sdk/eventstream-handler-node': 3.972.25
+      '@aws-sdk/middleware-eventstream': 3.972.21
+      '@aws-sdk/middleware-websocket': 3.972.36
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.974.28':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@aws-sdk/xml-builder': 3.972.33
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.1
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.56':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/credential-provider-env': 3.972.54
+      '@aws-sdk/credential-provider-http': 3.972.56
+      '@aws-sdk/credential-provider-login': 3.972.60
+      '@aws-sdk/credential-provider-process': 3.972.54
+      '@aws-sdk/credential-provider-sso': 3.972.60
+      '@aws-sdk/credential-provider-web-identity': 3.972.60
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.63':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.54
+      '@aws-sdk/credential-provider-http': 3.972.56
+      '@aws-sdk/credential-provider-ini': 3.972.61
+      '@aws-sdk/credential-provider-process': 3.972.54
+      '@aws-sdk/credential-provider-sso': 3.972.60
+      '@aws-sdk/credential-provider-web-identity': 3.972.60
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/credential-provider-imds': 4.4.6
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.54':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/token-providers': 3.1080.0
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.60':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.25':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.21':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.28':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/signature-v4-multi-region': 3.996.38
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/fetch-http-handler': 5.6.3
+      '@smithy/node-http-handler': 4.9.3
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.38':
+    dependencies:
+      '@aws-sdk/types': 3.973.15
+      '@smithy/signature-v4': 5.6.2
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1080.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.28
+      '@aws-sdk/nested-clients': 3.997.28
+      '@aws-sdk/types': 3.973.15
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.15':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.8':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.33':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -4691,6 +5410,27 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
+  '@earendil-works/pi-ai@0.80.3(ws@8.21.0)(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@google/genai': 1.52.0
+      '@mistralai/mistralai': 2.2.6(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.26.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
+      typebox: 1.1.38
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
   '@electric-sql/pglite@0.3.14': {}
 
   '@emnapi/core@1.10.0':
@@ -4799,6 +5539,17 @@ snapshots:
 
   '@exodus/bytes@1.15.0':
     optional: true
+
+  '@google/genai@1.52.0':
+    dependencies:
+      google-auth-library: 10.9.0
+      p-retry: 4.6.2
+      protobufjs: 7.5.5
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   '@hono/node-server@2.0.6(hono@4.12.27)':
     dependencies:
@@ -4930,6 +5681,18 @@ snapshots:
 
   '@marijn/find-cluster-break@1.0.2': {}
 
+  '@mistralai/mistralai@2.2.6(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.42.0
+      ws: 8.21.0
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@mixmark-io/domino@2.2.0': {}
 
   '@mongodb-js/zstd@7.0.0':
@@ -5004,13 +5767,66 @@ snapshots:
 
   '@open-draft/deferred-promise@2.2.0': {}
 
+  '@openai/codex@0.142.5':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.142.5-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.142.5-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.142.5-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.142.5-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.142.5-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.142.5-win32-x64'
+
+  '@openai/codex@0.142.5-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.142.5-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.142.5-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.142.5-linux-x64':
+    optional: true
+
+  '@openai/codex@0.142.5-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.142.5-win32-x64':
+    optional: true
+
+  '@opentelemetry/api@1.9.0': {}
+
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/semantic-conventions@1.42.0': {}
 
   '@oxc-project/types@0.132.0': {}
 
   '@pinojs/redact@0.4.0': {}
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.1': {}
+
+  '@protobufjs/fetch@1.1.1':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.2': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.2': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -5076,6 +5892,59 @@ snapshots:
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
+
+  '@smithy/core@3.29.1':
+    dependencies:
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.6':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.3':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.2':
+    dependencies:
+      '@smithy/core': 3.29.1
+      '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5353,6 +6222,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/whatwg-mimetype@3.0.2':
     optional: true
 
@@ -5488,6 +6359,8 @@ snapshots:
 
   adm-zip@0.5.17: {}
 
+  agent-base@7.1.4: {}
+
   anser@2.3.5: {}
 
   ansi-colors@4.1.3: {}
@@ -5558,6 +6431,8 @@ snapshots:
       require-from-string: 2.0.2
     optional: true
 
+  bignumber.js@9.3.1: {}
+
   birpc@4.0.0: {}
 
   bl@4.1.0:
@@ -5566,6 +6441,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
     optional: true
+
+  bowser@2.14.1: {}
 
   brace-expansion@5.0.6:
     dependencies:
@@ -5583,6 +6460,8 @@ snapshots:
       node-releases: 2.0.46
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer-equal-constant-time@1.0.1: {}
+
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -5595,6 +6474,10 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
 
   cac@7.0.0: {}
 
@@ -5654,6 +6537,8 @@ snapshots:
       es5-ext: 0.10.64
       type: 2.7.3
 
+  data-uri-to-buffer@4.0.1: {}
+
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
@@ -5679,6 +6564,15 @@ snapshots:
   deep-extend@0.6.0:
     optional: true
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
+  define-lazy-prop@3.0.0: {}
+
   defu@6.1.7: {}
 
   dequal@2.0.3: {}
@@ -5688,6 +6582,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   diff@8.0.4: {}
+
+  diff@9.0.0: {}
 
   dir-glob@3.0.1:
     dependencies:
@@ -5719,6 +6615,10 @@ snapshots:
       sql.js: 1.14.1
 
   dts-resolver@3.0.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   effect@3.21.3:
     dependencies:
@@ -5834,6 +6734,8 @@ snapshots:
     dependencies:
       type: 2.7.3
 
+  extend@3.0.2: {}
+
   extendable-error@0.1.7: {}
 
   fast-check@3.23.2:
@@ -5870,6 +6772,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fetchdts@0.1.7: {}
 
   file-type@21.3.4:
@@ -5902,6 +6809,10 @@ snapshots:
 
   flow-parser@0.314.0: {}
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fs-constants@1.0.0:
     optional: true
 
@@ -5922,6 +6833,22 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  gaxios@7.1.6:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.6
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -5953,6 +6880,19 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  google-auth-library@10.9.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.6
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   graceful-fs@4.2.11: {}
 
@@ -5989,6 +6929,20 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   human-id@4.1.3: {}
 
   iconv-lite@0.7.2:
@@ -6023,11 +6977,19 @@ snapshots:
     transitivePeerDependencies:
       - reflect-metadata
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-in-ssh@1.0.0: {}
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-number@7.0.0: {}
 
@@ -6045,6 +7007,10 @@ snapshots:
   is-unsafe@1.0.1: {}
 
   is-windows@1.0.2: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isbot@5.1.43: {}
 
@@ -6127,6 +7093,15 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      ts-algebra: 2.0.0
+
   json5@2.2.3: {}
 
   jsonfile@4.0.0:
@@ -6155,6 +7130,17 @@ snapshots:
       node-liblzma: 2.2.0
     transitivePeerDependencies:
       - supports-color
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   kind-of@6.0.3: {}
 
@@ -6217,6 +7203,8 @@ snapshots:
       p-locate: 4.1.0
 
   lodash.startcase@4.4.0: {}
+
+  long@5.3.2: {}
 
   lru-cache@11.4.0:
     optional: true
@@ -6304,9 +7292,17 @@ snapshots:
   node-addon-api@8.8.0:
     optional: true
 
+  node-domexception@1.0.0: {}
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp-build@4.8.4:
     optional: true
@@ -6327,6 +7323,20 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
     optional: true
+
+  open@11.0.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-in-ssh: 1.0.0
+      is-inside-container: 1.0.0
+      powershell-utils: 0.1.0
+      wsl-utils: 0.3.1
+
+  openai@6.26.0(ws@8.21.0)(zod@4.4.3):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.4.3
 
   outdent@0.5.0: {}
 
@@ -6350,6 +7360,11 @@ snapshots:
 
   p-map@2.1.0: {}
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   p-try@2.2.0: {}
 
   package-manager-detector@0.2.11:
@@ -6362,6 +7377,8 @@ snapshots:
     dependencies:
       entities: 8.0.0
     optional: true
+
+  partial-json@0.1.7: {}
 
   path-exists@3.0.0: {}
 
@@ -6470,6 +7487,8 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  powershell-utils@0.1.0: {}
+
   prebuild-install@7.1.3:
     dependencies:
       detect-libc: 2.1.2
@@ -6497,6 +7516,21 @@ snapshots:
       react-is: 17.0.2
 
   process-warning@5.0.0: {}
+
+  protobufjs@7.5.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.1
+      '@protobufjs/fetch': 1.1.1
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.2
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.2
+      '@types/node': 25.9.1
+      long: 5.3.2
 
   pump@3.0.4:
     dependencies:
@@ -6592,6 +7626,8 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  retry@0.13.1: {}
+
   reusify@1.1.0: {}
 
   rolldown-plugin-dts@0.25.1(@typescript/native-preview@7.0.0-dev.20260526.1)(rolldown@1.0.2)(typescript@6.0.3):
@@ -6634,12 +7670,13 @@ snapshots:
 
   rou3@0.8.1: {}
 
+  run-applescript@7.1.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-buffer@5.2.1:
-    optional: true
+  safe-buffer@5.2.1: {}
 
   safe-stable-stringify@2.5.0: {}
 
@@ -6858,6 +7895,8 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  ts-algebra@2.0.0: {}
+
   tsdown@0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1):
     dependencies:
       ansis: 4.3.0
@@ -6905,6 +7944,8 @@ snapshots:
   tweetnacl@1.0.3: {}
 
   type@2.7.3: {}
+
+  typebox@1.1.38: {}
 
   typescript@6.0.3: {}
 
@@ -6966,6 +8007,38 @@ snapshots:
     optionalDependencies:
       vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
 
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.9.1
+      '@vitest/browser-playwright': 4.1.8(playwright@1.61.0)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
+      '@vitest/coverage-v8': 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
+      happy-dom: 20.9.0
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
   vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
@@ -6998,12 +8071,16 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  vscode-jsonrpc@9.0.1: {}
+
   w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
     optional: true
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 
@@ -7051,6 +8128,11 @@ snapshots:
 
   ws@8.21.0: {}
 
+  wsl-utils@0.3.1:
+    dependencies:
+      is-wsl: 3.1.1
+      powershell-utils: 0.1.0
+
   xml-name-validator@5.0.0:
     optional: true
 
@@ -7073,6 +8155,10 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.9.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@4.3.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,18 @@ catalogs:
     '@changesets/cli':
       specifier: 2.31.0
       version: 2.31.0
+    '@codemirror/autocomplete':
+      specifier: 6.20.3
+      version: 6.20.3
+    '@codemirror/lint':
+      specifier: 6.9.7
+      version: 6.9.7
+    '@codemirror/state':
+      specifier: 6.7.1
+      version: 6.7.1
+    '@codemirror/view':
+      specifier: 6.43.6
+      version: 6.43.6
     '@codesandbox/sandpack-react':
       specifier: 2.20.0
       version: 2.20.0
@@ -72,6 +84,12 @@ catalogs:
     '@typescript/native-preview':
       specifier: 7.0.0-dev.20260526.1
       version: 7.0.0-dev.20260526.1
+    '@typescript/vfs':
+      specifier: 1.6.4
+      version: 1.6.4
+    '@valtown/codemirror-ts':
+      specifier: 2.3.1
+      version: 2.3.1
     '@vitejs/plugin-react':
       specifier: 6.0.3
       version: 6.0.3
@@ -90,6 +108,9 @@ catalogs:
     cac:
       specifier: 7.0.0
       version: 7.0.0
+    comlink:
+      specifier: 4.4.2
+      version: 4.4.2
     croner:
       specifier: 10.0.1
       version: 10.0.1
@@ -1081,15 +1102,36 @@ importers:
 
   playground/compare:
     dependencies:
+      '@codemirror/autocomplete':
+        specifier: 'catalog:'
+        version: 6.20.3
+      '@codemirror/lint':
+        specifier: 'catalog:'
+        version: 6.9.7
+      '@codemirror/state':
+        specifier: 'catalog:'
+        version: 6.7.1
+      '@codemirror/view':
+        specifier: 'catalog:'
+        version: 6.43.6
       '@codesandbox/sandpack-react':
         specifier: 'catalog:'
         version: 2.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@pumped-fn/lite':
         specifier: workspace:*
         version: link:../../pkg/core/lite
+      '@typescript/vfs':
+        specifier: 'catalog:'
+        version: 1.6.4(typescript@6.0.3)
+      '@valtown/codemirror-ts':
+        specifier: 'catalog:'
+        version: 2.3.1(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)
       awilix:
         specifier: 'catalog:'
         version: 13.0.5
+      comlink:
+        specifier: 'catalog:'
+        version: 4.4.2
       effect:
         specifier: 'catalog:'
         version: 3.21.3
@@ -1576,11 +1618,11 @@ packages:
   '@codemirror/lint@6.9.7':
     resolution: {integrity: sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==}
 
-  '@codemirror/state@6.6.0':
-    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+  '@codemirror/state@6.7.1':
+    resolution: {integrity: sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==}
 
-  '@codemirror/view@6.43.1':
-    resolution: {integrity: sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw==}
+  '@codemirror/view@6.43.6':
+    resolution: {integrity: sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==}
 
   '@codesandbox/nodebox@0.1.8':
     resolution: {integrity: sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==}
@@ -2518,6 +2560,19 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
+  '@typescript/vfs@1.6.4':
+    resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
+    peerDependencies:
+      typescript: '*'
+
+  '@valtown/codemirror-ts@2.3.1':
+    resolution: {integrity: sha512-v5XiI4WA+bUy0XDgkrqZksqBWgIUeyLZuC94Px/rhXBph8ASmVXaimlGDtt0vH/9t8aDdIZYdr59r9H3oKMFOg==}
+    peerDependencies:
+      '@codemirror/autocomplete': ^6
+      '@codemirror/lint': ^6
+      '@codemirror/state': ^6
+      '@codemirror/view': ^6
+
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2746,6 +2801,9 @@ packages:
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
+
+  comlink@4.4.2:
+    resolution: {integrity: sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==}
 
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
@@ -5273,22 +5331,22 @@ snapshots:
   '@codemirror/autocomplete@6.20.3':
     dependencies:
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
       '@lezer/common': 1.5.2
 
   '@codemirror/commands@6.10.3':
     dependencies:
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
       '@lezer/common': 1.5.2
 
   '@codemirror/lang-css@6.3.1':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.1
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
 
@@ -5298,8 +5356,8 @@ snapshots:
       '@codemirror/lang-css': 6.3.1
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
       '@lezer/common': 1.5.2
       '@lezer/css': 1.3.3
       '@lezer/html': 1.3.13
@@ -5309,15 +5367,15 @@ snapshots:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/language': 6.12.3
       '@codemirror/lint': 6.9.7
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
       '@lezer/common': 1.5.2
       '@lezer/javascript': 1.5.4
 
   '@codemirror/language@6.12.3':
     dependencies:
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
       '@lezer/common': 1.5.2
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
@@ -5325,17 +5383,17 @@ snapshots:
 
   '@codemirror/lint@6.9.7':
     dependencies:
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
       crelt: 1.0.6
 
-  '@codemirror/state@6.6.0':
+  '@codemirror/state@6.7.1':
     dependencies:
       '@marijn/find-cluster-break': 1.0.2
 
-  '@codemirror/view@6.43.1':
+  '@codemirror/view@6.43.6':
     dependencies:
-      '@codemirror/state': 6.6.0
+      '@codemirror/state': 6.7.1
       crelt: 1.0.6
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
@@ -5362,8 +5420,8 @@ snapshots:
       '@codemirror/lang-html': 6.4.11
       '@codemirror/lang-javascript': 6.2.5
       '@codemirror/language': 6.12.3
-      '@codemirror/state': 6.6.0
-      '@codemirror/view': 6.43.1
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
       '@codesandbox/sandpack-client': 2.19.8
       '@lezer/highlight': 1.2.3
       '@react-hook/intersection-observer': 3.1.2(react@19.2.6)
@@ -6263,6 +6321,20 @@ snapshots:
       '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260526.1
       '@typescript/native-preview-win32-x64': 7.0.0-dev.20260526.1
 
+  '@typescript/vfs@1.6.4(typescript@6.0.3)':
+    dependencies:
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@valtown/codemirror-ts@2.3.1(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.3
+      '@codemirror/lint': 6.9.7
+      '@codemirror/state': 6.7.1
+      '@codemirror/view': 6.43.6
+
   '@vitejs/plugin-react@6.0.3(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
@@ -6503,6 +6575,8 @@ snapshots:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+
+  comlink@4.4.2: {}
 
   commander@6.2.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,14 @@ peerDependencyRules:
 
 catalog:
   "@agentclientprotocol/sdk": 1.2.1
+  "@codemirror/autocomplete": 6.20.3
+  "@codemirror/lint": 6.9.7
+  "@codemirror/state": 6.7.1
+  "@codemirror/view": 6.43.6
   "@codesandbox/sandpack-react": 2.20.0
+  "@typescript/vfs": 1.6.4
+  "@valtown/codemirror-ts": 2.3.1
+  comlink: 4.4.2
   "@earendil-works/pi-ai": 0.80.3
   "@changesets/changelog-github": 0.7.0
   "@hono/node-server": 2.0.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,11 +59,14 @@ peerDependencyRules:
     typescript: ^5.0.0 || ^6.0.0
 
 catalog:
+  "@agentclientprotocol/sdk": 1.2.1
   "@codesandbox/sandpack-react": 2.20.0
+  "@earendil-works/pi-ai": 0.80.3
   "@changesets/changelog-github": 0.7.0
   "@hono/node-server": 2.0.6
   "@changesets/cli": 2.31.0
   "@json-render/core": 0.19.0
+  "@agentclientprotocol/codex-acp": 1.1.0
   "@nats-io/kv": 3.4.0
   "@nats-io/transport-node": 3.4.0
   "@tanstack/react-start": 1.168.26

--- a/research/provider-modules-spec.md
+++ b/research/provider-modules-spec.md
@@ -1,0 +1,83 @@
+# Spec packet: provider modules (claude, codex, pi) + composition lint rules
+
+You are implementing in the pumped-fn repo, worktree `/home/lagz0ne/dev/pumped-fn/.claude/worktrees/feat+pi` (branch for this feature). Work only in this tree. pnpm workspace; read root `CLAUDE.md` and obey it fully (no comments, no `any`, no type suffixes on handles, no factory ceremony).
+
+## Goal
+
+Three provider modules for `@pumped-fn/sdk`'s `Model` seam, plus lint rules that enforce the composition pattern they demonstrate.
+
+1. **`@pumped-fn/sdk-claude`** (rework existing `pkg/sdk/claude`): drives `claude -p` per round. Auth: either a long-lived token supplied via config tag (env `CLAUDE_CODE_OAUTH_TOKEN` passed to the subprocess) or reuse of the machine's global auth (`~/.claude`, no refresh logic in our code — the CLI handles it). No OAuth flows, no token refresh implementation.
+2. **`@pumped-fn/sdk-codex`** (rework existing `pkg/sdk/codex`): same auth story (env key or global `~/.codex/auth.json`), driving `codex exec`. Additionally an **ACP mode**: a second `Model` implementation that talks Agent Client Protocol over stdio to a codex ACP server, using the official TS ACP client library.
+3. **`@pumped-fn/sdk-pi`** (new `pkg/sdk/pi`): in-process integration with `@earendil-works/pi-ai` — no subprocess. Native tool calling: `ModelRequest.tools/skills/subagents` become native tool declarations (`load_skill`, `call_subagent` pseudo-tools); assistant tool calls map back to `ModelResponse.toolCalls/skillCalls/subagentCalls`. Validate `provider/modelId` against pi-ai's model catalog; expose a way to list supported models.
+4. **Lint rules** in `pkg/tool/lint` enforcing the composition style used above (see "Composition pattern" and "Lint" sections).
+
+## Composition pattern (binding — this is the point of the exercise)
+
+Modules associate by reference. A provider package exposes:
+- module-level handle definitions (`flow`/`atom`/`resource` created ONCE at module top level),
+- config as a `tag<T>()`, declared via `deps: { config: tags.required(...) }` (or `tags.optional` with defaults),
+- a tagged registration export, e.g. `export const pi = model(turn)`.
+
+FORBIDDEN: exported functions that construct and return handles (`export function claude(options) { return model(flow({...})) }`). Options captured in closures are invisible edges; per-call flows break preset substitution and memoization. The existing `claudeHarness`/`codexHarness`/`claude()`/`codex()` factory shapes in `pkg/sdk/core` + wrappers are the anti-pattern being retired — migrate them: core keeps only reference-level building blocks (`cliWorker` stays a factory only if it remains a generic low-level constructor used at module level by provider packages; prefer converting provider harnesses to module-level flows + config tags).
+
+Observability is inherited, not reinvented: every provider is a `Model` resolved through the existing `complete` flow (`step({workflow:true, kind:"llm"})`). Provider-internal effects (subprocess run, ACP session, pi-ai call) must be visible edges: use `step(...)` tags on flows for durable/span attribution, record through the `events` resource where the agent runtime does, and thread `abortSignal` tag where long-running. No bespoke logger, no console.
+
+## Auth facts (verified 2026-07-10)
+
+Claude CLI (v2.1.206):
+- Long-lived token: `claude setup-token` prints a 1-year OAuth token; passed as env `CLAUDE_CODE_OAUTH_TOKEN` to `claude -p`. No refresh within the year. Alternatives: `ANTHROPIC_API_KEY` (Console key), `ANTHROPIC_AUTH_TOKEN` (bearer/gateway).
+- Precedence: cloud-provider envs → `ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY` → `apiKeyHelper` → `CLAUDE_CODE_OAUTH_TOKEN` → stored subscription OAuth.
+- Global auth reuse: on Linux, stored OAuth lives at `~/.claude/.credentials.json` (0600, auto-refreshed by the CLI) plus state file `~/.claude.json`. Under env isolation (bubblewrap), either bind a writable HOME containing both, or set `CLAUDE_CONFIG_DIR` to a bound dir, or simplest: inject the token env. `--bare` does NOT read `CLAUDE_CODE_OAUTH_TOKEN` (API key / apiKeyHelper only) — the module must not combine bare mode with oauth-token config.
+- Config tag design: `claudeConfig` supports `{ auth: { kind: "token", env?: name } | { kind: "global" } }` → token kind passes env through to the subprocess; global kind binds HOME/`CLAUDE_CONFIG_DIR` through the isolate. Never write auth files.
+
+Codex CLI (v0.144.1):
+- `CODEX_API_KEY` env is the supported single-run key for `codex exec` (only exec). `OPENAI_API_KEY` is a login-time input (`codex login --with-api-key` via stdin), not read at runtime.
+- Global auth: `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`; contains tokens, auto-refreshed during use). `--ignore-user-config` skips config.toml but auth still uses `CODEX_HOME` — so global-auth reuse under isolation = bind `~/.codex` (writable) or set `CODEX_HOME`.
+- Config tag design mirrors claude: `{ auth: { kind: "api-key", env?: name } | { kind: "global" } }`.
+
+## ACP facts (verified 2026-07-10)
+
+- Codex has NO native ACP subcommand. Adapter: `@zed-industries/codex-acp` (npm, v0.16.0, Rust binary, bin `codex-acp`, run via `npx @zed-industries/codex-acp`), speaks ACP JSON-RPC 2.0 over stdio, reuses `~/.codex` auth. (Symmetry note: `@zed-industries/claude-code-acp` exists for claude — out of scope now, but keep the ACP client generic enough to point at either binary via config.)
+- TS client library: `@agentclientprotocol/sdk` (v1.2.1 — the current official lib; do NOT use the stale `@zed-industries/agent-client-protocol`). Usage: `spawn` the adapter, wrap stdin/stdout in `ClientSideConnection` (you implement the Client interface for `session/update` and `session/request_permission`), then `initialize` → `newSession` → `prompt`; agent streams `session/update` notifications; prompt resolves with a stop reason; `session/cancel` for aborts.
+- ACP Model shape: a `resource` owning the spawned adapter process + `ClientSideConnection` (lifecycle: dispose kills process), and a module-level `Model` flow depending on it: one `ModelRequest` round = one `session/prompt`; accumulate `session/update` content into `ModelResponse.content`; auto-grant or deny `session/request_permission` per config tag (this is a controlled edge — record it via `events`). Wire `abortSignal` tag → `session/cancel`. Exact request/response type names must be taken from the `@agentclientprotocol/sdk` typings at implementation time — verify from `node_modules` typings, do not guess.
+
+## pi-ai API facts (verified 2026-07-10 against pi repo HEAD, @earendil-works/pi-ai@0.80.6)
+
+A full clone of the pi repo is available for reference at `/tmp/claude-1001/-home-lagz0ne-dev-pumped-fn/29157e00-c9ca-46c6-90cc-ce2497e9d9d0/scratchpad/pi` (source of truth: `packages/ai/src/types.ts`, `models.ts`, `providers/all.ts`).
+
+- Use the NEW surface: `builtinModels(options?) : MutableModels` from `@earendil-works/pi-ai/providers/all` (or `createModels` + per-provider factories from `@earendil-works/pi-ai/providers/<id>` for lean deps). Do NOT use `@earendil-works/pi-ai/compat` (`getModel`/`complete` globals — deprecated; note the pi repo's own sdk examples still use it, ignore them).
+- Calls: `models.complete(model, context, options?): Promise<AssistantMessage>`; streaming via `models.stream(...)` returning `AsyncIterable<AssistantMessageEvent>` with `.result()`. Unified reasoning-level variants: `completeSimple`/`streamSimple` with `SimpleStreamOptions { reasoning?: "minimal"|"low"|"medium"|"high"|"xhigh"|"max" }`. Post-invocation errors do NOT throw — they surface as `stopReason: "error" | "aborted"` + `errorMessage` on the result; map that to a thrown domain error in our flow.
+- `Context = { systemPrompt?: string; messages: Message[]; tools?: Tool[] }`. `Message = UserMessage | AssistantMessage | ToolResultMessage`; tool results are TOP-LEVEL messages `{ role: "toolResult", toolCallId, toolName, content: [{type:"text",...}], isError, timestamp }`. Every message requires `timestamp` (Unix ms) — take timestamps from an injected clock edge, not naked `Date.now()` (lint rule `no-naked-globals`).
+- Tools: `{ name, description, parameters: TSchema }` (TypeBox, re-exported from root as `Type`). Tool calls come back as `ToolCall { type:"toolCall", id, name, arguments }` blocks in `AssistantMessage.content`, `stopReason: "toolUse"`. `validateToolCall(tools, toolCall)` exported. Use exported `StringEnum` helper (NOT `Type.Enum`) for enum params (Google compat).
+- Auth precedence at request time: `options.apiKey` → `CredentialStore` passed to `builtinModels({credentials})` → ambient env (anthropic: `ANTHROPIC_OAUTH_TOKEN`, `ANTHROPIC_API_KEY`); per-call `options.env` beats process.env. For this module: config tag carries `{ apiKeyEnv?: string }` resolved through an adapter edge; NO OAuth flows (pi-ai exposes them; out of scope).
+- Catalog: `models.getModel(provider, id)` sync, `undefined` when unsupported → throw domain error listing `models.getModels(provider).map(m => m.id)`. Typed static access also available: `getBuiltinModel/getBuiltinModels/getBuiltinProviders` from `providers/all`. `getSupportedThinkingLevels(model)` / `clampThinkingLevel(model, level)` for thinking validation. Expose a module-level flow (or resource-backed accessor) to list supported models — that is the "supported models" deliverable.
+- Usage/cost: `AssistantMessage.usage` has token counts + `cost.total` — record onto the `events` buffer with the model round.
+- Packaging: ESM-only, `engines.node >= 22.19.0`, `typebox@1.1.38` dep. Add via catalog per repo dependency rules (`pnpm-workspace.yaml` catalog first).
+
+pi module shape (binding): module-level `piConfig = tag<PiConfig>` (`{ provider, modelId, thinking?, apiKeyEnv? }`), a module-level `resource` owning the `Models` collection (`builtinModels()` — lazy, disposed with scope), and one module-level `Model` flow `deps: { models: <resource>, config: tags.required(piConfig) }` doing request→Context mapping, one `complete`/`completeSimple` call, response→`ModelResponse` mapping. Export `export const pi = model(<flow>)`. Mapping rules: `instructions`→`systemPrompt`; our `Message[]`→pi messages; `tools` Capabilities → pi Tools with permissive object schemas; `skills` → one `load_skill` tool (StringEnum of skill names); `subagents` → one `call_subagent` tool (name + prompt input); returned ToolCall blocks split back into `toolCalls`/`skillCalls`/`subagentCalls` on `ModelResponse`; text blocks joined → `content`; `stop` = stopReason `"stop"` with no calls.
+
+## Lint rules (new; additive only)
+
+Add to `pkg/tool/lint` (README table + rules in `src/index.ts`, mirroring existing rule structure):
+- `pumped/no-handle-factory` (error): an exported function whose body creates and returns (directly or via wrapper like `model(...)`) an `atom`/`flow`/`resource`/`material`/`tag` handle. Composition roots (`createScope` call sites) and the documented core constructors (`agent`, `tool`, `skill`, `sub`, `session`, `guard`, `material`, `channel`, `schedule`, `cliWorker`) are allowlisted by config, not by loosening the rule.
+- `pumped/config-via-tags` (warn to start): provider-module flows reading configuration from closure variables defined at module level that are parameters of an enclosing function — i.e. options-closure detection complementing `no-handle-factory`.
+Design the exact AST detection conservatively (syntactic, documented false negatives) in the style of existing rules like `no-handle-spread` / `no-unattributed-await`.
+
+## Anti-goals (binding)
+
+- NO loosening of any existing lint rule: no rule deletions, no severity downgrades, no new allowlist entries for existing rules to make new code pass. New code conforms to the existing rules.
+- NO bespoke observability: reuse `step`, `events`, suspense/workflow extension composition. If a provider needs logging, it is an event/edge, not a `console.log`.
+- NO OAuth/refresh implementations. Token in via tag/env passthrough, or global auth reuse. Nothing writes auth files.
+- NO test slop: use vitest `expectTypeOf` for type assertions (it evaluates its argument — assert against real values), no never-executed scaffolding, terse test names, no hand-rolled type gymnastics.
+- NO module mocks anywhere (`vi.mock` is lint-rejected): the scope is the only seam. An adapter's own unit test may fake the global it wraps (subprocess boundary) below the seam.
+
+## Testing (binding)
+
+- Unit: scope-seam tests with preset substitution (see `pkg/sdk/test` `modelStub` for the reference non-CLI Model).
+- Integration: THIS machine has authed `claude` and `codex` CLIs. Write integration tests that actually invoke them (small, cheap prompts; generous timeouts; marked/isolated so they can be filtered, e.g. separate `*.integration.test.ts` + vitest config include). They must run and pass locally as part of your verification. pi integration runs only if a supported provider key is present in env; skip cleanly otherwise (skip must be visible, not silent green).
+- Gates you must run and report exit codes for: workspace build first (dist staleness!), then `pnpm -r typecheck`, `pnpm -r test`, root `pnpm lint`.
+
+## Deliverables
+
+- Code + tests per above; `pkg/sdk/README.md` and each package README updated; root `README.md` diagram if the lane shape changed.
+- A short CHANGES summary listing every migrated/removed export (the factory retirement is a breaking change to `@pumped-fn/sdk` 2.x — flag it, do not silently alias).

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -87,6 +87,9 @@
       "@pumped-fn/sdk-just-bash": [
         "./pkg/sdk/bash/src/index.ts"
       ],
+      "@pumped-fn/sdk-pi": [
+        "./pkg/sdk/pi/src/index.ts"
+      ],
       "@pumped-fn/sdk-test": [
         "./pkg/sdk/test/src/index.ts"
       ],


### PR DESCRIPTION
## What

Rebuilds the comparison homepage into a full showcase:

- **Live type intelligence in the editor** — a lazy web worker hosts a TypeScript virtual environment seeded with the checked-in case files and the real `.d.ts` surface of `@pumped-fn/lite`, `effect`, `awilix`, `inversify`, and `vitest`. Hover shows inferred types (e.g. the full `Lite.Flow<…>` of `provision`), Ctrl-Space completes, diagnostics lint live. Payload ships as a code-split worker chunk loaded on idle.
- **Syntax color palette** — tokens use a fixed five-color palette on `sp-syntax-*` spans; all page chrome stays grayscale. `color-audit.mjs` now declares `editorSyntaxPalette` as policy: authored theme must conform, and the computed audit exempts exactly those values on syntax spans (plus their `currentColor`-derived properties).
- **Three-proof preview** — the Sandpack preview is a mono three-view app: *Lifecycle* (five result cards + shared 17-event timeline), *Throughput* (warm-up + ~300ms timed batches per lane, live bars, measured on the visitor's machine), *Reactivity* (`controller(dep, { resolve: true, watch: true })` chain painted from one `scope.changes` loop — a 10,000-update synchronous burst lands as ~2 derived recomputes and 1 DOM paint).
- **Shell refinements** — topbar, per-file line counts on lane cards, dimension descriptions, keyboard shortcuts (1·2·3), type-intel status indicator, footer, meta/OG/favicon, CDN preconnects.

`build`/`build:pages`/`dev` now build `@pumped-fn/lite` dist first (the worker payload embeds its `.d.ts`).

## Verification

- `pnpm -F @pumped-fn/compare verify` — lint 46 files / 0 diagnostics, 15 tests, typecheck, build, `Sandpack executed all five comparison lanes`
- `pnpm pages:dry-run` — staged, digests verified, both viewports pass selectors + lifecycle + computed grayscale audit + overflow audit, redirect verified
- Interactive Chromium drive: hover tooltip returns real inferred types; benchmark and burst demos run clean

README documents the color policy and the type-intelligence architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)