### PR TITLE
fix(ci): declare @google/genai as ignored built dependency

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,9 @@ packages:
   - playground/*
 
 catalogMode: strict
+
+ignoredBuiltDependencies:
+  - '@google/genai'
 cleanupUnusedCatalogs: true
 minimumReleaseAge: 1440
 trustPolicy: no-downgrade


### PR DESCRIPTION
@earendil-works/pi-ai (merged with #342's squash) pulls in @google/genai, whose build scripts we never run. With `strictDepBuilds: true` pnpm exits non-zero on any undeclared skipped build, which failed every Install-dependencies step in CI on #342.

Verified: fresh worktree of `origin/main` + this change → `pnpm install --frozen-lockfile` exits 0.

This PR's own checks re-run the full CI (build, typecheck, tests, comparison browser smoke, pages dry-run) against the merged showcase code, which CI never got to execute on #342.

🤖 Generated with [Claude Code](https://claude.com/claude-code)