### PR TITLE
feat(sdk): add context-owned managed tools

### DIFF
--- a/.changeset/managed-tools.md
+++ b/.changeset/managed-tools.md
@@ -3,6 +3,7 @@
 "@pumped-fn/sdk-just-bash": patch
 "@pumped-fn/sdk-claude": patch
 "@pumped-fn/sdk-codex": patch
+"@pumped-fn/sdk-pi": patch
 ---
 
-Add context-owned managed tools and agent turns.
+Add context-owned managed tools and agent turns with scope-configurable Standard Schema validation, Zod and Valibot engine examples, and validated JSON Schema propagation to Claude, Codex, and pi-ai.

--- a/.changeset/managed-tools.md
+++ b/.changeset/managed-tools.md
@@ -1,0 +1,8 @@
+---
+"@pumped-fn/sdk": patch
+"@pumped-fn/sdk-just-bash": patch
+"@pumped-fn/sdk-claude": patch
+"@pumped-fn/sdk-codex": patch
+---
+
+Add context-owned managed tools and agent turns.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Put your app behind a scope, and it becomes fully testable, fully traceable, wit
 createScope({ presets, tags, extensions })
   -> scope-owned graph
   -> execution context per request, job, action, or test
-  -> currentTool resource -> currentAgent resource -> turn flow
+  -> currentTool resource + validation.engine tag -> currentAgent resource -> turn flow
   -> flows, resources, tags, and wrapped execution edges
   -> module-level Model providers: Claude CLI, Codex CLI/ACP, or pi-ai
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Put your app behind a scope, and it becomes fully testable, fully traceable, wit
 createScope({ presets, tags, extensions })
   -> scope-owned graph
   -> execution context per request, job, action, or test
+  -> currentTool resource -> currentAgent resource -> turn flow
   -> flows, resources, tags, and wrapped execution edges
   -> module-level Model providers: Claude CLI, Codex CLI/ACP, or pi-ai
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 | Directory | Package | What it shows | Run |
 | --- | --- | --- | --- |
-| `invoice-triage/` | `@pumped-fn/invoice-triage` | [Invoice triage](./invoice-triage/README.md) imports invoices into Postgres and triages them with a model provider across daemon, server, CLI, cron, and tests. | `docker compose -f examples/invoice-triage/compose.yaml up -d postgres`<br>`pnpm -F @pumped-fn/invoice-triage start < examples/invoice-triage/fixtures/demo.ndjson`<br>`PORT=3000 pnpm -F @pumped-fn/invoice-triage server`<br>`pnpm -F @pumped-fn/invoice-triage test` |
+| `invoice-triage/` | `@pumped-fn/invoice-triage` | [Invoice triage](./invoice-triage/README.md) imports invoices into Postgres, triages them with a model provider, and includes an executable Zod-validated managed invoice lookup tool at the same scope seam. | `docker compose -f examples/invoice-triage/compose.yaml up -d postgres`<br>`pnpm -F @pumped-fn/invoice-triage start < examples/invoice-triage/fixtures/demo.ndjson`<br>`PORT=3000 pnpm -F @pumped-fn/invoice-triage server`<br>`pnpm -F @pumped-fn/invoice-triage test` |
 
 Adding an example? See [CONTRIBUTING.md](./CONTRIBUTING.md).
 

--- a/examples/invoice-triage/README.md
+++ b/examples/invoice-triage/README.md
@@ -91,6 +91,7 @@ flowchart TD
 - Postgres-backed ingest through Drizzle migrations, store flows, and PGlite presets in tests.
 - Signal-driven workers and ops views using `queueSignal`, `storedSignal`, `outstanding`, `importing`, `drained`, and `stopping`.
 - Provider seams for the model tag, notifier client, clock, request id, reminder policy, and database URL.
+- A Zod-validated `findInvoice` managed tool, `invoiceAssistant` current resource, and `askInvoice` turn whose validation engine and model are selected at the scope seam.
 - Scheduler-backed cron registration, idempotent reminder claims, release-on-failure SQL, and deterministic manual ticks in tests.
 - Hono server, daemon, CLI, and OpenTelemetry spans over the same graph.
 
@@ -102,7 +103,7 @@ Business features are flows/resources; free functions are pure calculations; ctx
 
 Outbound and pull capabilities such as `intakeLines` are atoms because the graph controls when it consumes them. Anything that creates execution contexts is root-owned: the server root creates request contexts inline in handlers, and importing `bin/server.ts` only exports the Hono app without starting workers or a listener.
 
-External data is schema-validated with zod at parse and model-output boundaries; graph-internal handoffs stay typed.
+External data is schema-validated with Zod at parse, managed-tool input, and model-output boundaries; graph-internal handoffs stay typed. `src/assistant.ts` declares the tool schema once. The scope-injected `validation.engine` converts it to the JSON Schema shown to the model and validates each call before `invoice.findStored` executes.
 
 Database access lives in `src/store.ts`. `database` is an atom, and each store operation is a plain flow that deps it directly and runs its Drizzle SQL inline. Multi-write operations (`enqueue`, `settleInvoice`, `markReminderSent`) wrap their writes in `db.transaction(async (tx) => …)` so the two writes are atomic per operation; reads (`listStored`, `listPending`, `reviewCount`, `listAudit`) are plain `db.select`. Each write/read flow carries `step({ workflow: true, kind: "store" })`, so its SQL await is attributed to that step's span. There is no per-flow transaction boundary and no held transaction: SQL commits inline as each operation resolves, so a flow that mutates then bumps a signal is naturally post-commit.
 

--- a/examples/invoice-triage/src/assistant.ts
+++ b/examples/invoice-triage/src/assistant.ts
@@ -1,0 +1,17 @@
+import { currentAgent, currentTool, turn } from "@pumped-fn/sdk"
+import { z } from "zod"
+import { findStored } from "./store"
+
+export const findInvoice = currentTool({
+  description: "Find a stored invoice by invoice ID.",
+  inputSchema: z.object({ invoiceId: z.string().min(1) }),
+  flow: findStored,
+})
+
+export const invoiceAssistant = currentAgent({
+  name: "invoice-assistant",
+  instructions: "Use the available invoice tools. Do not invent invoice data.",
+  tools: { findInvoice },
+})
+
+export const askInvoice = turn({ agent: invoiceAssistant })

--- a/examples/invoice-triage/src/store.ts
+++ b/examples/invoice-triage/src/store.ts
@@ -139,6 +139,17 @@ export const listStored = flow({
   },
 })
 
+export const findStored = flow({
+  name: "invoice.findStored",
+  parse: typed<{ invoiceId: string }>(),
+  deps: { db: database },
+  tags: [step({ workflow: true, kind: "store" })],
+  factory: async (ctx, { db }): Promise<StoredInvoice | undefined> => {
+    const [row] = await db.select().from(storedInvoices).where(eq(storedInvoices.id, ctx.input.invoiceId))
+    return row === undefined ? undefined : storedFromRow(row)
+  },
+})
+
 export const listPending = flow({
   name: "invoice.listPending",
   deps: { db: database },

--- a/examples/invoice-triage/tests/managed-tools.test.ts
+++ b/examples/invoice-triage/tests/managed-tools.test.ts
@@ -1,0 +1,57 @@
+import { createScope, preset } from "@pumped-fn/lite"
+import { model, validation } from "@pumped-fn/sdk"
+import { modelStub } from "@pumped-fn/sdk-test"
+import { expect, it } from "vitest"
+import { z } from "zod"
+import { askInvoice } from "../src/assistant"
+import { database } from "../src/database"
+import { clock } from "../src/ports"
+import { saveInvoice } from "../src/store"
+import { pgliteDatabase } from "./support/database"
+
+const now = new Date("2026-07-13T00:00:00.000Z")
+
+it("runs a Zod-validated managed invoice tool through the injected model", async () => {
+  const provider = modelStub((request) => request.round === 0
+    ? {
+        content: "Looking up the invoice.",
+        toolCalls: [{ name: "invoice.findStored", input: { invoiceId: "inv-42" } }],
+      }
+    : { content: request.messages.at(-1)?.content ?? "missing", stop: true })
+  const scope = createScope({
+    presets: [preset(database, await pgliteDatabase())],
+    tags: [
+      clock({ now: () => now }),
+      model(provider),
+      validation.engine(validation.standard<z.ZodType>((schema) => z.toJSONSchema(schema))),
+    ],
+  })
+  const ctx = scope.createContext()
+
+  await ctx.exec({
+    flow: saveInvoice,
+    input: {
+      invoice: {
+        id: "inv-42",
+        vendor: "Acme SaaS",
+        amount: 240,
+        dueDate: "2026-07-20",
+        description: "Team subscription",
+      },
+      classification: {
+        vendor: "Acme SaaS",
+        amount: 240,
+        dueDate: "2026-07-20",
+        category: "saas",
+        risk: "auto-approve",
+        reason: "Within policy",
+      },
+    },
+  })
+  const result = await ctx.exec({ flow: askInvoice, input: { prompt: "Find inv-42." } })
+
+  expect(result.toolResults).toMatchObject([{ name: "invoice.findStored", output: { id: "inv-42" } }])
+  expect(result.content).toContain("inv-42")
+  await ctx.close()
+  await scope.dispose()
+})

--- a/pkg/sdk/bash/README.md
+++ b/pkg/sdk/bash/README.md
@@ -22,5 +22,18 @@ const scope = createScope({
 
 `sandbox()` returns a lazy `agent.sandbox` tag. The `Bash` runtime is created only when a sandbox capability is first used, and the flow can be run with any other `sdk` sandbox tag instead.
 
+`Sandbox.exec` accepts an optional `AbortSignal`. just-bash checks the signal at statement boundaries and stops a cancelled execution cooperatively:
+
+```ts
+import { createSandbox } from "@pumped-fn/sdk-just-bash"
+
+const target = createSandbox()
+const controller = new AbortController()
+const execution = target.exec("bash", ["-c", "sleep 100; printf late"], { signal: controller.signal })
+controller.abort()
+const result = await execution
+if (result.exitCode !== 124) throw new Error("execution was not cancelled")
+```
+
 ---
 Part of [pumped-fn](https://github.com/pumped-fn/pumped-fn) — start with the [docs](https://github.com/pumped-fn/pumped-fn/tree/main/docs) or the [mental model](https://github.com/pumped-fn/pumped-fn/blob/main/docs/mental-model.md).

--- a/pkg/sdk/bash/src/index.ts
+++ b/pkg/sdk/bash/src/index.ts
@@ -1,5 +1,5 @@
 import { Bash } from "just-bash"
-import { sandbox as agentSandbox, type Sandbox } from "@pumped-fn/sdk"
+import { sandbox as agentSandbox, type Sandbox, type SandboxExecOptions } from "@pumped-fn/sdk"
 import type { Lite } from "@pumped-fn/lite"
 import { dirname } from "node:path/posix"
 
@@ -31,8 +31,8 @@ export function createSandbox(options: JustBashOptions = {}): Sandbox {
       const result = await run().exec(`mkdir -p ${quote(dirname(path))} && cat > ${quote(path)}`, { stdin: content })
       if (result.exitCode !== 0) throw new Error(result.stderr.trim() || `writeFile failed for ${path}`)
     },
-    async exec(command, args = []) {
-      const result = await run().exec([command, ...args].map(quote).join(" "))
+    async exec(command, args = [], options?: SandboxExecOptions) {
+      const result = await run().exec([command, ...args].map(quote).join(" "), { signal: options?.signal })
       return {
         stdout: result.stdout,
         stderr: result.stderr,

--- a/pkg/sdk/bash/tests/just-bash.test.ts
+++ b/pkg/sdk/bash/tests/just-bash.test.ts
@@ -88,3 +88,13 @@ it("can be replaced per execution context without rebuilding flows", async () =>
   await fakeCtx.close()
   await scope.dispose()
 })
+
+it("forwards cancellation and prevents late boundary effects", async () => {
+  const target = createSandbox({ bash: new Bash() })
+  const controller = new AbortController()
+  const execution = target.exec("bash", ["-c", "sleep 100; printf late"], { signal: controller.signal })
+
+  setImmediate(() => controller.abort())
+
+  await expect(execution).resolves.toMatchObject({ stdout: "", stderr: "", exitCode: 124 })
+})

--- a/pkg/sdk/claude/README.md
+++ b/pkg/sdk/claude/README.md
@@ -8,26 +8,41 @@ Module-level managed Claude CLI model provider for `@pumped-fn/sdk`.
 agent -> model tag -> claude turn -> claude run -> scope-owned stream-json process
 ```
 
-Managed tools resolve in core before the provider request and need no provider registry.
+Managed tools resolve and publish their validated JSON Schema before the provider request. They need no provider registry.
 
 ```ts
-import { createScope } from "@pumped-fn/lite"
-import { agent } from "@pumped-fn/sdk"
+import { createScope, flow, typed } from "@pumped-fn/lite"
+import { currentAgent, currentTool, turn, validation } from "@pumped-fn/sdk"
 import { claude, claudeConfig } from "@pumped-fn/sdk-claude"
+import * as z from "zod"
 
-const triage = agent({ name: "triage" })
+const inspect = currentTool({
+  description: "Inspect a ticket by ID.",
+  inputSchema: z.object({ ticketId: z.string().min(1) }),
+  flow: flow({
+    name: "ticket.inspect",
+    parse: typed<{ ticketId: string }>(),
+    factory: (ctx) => ({ id: ctx.input.ticketId, status: "open" }),
+  }),
+})
+const triage = currentAgent({ name: "triage", tools: { inspect } })
+const run = turn({ agent: triage })
 const scope = createScope({
-  tags: [claude, claudeConfig({
-    auth: { kind: "global" },
-    cwd: process.cwd(),
-    roots: [],
-    permission: "deny",
-    shutdownTimeoutMs: 1_000,
-  })],
+  tags: [
+    claude,
+    claudeConfig({
+      auth: { kind: "global" },
+      cwd: process.cwd(),
+      roots: [],
+      permission: "deny",
+      shutdownTimeoutMs: 1_000,
+    }),
+    validation.engine(validation.standard<z.ZodType>((schema) => z.toJSONSchema(schema))),
+  ],
 })
 const ctx = scope.createContext()
 
-await ctx.exec({ flow: triage.turn, input: { prompt: "Triage this ticket." } })
+await ctx.exec({ flow: run, input: { prompt: "Inspect ticket T-42." } })
 ```
 
 Global auth reuses the Claude CLI's writable `~/.claude` state. Token auth reads a long-lived token

--- a/pkg/sdk/claude/README.md
+++ b/pkg/sdk/claude/README.md
@@ -8,6 +8,8 @@ Module-level managed Claude CLI model provider for `@pumped-fn/sdk`.
 agent -> model tag -> claude turn -> claude run -> scope-owned stream-json process
 ```
 
+Managed tools resolve in core before the provider request and need no provider registry.
+
 ```ts
 import { createScope } from "@pumped-fn/lite"
 import { agent } from "@pumped-fn/sdk"

--- a/pkg/sdk/claude/package.json
+++ b/pkg/sdk/claude/package.json
@@ -45,7 +45,8 @@
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod": "catalog:"
   },
   "license": "MIT",
   "repository": {

--- a/pkg/sdk/claude/tests/claude.test.ts
+++ b/pkg/sdk/claude/tests/claude.test.ts
@@ -2,7 +2,7 @@ import { PassThrough } from "node:stream"
 import { EventEmitter } from "node:events"
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process"
 import { createScope, flow, preset, typed, type Lite } from "@pumped-fn/lite"
-import { abortSignal, agent, model, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
+import { abortSignal, agent, currentAgent, currentTool, model, turn, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
 import { expect, expectTypeOf, it } from "vitest"
 import * as claudeModule from "../src/index"
 import {
@@ -61,6 +61,45 @@ it("can replace the model tag per context", async () => {
 
   await claudeCtx.close()
   await fakeCtx.close()
+  await scope.dispose()
+})
+
+it("resolves managed tools before the Claude request", async () => {
+  const prompts: PromptInput[] = []
+  const responses = [
+    JSON.stringify({ content: "calling", stop: false, toolCalls: [{ name: "inspect", input: "claude" }] }),
+    JSON.stringify({ content: "done", stop: true }),
+  ]
+  const fake = flow({
+    name: "claude.managed-tools.fake",
+    parse: typed<PromptInput>(),
+    factory: (ctx) => {
+      prompts.push(ctx.input)
+      return responses.shift()!
+    },
+  })
+  const inspect = currentTool({
+    description: "Inspect input.",
+    flow: flow({
+      name: "inspect",
+      parse: typed<string>(),
+      factory: (ctx) => `tool:${ctx.input}`,
+    }),
+  })
+  const managed = currentAgent({ name: "managed", tools: { inspect } })
+  const run = turn({ agent: managed })
+  const scope = createScope({
+    presets: [preset(claudeRun, fake)],
+    tags: [claude, claudeConfig(managedConfig())],
+  })
+  const ctx = scope.createContext()
+
+  const result = await ctx.exec({ flow: run, input: { prompt: "run" } })
+
+  expect(prompts[0]?.prompt).toContain("inspect")
+  expect(prompts[1]?.prompt).toContain("tool:claude")
+  expect(result.toolResults).toMatchObject([{ name: "inspect", output: "tool:claude" }])
+  await ctx.close()
   await scope.dispose()
 })
 

--- a/pkg/sdk/claude/tests/claude.test.ts
+++ b/pkg/sdk/claude/tests/claude.test.ts
@@ -2,8 +2,9 @@ import { PassThrough } from "node:stream"
 import { EventEmitter } from "node:events"
 import type { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio } from "node:child_process"
 import { createScope, flow, preset, typed, type Lite } from "@pumped-fn/lite"
-import { abortSignal, agent, currentAgent, currentTool, model, turn, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
+import { abortSignal, agent, currentAgent, currentTool, model, turn, validation, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
 import { expect, expectTypeOf, it } from "vitest"
+import * as z from "zod"
 import * as claudeModule from "../src/index"
 import {
   claude,
@@ -80,6 +81,7 @@ it("resolves managed tools before the Claude request", async () => {
   })
   const inspect = currentTool({
     description: "Inspect input.",
+    inputSchema: z.string(),
     flow: flow({
       name: "inspect",
       parse: typed<string>(),
@@ -90,13 +92,19 @@ it("resolves managed tools before the Claude request", async () => {
   const run = turn({ agent: managed })
   const scope = createScope({
     presets: [preset(claudeRun, fake)],
-    tags: [claude, claudeConfig(managedConfig())],
+    tags: [
+      claude,
+      claudeConfig(managedConfig()),
+      validation.engine(validation.standard<z.ZodType>((schema) => z.toJSONSchema(schema))),
+    ],
   })
   const ctx = scope.createContext()
 
   const result = await ctx.exec({ flow: run, input: { prompt: "run" } })
 
   expect(prompts[0]?.prompt).toContain("inspect")
+  expect(prompts[0]?.prompt).toContain("Input JSON Schema:")
+  expect(prompts[0]?.prompt).toContain('"type":"string"')
   expect(prompts[1]?.prompt).toContain("tool:claude")
   expect(result.toolResults).toMatchObject([{ name: "inspect", output: "tool:claude" }])
   await ctx.close()

--- a/pkg/sdk/codex/README.md
+++ b/pkg/sdk/codex/README.md
@@ -4,6 +4,8 @@
 
 Module-level Codex CLI and ACP model providers for `@pumped-fn/sdk`.
 
+Managed tools resolve in core before the provider request and need no provider registry.
+
 ```ts
 import { createScope } from "@pumped-fn/lite"
 import { agent } from "@pumped-fn/sdk"

--- a/pkg/sdk/codex/README.md
+++ b/pkg/sdk/codex/README.md
@@ -4,17 +4,35 @@
 
 Module-level Codex CLI and ACP model providers for `@pumped-fn/sdk`.
 
-Managed tools resolve in core before the provider request and need no provider registry.
+Managed tools resolve and publish their validated JSON Schema before the provider request. They need no provider registry.
 
 ```ts
-import { createScope } from "@pumped-fn/lite"
-import { agent } from "@pumped-fn/sdk"
+import { createScope, flow, typed } from "@pumped-fn/lite"
+import { currentAgent, currentTool, turn, validation } from "@pumped-fn/sdk"
 import { codex, codexConfig } from "@pumped-fn/sdk-codex"
+import * as z from "zod"
 
-const triage = agent({ name: "triage" })
-const scope = createScope({
-  tags: [codex, codexConfig({ auth: { kind: "global" } })],
+const inspect = currentTool({
+  description: "Inspect a repository issue.",
+  inputSchema: z.object({ issue: z.number().int().positive() }),
+  flow: flow({
+    name: "issue.inspect",
+    parse: typed<{ issue: number }>(),
+    factory: (ctx) => ({ issue: ctx.input.issue, state: "open" }),
+  }),
 })
+const triage = currentAgent({ name: "triage", tools: { inspect } })
+const run = turn({ agent: triage })
+const scope = createScope({
+  tags: [
+    codex,
+    codexConfig({ auth: { kind: "global" } }),
+    validation.engine(validation.standard<z.ZodType>((schema) => z.toJSONSchema(schema))),
+  ],
+})
+const ctx = scope.createContext()
+
+await ctx.exec({ flow: run, input: { prompt: "Inspect issue 42." } })
 ```
 
 Global auth reuses writable `CODEX_HOME` state. API-key auth reads the configured environment name

--- a/pkg/sdk/codex/package.json
+++ b/pkg/sdk/codex/package.json
@@ -49,7 +49,8 @@
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod": "catalog:"
   },
   "license": "MIT",
   "repository": {

--- a/pkg/sdk/codex/tests/codex.test.ts
+++ b/pkg/sdk/codex/tests/codex.test.ts
@@ -1,5 +1,5 @@
 import { createScope, flow, preset, typed } from "@pumped-fn/lite"
-import { agent, complete, model, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
+import { agent, complete, currentAgent, currentTool, model, turn, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
 import { expect, expectTypeOf, it } from "vitest"
 import * as codexModule from "../src/index"
 import {
@@ -106,3 +106,46 @@ it("can replace the model tag per context", async () => {
   await fakeCtx.close()
   await scope.dispose()
 })
+
+it("resolves managed tools before the Codex request", async () => {
+  const prompts: PromptInput[] = []
+  const responses = [
+    JSON.stringify({ content: "calling", stop: false, toolCalls: [{ name: "inspect", input: "codex" }] }),
+    JSON.stringify({ content: "done", stop: true }),
+  ]
+  const fake = flow({
+    name: "codex.managed-tools.fake",
+    parse: typed<PromptInput>(),
+    factory: (ctx) => {
+      prompts.push(ctx.input)
+      return responses.shift()!
+    },
+  })
+  const inspect = currentTool({
+    description: "Inspect input.",
+    flow: flow({
+      name: "inspect",
+      parse: typed<string>(),
+      factory: (ctx) => `tool:${ctx.input}`,
+    }),
+  })
+  const managed = currentAgent({ name: "managed", tools: { inspect } })
+  const run = turn({ agent: managed })
+  const scope = createScope({
+    presets: [preset(codexRun, fake)],
+    tags: [codex, codexConfig(managedConfig())],
+  })
+  const ctx = scope.createContext()
+
+  const result = await ctx.exec({ flow: run, input: { prompt: "run" } })
+
+  expect(prompts[0]?.prompt).toContain("inspect")
+  expect(prompts[1]?.prompt).toContain("tool:codex")
+  expect(result.toolResults).toMatchObject([{ name: "inspect", output: "tool:codex" }])
+  await ctx.close()
+  await scope.dispose()
+})
+
+function managedConfig(): Parameters<typeof codexConfig>[0] {
+  return { auth: { kind: "global" } }
+}

--- a/pkg/sdk/codex/tests/codex.test.ts
+++ b/pkg/sdk/codex/tests/codex.test.ts
@@ -1,6 +1,7 @@
 import { createScope, flow, preset, typed } from "@pumped-fn/lite"
-import { agent, complete, currentAgent, currentTool, model, turn, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
+import { agent, complete, currentAgent, currentTool, model, turn, validation, type Model, type ModelRequest, type PromptInput } from "@pumped-fn/sdk"
 import { expect, expectTypeOf, it } from "vitest"
+import * as z from "zod"
 import * as codexModule from "../src/index"
 import {
   codex,
@@ -123,6 +124,7 @@ it("resolves managed tools before the Codex request", async () => {
   })
   const inspect = currentTool({
     description: "Inspect input.",
+    inputSchema: z.string(),
     flow: flow({
       name: "inspect",
       parse: typed<string>(),
@@ -133,13 +135,19 @@ it("resolves managed tools before the Codex request", async () => {
   const run = turn({ agent: managed })
   const scope = createScope({
     presets: [preset(codexRun, fake)],
-    tags: [codex, codexConfig(managedConfig())],
+    tags: [
+      codex,
+      codexConfig(managedConfig()),
+      validation.engine(validation.standard<z.ZodType>((schema) => z.toJSONSchema(schema))),
+    ],
   })
   const ctx = scope.createContext()
 
   const result = await ctx.exec({ flow: run, input: { prompt: "run" } })
 
   expect(prompts[0]?.prompt).toContain("inspect")
+  expect(prompts[0]?.prompt).toContain("Input JSON Schema:")
+  expect(prompts[0]?.prompt).toContain('"type":"string"')
   expect(prompts[1]?.prompt).toContain("tool:codex")
   expect(result.toolResults).toMatchObject([{ name: "inspect", output: "tool:codex" }])
   await ctx.close()

--- a/pkg/sdk/core/PATTERNS.md
+++ b/pkg/sdk/core/PATTERNS.md
@@ -211,11 +211,16 @@ const result = await ctx.exec({
 
 ## 4.1 Managed Tools (2.x)
 
-Use `currentTool()` when a tool flow needs context-owned dependencies. Put those resources in the keyed `tools` record passed to `currentAgent()`; resolution creates one frozen, ordered snapshot of projected flow handles before `turn()` calls the model. The model provider remains the `model` tag used by `complete`.
+Use `currentTool()` when a tool flow needs context-owned dependencies. Put those resources in the keyed `tools` record passed to `currentAgent()`; resolution creates one frozen, ordered snapshot of validated projected flow handles before `turn()` calls the model. The model provider remains the `model` tag used by `complete`.
 
 ```ts
+import { createScope, tags } from "@pumped-fn/lite"
+import { currentAgent, currentTool, model, turn, validation } from "@pumped-fn/sdk"
+import * as z from "zod"
+
 const search = currentTool({
   description: "Search records.",
+  inputSchema: z.object({ query: z.string().min(1) }),
   flow: searchFlow,
   deps: { backend: tags.required(searchBackend) },
 })
@@ -226,10 +231,26 @@ const managed = currentAgent({
 })
 
 const run = turn({ agent: managed })
+const scope = createScope({
+  tags: [
+    model(provider),
+    validation.engine(validation.standard<z.ZodType>((schema) => z.toJSONSchema(schema))),
+  ],
+})
+const ctx = scope.createContext()
 const result = await ctx.exec({ flow: run, input: { prompt: "find 42" } })
 ```
 
-The managed agent has no `.turn` member. A tool call can only dispatch through the exact flow handle advertised in its resolved snapshot, so model input cannot provide required tags or replace the backend dependency.
+The managed agent has no `.turn` member. A tool call can only dispatch through the exact flow handle and input schema advertised in its resolved snapshot. Invalid model input fails before the flow starts. Model input cannot provide required tags or replace the backend dependency. There is no default validation engine.
+
+Valibot uses the same graph. Only the scope tag changes:
+
+```ts
+import { toJsonSchema } from "@valibot/to-json-schema"
+import * as v from "valibot"
+
+validation.engine(validation.standard<v.GenericSchema>((schema) => toJsonSchema(schema)))
+```
 
 Why: tools and subagent turns still run through `ctx.exec()`, so the same workflow extension can replay, suspend, route, or time out the work. `events` is a boundary resource, so run inspection is testable without a global observer.
 

--- a/pkg/sdk/core/PATTERNS.md
+++ b/pkg/sdk/core/PATTERNS.md
@@ -209,6 +209,28 @@ const result = await ctx.exec({
 })
 ```
 
+## 4.1 Managed Tools (2.x)
+
+Use `currentTool()` when a tool flow needs context-owned dependencies. Put those resources in the keyed `tools` record passed to `currentAgent()`; resolution creates one frozen, ordered snapshot of projected flow handles before `turn()` calls the model. The model provider remains the `model` tag used by `complete`.
+
+```ts
+const search = currentTool({
+  description: "Search records.",
+  flow: searchFlow,
+  deps: { backend: tags.required(searchBackend) },
+})
+
+const managed = currentAgent({
+  name: "managed-search",
+  tools: { search },
+})
+
+const run = turn({ agent: managed })
+const result = await ctx.exec({ flow: run, input: { prompt: "find 42" } })
+```
+
+The managed agent has no `.turn` member. A tool call can only dispatch through the exact flow handle advertised in its resolved snapshot, so model input cannot provide required tags or replace the backend dependency.
+
 Why: tools and subagent turns still run through `ctx.exec()`, so the same workflow extension can replay, suspend, route, or time out the work. `events` is a boundary resource, so run inspection is testable without a global observer.
 
 ## 5. Agent Evals

--- a/pkg/sdk/core/README.md
+++ b/pkg/sdk/core/README.md
@@ -2,7 +2,7 @@
 
 ## 2.x Compatibility
 
-The legacy `tool()` and `agent()` APIs remain unchanged. The 2.x managed-tool API adds `currentTool()`, `currentAgent()`, and `turn()` for an explicitly resolved tool snapshot: tools are resolved before the model call, and each advertised tool dispatches through the exact projected flow handle captured in that snapshot.
+The legacy `tool()` and `agent()` APIs remain unchanged. The 2.x managed-tool API adds `currentTool()`, `currentAgent()`, and `turn()` for an explicitly resolved tool snapshot: tools and their Standard Schema inputs resolve before the model call, and each advertised tool validates through the scope-injected `validation.engine` before dispatching through the exact projected flow handle captured in that snapshot. Zod and Valibot are supported without a built-in default.
 
 Generic runtime primitives on top of `@pumped-fn/lite`: durable workflow steps, sessions,
 materials, event buffers, guards, sandboxes, CLI workers, and an eval harness. Agents and models

--- a/pkg/sdk/core/README.md
+++ b/pkg/sdk/core/README.md
@@ -1,5 +1,9 @@
 # @pumped-fn/sdk
 
+## 2.x Compatibility
+
+The legacy `tool()` and `agent()` APIs remain unchanged. The 2.x managed-tool API adds `currentTool()`, `currentAgent()`, and `turn()` for an explicitly resolved tool snapshot: tools are resolved before the model call, and each advertised tool dispatches through the exact projected flow handle captured in that snapshot.
+
 Generic runtime primitives on top of `@pumped-fn/lite`: durable workflow steps, sessions,
 materials, event buffers, guards, sandboxes, CLI workers, and an eval harness. Agents and models
 are one primitive family built on the same seam, not the headline.

--- a/pkg/sdk/core/package.json
+++ b/pkg/sdk/core/package.json
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "build": "tsdown",
-    "typecheck": "tsgo --noEmit",
+    "typecheck": "tsgo --noEmit && tsgo --noEmit -p tsconfig.test.json",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/pkg/sdk/core/package.json
+++ b/pkg/sdk/core/package.json
@@ -38,16 +38,20 @@
     "@pumped-fn/lite": "^3.1.0"
   },
   "dependencies": {
+    "@standard-schema/spec": "catalog:",
     "@pumped-fn/lite-extension-suspense": "workspace:^"
   },
   "devDependencies": {
     "@pumped-fn/lite": "workspace:*",
+    "@valibot/to-json-schema": "catalog:",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",
+    "valibot": "catalog:",
     "vite": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod": "catalog:"
   },
   "license": "MIT",
   "repository": {

--- a/pkg/sdk/core/src/index.ts
+++ b/pkg/sdk/core/src/index.ts
@@ -1,4 +1,5 @@
 import { atom, flow, resource, tag, tags, typed, type Lite } from "@pumped-fn/lite"
+import type { StandardSchemaV1 } from "@standard-schema/spec"
 import {
   extension as suspenseExtension,
   formatSuspenseStepKey,
@@ -910,7 +911,12 @@ function guardTextOf(value: unknown): string | undefined {
 }
 
 function formatCapability(capability: Capability): string {
-  return `- ${capability.name}: ${capability.description}`
+  return [
+    `- ${capability.name}: ${capability.description}`,
+    capability.inputSchema === undefined
+      ? undefined
+      : `  Input JSON Schema: ${JSON.stringify(capability.inputSchema)}`,
+  ].filter((item) => item !== undefined).join("\n")
 }
 
 function formatLoadedSkill(skill: LoadedSkill): string {
@@ -998,6 +1004,7 @@ export interface TurnInput {
 export interface Capability {
   name: string
   description: string
+  inputSchema?: JsonSchema
 }
 
 export interface Tool<Output = unknown, Input = unknown> extends Capability {
@@ -1244,56 +1251,122 @@ export function agent(options: AgentOptions): Agent {
   return agent
 }
 
+export type JsonSchema = boolean | Readonly<object>
+
+export interface ValidationEngine {
+  validate(schema: StandardSchemaV1, input: unknown): MaybePromise<StandardSchemaV1.Result<unknown>>
+  toJsonSchema(schema: StandardSchemaV1): JsonSchema
+}
+
+export interface ValidationEngineOptions<Schema extends StandardSchemaV1> {
+  validate(schema: Schema, input: unknown): MaybePromise<StandardSchemaV1.Result<unknown>>
+  toJsonSchema(schema: Schema): JsonSchema
+}
+
+const validationEngine = tag<ValidationEngine>({ label: "agent.validation.engine" })
+
+function defineValidationEngine<Schema extends StandardSchemaV1>(
+  options: ValidationEngineOptions<Schema>
+): ValidationEngine {
+  return {
+    validate: (schema, input) => options.validate(schema as Schema, input),
+    toJsonSchema: (schema) => options.toJsonSchema(schema as Schema),
+  }
+}
+
+function standardValidationEngine<Schema extends StandardSchemaV1>(
+  toJsonSchema: (schema: Schema) => JsonSchema
+): ValidationEngine {
+  return defineValidationEngine<Schema>({
+    validate: (schema, input) => schema["~standard"].validate(input),
+    toJsonSchema,
+  })
+}
+
+export const validation = Object.freeze({
+  engine: validationEngine,
+  define: defineValidationEngine,
+  standard: standardValidationEngine,
+})
+
+export class ToolInputError extends Error {
+  override readonly name = "ToolInputError"
+
+  constructor(
+    readonly toolName: string,
+    readonly issues: readonly StandardSchemaV1.Issue[]
+  ) {
+    super(`Tool "${toolName}" input failed validation: ${issues.map((issue) => issue.message).join("; ")}`)
+  }
+}
+
 export interface CurrentTool<Output, Input, Yield = never> {
   readonly name: string
   readonly description: string
+  readonly inputSchema: JsonSchema
   readonly flow: Lite.FlowHandle<Output, Input, Yield>
+  readonly validate: (input: unknown) => MaybePromise<StandardSchemaV1.Result<unknown>>
 }
 
 interface CurrentToolResourceValue {
   readonly name: string
   readonly description: string
-  readonly flow: Lite.FlowHandle<unknown, unknown, unknown>
+  readonly inputSchema: JsonSchema
+  readonly flow: Lite.FlowHandle<any, any, any>
+  readonly validate: (input: unknown) => MaybePromise<StandardSchemaV1.Result<unknown>>
 }
 
 type CurrentToolResource = Lite.Resource<CurrentToolResourceValue>
 
 export interface CurrentToolOptions<
   Output,
-  Input,
+  Schema extends StandardSchemaV1,
   Fault = never,
   Yield = never,
   D extends Record<string, Lite.ResourceDependency> = Record<string, never>,
 > {
   name?: string
   description: string
-  flow: Lite.Flow<Output, Input, Fault, Yield>
-  deps?: D & { flow?: never }
+  inputSchema: Schema
+  flow: Lite.Flow<Output, StandardSchemaV1.InferOutput<Schema>, Fault, Yield>
+  deps?: D & { flow?: never; validation?: never }
 }
 
 export function currentTool<
   Output,
-  Input,
+  const Schema extends StandardSchemaV1,
   Fault = never,
   Yield = never,
   const D extends Record<string, Lite.ResourceDependency> = Record<string, never>,
->(options: CurrentToolOptions<Output, Input, Fault, Yield, D>): Lite.Resource<CurrentTool<Output, Input, Yield>> {
+>(options: CurrentToolOptions<Output, Schema, Fault, Yield, D>): Lite.Resource<
+  CurrentTool<Output, StandardSchemaV1.InferOutput<Schema>, Yield>
+> {
   const name = options.name ?? options.flow.name
   if (!name) throw new Error("Current agent tool requires a name")
-  const deps = { ...(options.deps ?? {}), flow: options.flow }
+  const deps = {
+    ...(options.deps ?? {}),
+    validation: tags.required(validation.engine),
+    flow: options.flow,
+  }
   return resource({
     name,
     ownership: "current",
     deps,
-    factory: (_ctx, resolved) => Object.freeze({
+    factory: (_ctx, { flow, validation }) => Object.freeze({
       name,
       description: options.description,
-      flow: resolved.flow,
+      inputSchema: freezeJsonSchema(validation.toJsonSchema(options.inputSchema)),
+      flow,
+      validate: (input: unknown) => validation.validate(options.inputSchema, input),
     }),
   })
 }
 
 export type CurrentToolValue<T> = T extends Lite.Resource<infer Value> ? Value : never
+
+function freezeJsonSchema(schema: JsonSchema): JsonSchema {
+  return typeof schema === "boolean" ? schema : Object.freeze(schema)
+}
 
 export interface CurrentAgentOptions<Tools extends Record<string, CurrentToolResource>> {
   name: string
@@ -1822,8 +1895,10 @@ async function executeCurrentAgentTool<Tools extends Record<string, CurrentToolR
     targetName: target.name,
     input: call.input,
   })
+  const validated = await target.validate(call.input)
+  if (validated.issues) throw new ToolInputError(target.name, validated.issues)
   const output = await target.flow.exec({
-    input: call.input,
+    input: validated.value as any,
     name: target.name,
     tags: [agentStepTag({ workflow: true, kind: "tool" }, target.flow.flow.tags)],
   })
@@ -1967,10 +2042,15 @@ function agentToolCapability(tool: AnyTool): Capability {
   }
 }
 
-function currentToolCapability(tool: { name: string; description: string }): Capability {
+function currentToolCapability(tool: {
+  name: string
+  description: string
+  inputSchema: JsonSchema
+}): Capability {
   return {
     name: tool.name,
     description: tool.description,
+    inputSchema: tool.inputSchema,
   }
 }
 

--- a/pkg/sdk/core/src/index.ts
+++ b/pkg/sdk/core/src/index.ts
@@ -978,10 +978,14 @@ export interface SandboxExecResult {
   exitCode: number
 }
 
+export interface SandboxExecOptions {
+  signal?: AbortSignal
+}
+
 export interface Sandbox {
   readFile(path: string): MaybePromise<string>
   writeFile(path: string, content: string): MaybePromise<void>
-  exec(command: string, args?: readonly string[]): MaybePromise<SandboxExecResult>
+  exec(command: string, args?: readonly string[], options?: SandboxExecOptions): MaybePromise<SandboxExecResult>
 }
 
 export interface TurnInput {
@@ -1238,6 +1242,117 @@ export function agent(options: AgentOptions): Agent {
     maxRounds,
   }
   return agent
+}
+
+export interface CurrentTool<Output, Input, Yield = never> {
+  readonly name: string
+  readonly description: string
+  readonly flow: Lite.FlowHandle<Output, Input, Yield>
+}
+
+interface CurrentToolResourceValue {
+  readonly name: string
+  readonly description: string
+  readonly flow: Lite.FlowHandle<unknown, unknown, unknown>
+}
+
+type CurrentToolResource = Lite.Resource<CurrentToolResourceValue>
+
+export interface CurrentToolOptions<
+  Output,
+  Input,
+  Fault = never,
+  Yield = never,
+  D extends Record<string, Lite.ResourceDependency> = Record<string, never>,
+> {
+  name?: string
+  description: string
+  flow: Lite.Flow<Output, Input, Fault, Yield>
+  deps?: D & { flow?: never }
+}
+
+export function currentTool<
+  Output,
+  Input,
+  Fault = never,
+  Yield = never,
+  const D extends Record<string, Lite.ResourceDependency> = Record<string, never>,
+>(options: CurrentToolOptions<Output, Input, Fault, Yield, D>): Lite.Resource<CurrentTool<Output, Input, Yield>> {
+  const name = options.name ?? options.flow.name
+  if (!name) throw new Error("Current agent tool requires a name")
+  const deps = { ...(options.deps ?? {}), flow: options.flow }
+  return resource({
+    name,
+    ownership: "current",
+    deps,
+    factory: (_ctx, resolved) => Object.freeze({
+      name,
+      description: options.description,
+      flow: resolved.flow,
+    }),
+  })
+}
+
+export type CurrentToolValue<T> = T extends Lite.Resource<infer Value> ? Value : never
+
+export interface CurrentAgentOptions<Tools extends Record<string, CurrentToolResource>> {
+  name: string
+  description?: string
+  instructions?: string
+  tools: Tools
+  maxRounds?: number
+}
+
+export interface CurrentAgent<Tools extends Record<string, CurrentToolResource>> {
+  readonly name: string
+  readonly description?: string
+  readonly instructions: string
+  readonly tools: readonly CurrentToolValue<Tools[keyof Tools]>[]
+  readonly maxRounds: number
+}
+
+export function currentAgent<const Tools extends Record<string, CurrentToolResource>>(
+  options: CurrentAgentOptions<Tools>
+): Lite.Resource<CurrentAgent<Tools>> {
+  const maxRounds = options.maxRounds ?? 4
+  return resource({
+    name: options.name,
+    ownership: "current",
+    deps: options.tools,
+    factory: (_ctx, tools) => {
+      const values = Object.values(tools)
+      const names = new Set<string>()
+      for (const tool of values) {
+        if (names.has(tool.name)) throw new Error(`Current agent "${options.name}" has duplicate tool name "${tool.name}"`)
+        names.add(tool.name)
+      }
+      return Object.freeze({
+        name: options.name,
+        description: options.description,
+        instructions: options.instructions ?? "",
+        tools: Object.freeze(values),
+        maxRounds,
+      })
+    },
+  })
+}
+
+export interface TurnOptions<Tools extends Record<string, CurrentToolResource>> {
+  name?: string
+  agent: Lite.Resource<CurrentAgent<Tools>>
+  tags?: Lite.Tagged<unknown>[]
+}
+
+export function turn<const Tools extends Record<string, CurrentToolResource>>(
+  options: TurnOptions<Tools>
+): Lite.Flow<TurnResult, TurnInput> {
+  return flow({
+    name: options.name ?? `${options.agent.name ?? "agent"}-turn`,
+    parse: typed<TurnInput>(),
+    deps: { agent: options.agent, complete },
+    tags: agentStepTags({ workflow: true, kind: "agent" }, options.tags),
+    factory: (ctx, deps) => executeCurrentAgentTurn(ctx, deps.agent, deps.complete),
+  })
 }
 
 function execTurn(
@@ -1610,6 +1725,122 @@ async function executeAgentTurn(
   }
 }
 
+async function executeCurrentAgentTurn<Tools extends Record<string, CurrentToolResource>>(
+  ctx: Lite.ExecutionContext & { readonly input: TurnInput },
+  agent: CurrentAgent<Tools>,
+  complete: Lite.FlowHandle<ModelResponse, ModelRequest>
+): Promise<TurnResult> {
+  const messages = initialMessages(ctx.input)
+  const toolResults: ToolResult[] = []
+  const subagentResults: SubResult[] = []
+  const skillResults: SkillResult[] = []
+  const maxRounds = ctx.input.maxRounds ?? agent.maxRounds
+  let content = ""
+  let rounds = 0
+  const startIndex = (await ctx.resolve(events)).events.length
+
+  await recordAgentEvent(ctx, {
+    type: "agent_start",
+    agentName: agent.name,
+    input: ctx.input,
+  })
+
+  for (let round = 0; round < maxRounds; round++) {
+    rounds = round + 1
+    await recordAgentEvent(ctx, {
+      type: "agent_model_start",
+      agentName: agent.name,
+      round,
+      input: messages,
+    })
+    const response = await complete.exec({
+      input: {
+        agentName: agent.name,
+        instructions: agent.instructions,
+        messages,
+        tools: agent.tools.map(currentToolCapability),
+        skills: [],
+        loadedSkills: [],
+        subagents: [],
+        round,
+      },
+    })
+    if (response.skillCalls !== undefined) throw new Error(`Current agent "${agent.name}" does not support skillCalls`)
+    if (response.subagentCalls !== undefined) throw new Error(`Current agent "${agent.name}" does not support subagentCalls`)
+    content = response.content
+    await recordAgentEvent(ctx, {
+      type: "agent_model_end",
+      agentName: agent.name,
+      round,
+      output: response,
+    })
+
+    const toolCalls = response.toolCalls ?? []
+    if (response.content) messages.push({ role: "assistant", content: response.content })
+    if (response.stop === true || toolCalls.length === 0) break
+
+    for (const call of toolCalls) {
+      const result = await executeCurrentAgentTool(ctx, agent, call)
+      toolResults.push(result)
+      messages.push({
+        role: "tool",
+        name: result.name,
+        content: stringifyAgentValue(result.output),
+        ...(result.id ? { id: result.id, input: result.input } : {}),
+      })
+    }
+  }
+
+  await recordAgentEvent(ctx, {
+    type: "agent_end",
+    agentName: agent.name,
+    output: content,
+  })
+
+  const buffer = await ctx.resolve(events)
+  return {
+    agentName: agent.name,
+    content,
+    messages,
+    skillResults,
+    toolResults,
+    subagentResults,
+    rounds,
+    events: buffer.events.slice(startIndex),
+  }
+}
+
+async function executeCurrentAgentTool<Tools extends Record<string, CurrentToolResource>>(
+  ctx: Lite.ExecutionContext,
+  agent: CurrentAgent<Tools>,
+  call: ToolCall
+): Promise<ToolResult> {
+  const target = findByName(agent.tools, call.name, "tool")
+  await recordAgentEvent(ctx, {
+    type: "agent_tool_start",
+    agentName: agent.name,
+    targetName: target.name,
+    input: call.input,
+  })
+  const output = await target.flow.exec({
+    input: call.input,
+    name: target.name,
+    tags: [agentStepTag({ workflow: true, kind: "tool" }, target.flow.flow.tags)],
+  })
+  await recordAgentEvent(ctx, {
+    type: "agent_tool_end",
+    agentName: agent.name,
+    targetName: target.name,
+    output,
+  })
+  return {
+    name: target.name,
+    id: call.id,
+    input: call.input,
+    output,
+  }
+}
+
 async function executeAgentSkill(
   ctx: Lite.ExecutionContext,
   agent: Agent,
@@ -1730,6 +1961,13 @@ function agentStepTag(defaults: Step, source: Lite.Tagged<any>[] = []): Lite.Tag
 }
 
 function agentToolCapability(tool: AnyTool): Capability {
+  return {
+    name: tool.name,
+    description: tool.description,
+  }
+}
+
+function currentToolCapability(tool: { name: string; description: string }): Capability {
   return {
     name: tool.name,
     description: tool.description,

--- a/pkg/sdk/core/tests/managed-tools.test.ts
+++ b/pkg/sdk/core/tests/managed-tools.test.ts
@@ -1,18 +1,26 @@
 import { createScope, flow, resource, tag, tags, typed, type Lite } from "@pumped-fn/lite"
+import { toJsonSchema } from "@valibot/to-json-schema"
 import { describe, expect, it } from "vitest"
+import * as v from "valibot"
+import * as z from "zod"
 import {
   agent,
   currentAgent,
   currentTool,
   model,
   step,
+  ToolInputError,
   tool,
   turn,
+  validation,
   type Model,
   type ModelRequest,
   type ModelResponse,
   type Step,
 } from "../src/index"
+
+const validationTag = validation.engine(validation.standard<z.ZodType>((schema) => z.toJSONSchema(schema)))
+const valibotValidationTag = validation.engine(validation.standard<v.GenericSchema>((schema) => toJsonSchema(schema)))
 
 function provider(response: (request: ModelRequest) => ModelResponse): Model {
   return flow({
@@ -64,12 +72,14 @@ describe("managed tools", () => {
     })
     const first = currentTool({
       description: "First.",
-      flow: flow({ name: "first", factory: () => "first" }),
+      inputSchema: z.unknown(),
+      flow: flow({ name: "first", parse: typed<unknown>(), factory: () => "first" }),
       deps: { ready: ready("first") },
     })
     const second = currentTool({
       description: "Second.",
-      flow: flow({ name: "second", factory: () => "second" }),
+      inputSchema: z.unknown(),
+      flow: flow({ name: "second", parse: typed<unknown>(), factory: () => "second" }),
       deps: { ready: ready("second") },
     })
     const managed = currentAgent({ name: "managed", tools: { first, second } })
@@ -77,7 +87,7 @@ describe("managed tools", () => {
     let advertised: readonly string[] = []
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider((request) => {
+      tags: [validationTag, model(provider((request) => {
         modelCalls++
         expect([...resolved]).toEqual(["first", "second"])
         advertised = request.tools.map((item) => item.name)
@@ -109,13 +119,14 @@ describe("managed tools", () => {
     const selected = currentTool({
       name: "selected",
       description: "Selected.",
+      inputSchema: z.string(),
       flow: declared,
       deps,
     })
     const managed = currentAgent({ name: "managed", tools: { selected } })
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider(() => ({
+      tags: [validationTag, model(provider(() => ({
         content: "calling",
         toolCalls: [{ name: "selected", input: "item" }],
       })))],
@@ -142,18 +153,20 @@ describe("managed tools", () => {
     })
     const first = currentTool({
       description: "First.",
-      flow: flow({ name: "first", factory: () => "first" }),
+      inputSchema: z.unknown(),
+      flow: flow({ name: "first", parse: typed<unknown>(), factory: () => "first" }),
       deps: { dependency: managedDependency("tool-dependency") },
     })
     const second = currentTool({
       description: "Second.",
-      flow: flow({ name: "second", factory: () => "second" }),
+      inputSchema: z.unknown(),
+      flow: flow({ name: "second", parse: typed<unknown>(), factory: () => "second" }),
       deps: { dependency: managedDependency("agent-dependency") },
     })
     const managed = currentAgent({ name: "managed", tools: { first, second } })
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider(() => ({ content: "done", stop: true })))],
+      tags: [validationTag, model(provider(() => ({ content: "done", stop: true })))],
     })
     const ctx = scope.createContext()
 
@@ -167,14 +180,15 @@ describe("managed tools", () => {
     const policy = tag<string>({ label: "policy" })
     const guarded = currentTool({
       description: "Guarded.",
-      flow: flow({ name: "guarded", factory: () => "ok" }),
+      inputSchema: z.unknown(),
+      flow: flow({ name: "guarded", parse: typed<unknown>(), factory: () => "ok" }),
       deps: { policy: tags.required(policy) },
     })
     const managed = currentAgent({ name: "managed", tools: { guarded } })
     let modelCalls = 0
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider(() => {
+      tags: [validationTag, model(provider(() => {
         modelCalls++
         return { content: "unexpected", stop: true }
       }))],
@@ -186,10 +200,95 @@ describe("managed tools", () => {
     await close(scope, ctx)
   })
 
+  it("requires an explicit validation engine before advertising tools", async () => {
+    const inspect = currentTool({
+      description: "Inspect.",
+      inputSchema: z.object({ id: z.string() }),
+      flow: flow({
+        name: "inspect",
+        parse: typed<{ id: string }>(),
+        factory: (ctx) => ctx.input.id,
+      }),
+    })
+    let modelCalls = 0
+    const run = turn({ agent: currentAgent({ name: "managed", tools: { inspect } }) })
+    const scope = createScope({
+      tags: [model(provider(() => {
+        modelCalls++
+        return { content: "unexpected", stop: true }
+      }))],
+    })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: run, input: { prompt: "run" } })).rejects.toThrow("agent.validation.engine")
+    expect(modelCalls).toBe(0)
+    await close(scope, ctx)
+  })
+
+  it("advertises and enforces the Zod input schema before tool execution", async () => {
+    let executions = 0
+    let advertised: unknown
+    const inspect = currentTool({
+      description: "Inspect.",
+      inputSchema: z.object({ id: z.uuid() }),
+      flow: flow({
+        name: "inspect",
+        parse: typed<{ id: string }>(),
+        factory: (ctx) => {
+          executions++
+          return ctx.input.id
+        },
+      }),
+    })
+    const run = turn({ agent: currentAgent({ name: "managed", tools: { inspect } }) })
+    const scope = createScope({
+      tags: [validationTag, model(provider((request) => {
+        advertised = request.tools[0]?.inputSchema
+        return { content: "calling", toolCalls: [{ name: "inspect", input: { id: "not-a-uuid" } }] }
+      }))],
+    })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: run, input: { prompt: "run" } })).rejects.toBeInstanceOf(ToolInputError)
+    expect(advertised).toMatchObject({
+      properties: { id: { format: "uuid", type: "string" } },
+      required: ["id"],
+      type: "object",
+    })
+    expect(executions).toBe(0)
+    await close(scope, ctx)
+  })
+
+  it("switches to a Valibot engine at the scope seam", async () => {
+    const sum = currentTool({
+      description: "Add values.",
+      inputSchema: v.object({ left: v.number(), right: v.number() }),
+      flow: flow({
+        name: "sum",
+        parse: typed<{ left: number; right: number }>(),
+        factory: (ctx) => ctx.input.left + ctx.input.right,
+      }),
+    })
+    const run = turn({ agent: currentAgent({ name: "managed", tools: { sum } }) })
+    const scope = createScope({
+      tags: [valibotValidationTag, model(provider(() => ({
+        content: "calling",
+        toolCalls: [{ name: "sum", input: { left: 20, right: 22 } }],
+      })))],
+    })
+    const ctx = scope.createContext()
+
+    const result = await ctx.exec({ flow: run, input: { prompt: "run", maxRounds: 1 } })
+
+    expect(result.toolResults[0]?.output).toBe(42)
+    await close(scope, ctx)
+  })
+
   it("dispatches the tool selected from the advertised snapshot", async () => {
     const selected = currentTool({
       name: "selected",
       description: "Selected.",
+      inputSchema: z.object({ id: z.string() }),
       flow: flow({
         name: "selected-flow",
         parse: typed<{ id: string }>(),
@@ -199,7 +298,8 @@ describe("managed tools", () => {
     const other = currentTool({
       name: "other",
       description: "Other.",
-      flow: flow({ name: "other-flow", factory: () => "other" }),
+      inputSchema: z.unknown(),
+      flow: flow({ name: "other-flow", parse: typed<unknown>(), factory: () => "other" }),
     })
     const managed = currentAgent({ name: "managed", tools: { selected, other } })
     const responses = [
@@ -209,7 +309,7 @@ describe("managed tools", () => {
     let advertised: readonly string[] = []
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider((request) => {
+      tags: [validationTag, model(provider((request) => {
         advertised = request.tools.map((item) => item.name)
         return responses[request.round] ?? responses[1]!
       }))],
@@ -227,7 +327,13 @@ describe("managed tools", () => {
     const selected = currentTool({
       name: "selected",
       description: "Selected.",
-      flow: flow({ name: "selected-flow", tags: [step({ timeoutMs: 17 })], factory: () => "selected" }),
+      inputSchema: z.unknown(),
+      flow: flow({
+        name: "selected-flow",
+        parse: typed<unknown>(),
+        tags: [step({ timeoutMs: 17 })],
+        factory: () => "selected",
+      }),
     })
     const managed = currentAgent({ name: "managed", tools: { selected } })
     const observations: { name: string | undefined; step: Step | undefined }[] = []
@@ -241,7 +347,7 @@ describe("managed tools", () => {
     const run = turn({ agent: managed })
     const scope = createScope({
       extensions: [observer],
-      tags: [model(provider(() => ({
+      tags: [validationTag, model(provider(() => ({
         content: "calling",
         toolCalls: [{ name: "selected", input: "item" }],
       })))],
@@ -258,17 +364,19 @@ describe("managed tools", () => {
     const first = currentTool({
       name: "same",
       description: "First.",
-      flow: flow({ name: "first", factory: () => "first" }),
+      inputSchema: z.unknown(),
+      flow: flow({ name: "first", parse: typed<unknown>(), factory: () => "first" }),
     })
     const second = currentTool({
       name: "same",
       description: "Second.",
-      flow: flow({ name: "second", factory: () => "second" }),
+      inputSchema: z.unknown(),
+      flow: flow({ name: "second", parse: typed<unknown>(), factory: () => "second" }),
     })
     const managed = currentAgent({ name: "managed", tools: { first, second } })
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider(() => ({ content: "unexpected", stop: true })))],
+      tags: [validationTag, model(provider(() => ({ content: "unexpected", stop: true })))],
     })
     const ctx = scope.createContext()
 
@@ -307,8 +415,10 @@ describe("managed tools", () => {
     })
     const failing = currentTool({
       description: "Failing.",
+      inputSchema: z.unknown(),
       flow: flow({
         name: "failing",
+        parse: typed<unknown>(),
         factory: () => {
           throw new Error("tool failed")
         },
@@ -318,7 +428,7 @@ describe("managed tools", () => {
     const managed = currentAgent({ name: "managed", tools: { failing } })
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider(() => ({ content: "calling", toolCalls: [{ name: "failing", input: null }] })))],
+      tags: [validationTag, model(provider(() => ({ content: "calling", toolCalls: [{ name: "failing", input: null }] })))],
     })
     const ctx = scope.createContext()
 
@@ -340,13 +450,14 @@ describe("managed tools", () => {
     })
     const selected = currentTool({
       description: "Selected.",
-      flow: flow({ name: "selected", factory: () => "selected" }),
+      inputSchema: z.unknown(),
+      flow: flow({ name: "selected", parse: typed<unknown>(), factory: () => "selected" }),
       deps: { dependency },
     })
     const managed = currentAgent({ name: "managed", tools: { selected } })
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider(() => ({ content: "calling", toolCalls: [{ name: "selected", input: null }] })))],
+      tags: [validationTag, model(provider(() => ({ content: "calling", toolCalls: [{ name: "selected", input: null }] })))],
     })
     const ctx = scope.createContext()
 
@@ -359,6 +470,7 @@ describe("managed tools", () => {
     const backend = tag<string>({ label: "backend" })
     const lookup = currentTool({
       description: "Lookup.",
+      inputSchema: z.string(),
       flow: flow({
         name: "lookup",
         parse: typed<string>(),
@@ -369,7 +481,7 @@ describe("managed tools", () => {
     const managed = currentAgent({ name: "managed", tools: { lookup } })
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider(() => ({
+      tags: [validationTag, model(provider(() => ({
         content: "lookup",
         toolCalls: [{ name: "lookup", input: "item" }],
       })))],
@@ -391,6 +503,7 @@ describe("managed tools", () => {
     const approval = tag<boolean>({ label: "approval" })
     const approved = currentTool({
       description: "Approved action.",
+      inputSchema: z.object({ approved: z.boolean() }),
       flow: flow({
         name: "approved",
         parse: typed<{ approved: boolean }>(),
@@ -401,7 +514,7 @@ describe("managed tools", () => {
     const managed = currentAgent({ name: "managed", tools: { approved } })
     const run = turn({ agent: managed })
     const scope = createScope({
-      tags: [model(provider(() => ({
+      tags: [validationTag, model(provider(() => ({
         content: "calling",
         toolCalls: [{ name: "approved", input: { approved: true } }],
       })))],

--- a/pkg/sdk/core/tests/managed-tools.test.ts
+++ b/pkg/sdk/core/tests/managed-tools.test.ts
@@ -1,0 +1,414 @@
+import { createScope, flow, resource, tag, tags, typed, type Lite } from "@pumped-fn/lite"
+import { describe, expect, it } from "vitest"
+import {
+  agent,
+  currentAgent,
+  currentTool,
+  model,
+  step,
+  tool,
+  turn,
+  type Model,
+  type ModelRequest,
+  type ModelResponse,
+  type Step,
+} from "../src/index"
+
+function provider(response: (request: ModelRequest) => ModelResponse): Model {
+  return flow({
+    name: "test-model",
+    parse: typed<ModelRequest>(),
+    factory: (ctx) => response(ctx.input),
+  })
+}
+
+async function close(scope: Lite.Scope, ctx: Lite.ExecutionContext) {
+  await ctx.close()
+  await scope.dispose()
+}
+
+describe("managed tools", () => {
+  it("leaves legacy tool and agent unchanged", async () => {
+    const legacy = tool({
+      description: "Legacy tool.",
+      flow: flow({
+        name: "legacy-tool",
+        parse: typed<string>(),
+        factory: (ctx) => `legacy:${ctx.input}`,
+      }),
+    })
+    const legacyAgent = agent({
+      name: "legacy-agent",
+      tools: [legacy],
+      tags: [model(provider(() => ({ content: "done", stop: true })))],
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+
+    expect(legacyAgent.turn).toBeDefined()
+    await expect(ctx.exec({ flow: legacyAgent.turn, input: { prompt: "run" } })).resolves.toMatchObject({
+      agentName: "legacy-agent",
+      content: "done",
+    })
+    await close(scope, ctx)
+  })
+
+  it("resolves every tool before the model call", async () => {
+    const resolved = new Set<string>()
+    const ready = (name: string) => resource({
+      ownership: "current",
+      factory: () => {
+        resolved.add(name)
+        return name
+      },
+    })
+    const first = currentTool({
+      description: "First.",
+      flow: flow({ name: "first", factory: () => "first" }),
+      deps: { ready: ready("first") },
+    })
+    const second = currentTool({
+      description: "Second.",
+      flow: flow({ name: "second", factory: () => "second" }),
+      deps: { ready: ready("second") },
+    })
+    const managed = currentAgent({ name: "managed", tools: { first, second } })
+    let modelCalls = 0
+    let advertised: readonly string[] = []
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider((request) => {
+        modelCalls++
+        expect([...resolved]).toEqual(["first", "second"])
+        advertised = request.tools.map((item) => item.name)
+        return { content: "ready", stop: true }
+      }))],
+    })
+    const ctx = scope.createContext()
+
+    await ctx.exec({ flow: run, input: { prompt: "run" } })
+
+    expect(modelCalls).toBe(1)
+    expect(advertised).toEqual(["first", "second"])
+    await close(scope, ctx)
+  })
+
+  it("keeps the declared flow when runtime deps contain flow", async () => {
+    const declared = flow({
+      name: "declared",
+      parse: typed<string>(),
+      factory: (ctx) => `declared:${ctx.input}`,
+    })
+    const replacement = flow({
+      name: "replacement",
+      parse: typed<string>(),
+      factory: (ctx) => `replacement:${ctx.input}`,
+    })
+    const deps = { marker: resource({ factory: () => "marker" }) }
+    Reflect.set(deps, "flow", replacement)
+    const selected = currentTool({
+      name: "selected",
+      description: "Selected.",
+      flow: declared,
+      deps,
+    })
+    const managed = currentAgent({ name: "managed", tools: { selected } })
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider(() => ({
+        content: "calling",
+        toolCalls: [{ name: "selected", input: "item" }],
+      })))],
+    })
+    const ctx = scope.createContext()
+
+    const result = await ctx.exec({ flow: run, input: { prompt: "run", maxRounds: 1 } })
+
+    expect(result.toolResults).toMatchObject([{ name: "selected", output: "declared:item" }])
+    await close(scope, ctx)
+  })
+
+  it("closes current-owned managed dependencies with the turn", async () => {
+    const closed: string[] = []
+    const managedDependency = (name: string) => resource({
+      name,
+      ownership: "current",
+      factory: (ctx) => {
+        ctx.cleanup(() => {
+          closed.push(name)
+        })
+        return name
+      },
+    })
+    const first = currentTool({
+      description: "First.",
+      flow: flow({ name: "first", factory: () => "first" }),
+      deps: { dependency: managedDependency("tool-dependency") },
+    })
+    const second = currentTool({
+      description: "Second.",
+      flow: flow({ name: "second", factory: () => "second" }),
+      deps: { dependency: managedDependency("agent-dependency") },
+    })
+    const managed = currentAgent({ name: "managed", tools: { first, second } })
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider(() => ({ content: "done", stop: true })))],
+    })
+    const ctx = scope.createContext()
+
+    await ctx.exec({ flow: run, input: { prompt: "run" } })
+
+    expect([...closed].sort()).toEqual(["agent-dependency", "tool-dependency"])
+    await close(scope, ctx)
+  })
+
+  it("does not call the model when a required policy tag is missing", async () => {
+    const policy = tag<string>({ label: "policy" })
+    const guarded = currentTool({
+      description: "Guarded.",
+      flow: flow({ name: "guarded", factory: () => "ok" }),
+      deps: { policy: tags.required(policy) },
+    })
+    const managed = currentAgent({ name: "managed", tools: { guarded } })
+    let modelCalls = 0
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider(() => {
+        modelCalls++
+        return { content: "unexpected", stop: true }
+      }))],
+    })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: run, input: { prompt: "run" } })).rejects.toThrow("policy")
+    expect(modelCalls).toBe(0)
+    await close(scope, ctx)
+  })
+
+  it("dispatches the tool selected from the advertised snapshot", async () => {
+    const selected = currentTool({
+      name: "selected",
+      description: "Selected.",
+      flow: flow({
+        name: "selected-flow",
+        parse: typed<{ id: string }>(),
+        factory: (ctx) => `selected:${ctx.input.id}`,
+      }),
+    })
+    const other = currentTool({
+      name: "other",
+      description: "Other.",
+      flow: flow({ name: "other-flow", factory: () => "other" }),
+    })
+    const managed = currentAgent({ name: "managed", tools: { selected, other } })
+    const responses = [
+      { content: "calling", toolCalls: [{ name: "selected", input: { id: "42" } }] },
+      { content: "done", stop: true },
+    ]
+    let advertised: readonly string[] = []
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider((request) => {
+        advertised = request.tools.map((item) => item.name)
+        return responses[request.round] ?? responses[1]!
+      }))],
+    })
+    const ctx = scope.createContext()
+
+    const result = await ctx.exec({ flow: run, input: { prompt: "run" } })
+
+    expect(advertised).toEqual(["selected", "other"])
+    expect(result.toolResults).toMatchObject([{ name: "selected", output: "selected:42" }])
+    await close(scope, ctx)
+  })
+
+  it("dispatches through the captured handle with the standard tool step envelope", async () => {
+    const selected = currentTool({
+      name: "selected",
+      description: "Selected.",
+      flow: flow({ name: "selected-flow", tags: [step({ timeoutMs: 17 })], factory: () => "selected" }),
+    })
+    const managed = currentAgent({ name: "managed", tools: { selected } })
+    const observations: { name: string | undefined; step: Step | undefined }[] = []
+    const observer: Lite.Extension = {
+      name: "managed-tool-observer",
+      wrapExec: async (next, _target, childCtx) => {
+        if (childCtx.name === "selected") observations.push({ name: childCtx.name, step: childCtx.data.seekTag(step) })
+        return next()
+      },
+    }
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      extensions: [observer],
+      tags: [model(provider(() => ({
+        content: "calling",
+        toolCalls: [{ name: "selected", input: "item" }],
+      })))],
+    })
+    const ctx = scope.createContext()
+
+    await ctx.exec({ flow: run, input: { prompt: "run", maxRounds: 1 } })
+
+    expect(observations).toEqual([{ name: "selected", step: { workflow: true, kind: "tool", timeoutMs: 17 } }])
+    await close(scope, ctx)
+  })
+
+  it("rejects duplicate resolved public tool names before freezing the snapshot", async () => {
+    const first = currentTool({
+      name: "same",
+      description: "First.",
+      flow: flow({ name: "first", factory: () => "first" }),
+    })
+    const second = currentTool({
+      name: "same",
+      description: "Second.",
+      flow: flow({ name: "second", factory: () => "second" }),
+    })
+    const managed = currentAgent({ name: "managed", tools: { first, second } })
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider(() => ({ content: "unexpected", stop: true })))],
+    })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: run, input: { prompt: "run" } })).rejects.toThrow(
+      'Current agent "managed" has duplicate tool name "same"'
+    )
+    await close(scope, ctx)
+  })
+
+  it.each([
+    ["skillCalls", { skillCalls: [{ name: "unsupported" }] }],
+    ["subagentCalls", { subagentCalls: [{ name: "unsupported", input: { prompt: "nested" } }] }],
+  ] as const)("rejects managed provider %s explicitly", async (_field, response) => {
+    const managed = currentAgent({
+      name: "managed",
+      tools: {},
+    })
+    const run = turn({ agent: managed })
+    const scope = createScope({ tags: [model(provider(() => ({ content: "unsupported", ...response })))] })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: run, input: { prompt: "run" } })).rejects.toThrow(`does not support ${_field}`)
+    await close(scope, ctx)
+  })
+
+  it("cleans current-owned managed dependencies after tool failure", async () => {
+    let closed = 0
+    const dependency = resource({
+      ownership: "current",
+      factory: (ctx) => {
+        ctx.cleanup(() => {
+          closed++
+        })
+        return "ready"
+      },
+    })
+    const failing = currentTool({
+      description: "Failing.",
+      flow: flow({
+        name: "failing",
+        factory: () => {
+          throw new Error("tool failed")
+        },
+      }),
+      deps: { dependency },
+    })
+    const managed = currentAgent({ name: "managed", tools: { failing } })
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider(() => ({ content: "calling", toolCalls: [{ name: "failing", input: null }] })))],
+    })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: run, input: { prompt: "run" } })).rejects.toThrow("tool failed")
+    expect(closed).toBe(1)
+    await close(scope, ctx)
+  })
+
+  it("cleans current-owned managed dependencies when maxRounds ends on a tool call", async () => {
+    let closed = 0
+    const dependency = resource({
+      ownership: "current",
+      factory: (ctx) => {
+        ctx.cleanup(() => {
+          closed++
+        })
+        return "ready"
+      },
+    })
+    const selected = currentTool({
+      description: "Selected.",
+      flow: flow({ name: "selected", factory: () => "selected" }),
+      deps: { dependency },
+    })
+    const managed = currentAgent({ name: "managed", tools: { selected } })
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider(() => ({ content: "calling", toolCalls: [{ name: "selected", input: null }] })))],
+    })
+    const ctx = scope.createContext()
+
+    await ctx.exec({ flow: run, input: { prompt: "run", maxRounds: 1 } })
+    expect(closed).toBe(1)
+    await close(scope, ctx)
+  })
+
+  it("uses backend tags from each execution context", async () => {
+    const backend = tag<string>({ label: "backend" })
+    const lookup = currentTool({
+      description: "Lookup.",
+      flow: flow({
+        name: "lookup",
+        parse: typed<string>(),
+        deps: { backend: tags.required(backend) },
+        factory: (ctx, deps) => `${deps.backend}:${ctx.input}`,
+      }),
+    })
+    const managed = currentAgent({ name: "managed", tools: { lookup } })
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider(() => ({
+        content: "lookup",
+        toolCalls: [{ name: "lookup", input: "item" }],
+      })))],
+    })
+    const first = scope.createContext({ tags: [backend("first")] })
+    const second = scope.createContext({ tags: [backend("second")] })
+
+    const firstResult = await first.exec({ flow: run, input: { prompt: "run", maxRounds: 1 } })
+    const secondResult = await second.exec({ flow: run, input: { prompt: "run", maxRounds: 1 } })
+
+    expect(firstResult.toolResults[0]?.output).toBe("first:item")
+    expect(secondResult.toolResults[0]?.output).toBe("second:item")
+    await first.close()
+    await second.close()
+    await scope.dispose()
+  })
+
+  it("does not let model input supply a required approval tag", async () => {
+    const approval = tag<boolean>({ label: "approval" })
+    const approved = currentTool({
+      description: "Approved action.",
+      flow: flow({
+        name: "approved",
+        parse: typed<{ approved: boolean }>(),
+        deps: { approval: tags.required(approval) },
+        factory: (ctx) => `approved:${ctx.input.approved}`,
+      }),
+    })
+    const managed = currentAgent({ name: "managed", tools: { approved } })
+    const run = turn({ agent: managed })
+    const scope = createScope({
+      tags: [model(provider(() => ({
+        content: "calling",
+        toolCalls: [{ name: "approved", input: { approved: true } }],
+      })))],
+    })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: run, input: { prompt: "run" } })).rejects.toThrow("approval")
+    await close(scope, ctx)
+  })
+})

--- a/pkg/sdk/core/tests/type-contracts.ts
+++ b/pkg/sdk/core/tests/type-contracts.ts
@@ -1,0 +1,17 @@
+import { flow, type Lite } from "@pumped-fn/lite"
+import { currentAgent, currentTool } from "@pumped-fn/sdk"
+
+type AssertFalse<Value extends false> = Value
+
+const accepted = currentTool({
+  description: "Accepted.",
+  flow: flow({ name: "accepted", factory: () => "ok" }),
+})
+
+currentAgent({ name: "accepted", tools: { accepted } })
+
+type OrdinaryAccepted = Lite.Resource<string> extends Parameters<typeof currentAgent>[0]["tools"][string]
+  ? true
+  : false
+
+type OrdinaryRejected = AssertFalse<OrdinaryAccepted>

--- a/pkg/sdk/core/tests/type-contracts.ts
+++ b/pkg/sdk/core/tests/type-contracts.ts
@@ -1,11 +1,13 @@
-import { flow, type Lite } from "@pumped-fn/lite"
+import { flow, typed, type Lite } from "@pumped-fn/lite"
 import { currentAgent, currentTool } from "@pumped-fn/sdk"
+import * as z from "zod"
 
 type AssertFalse<Value extends false> = Value
 
 const accepted = currentTool({
   description: "Accepted.",
-  flow: flow({ name: "accepted", factory: () => "ok" }),
+  inputSchema: z.unknown(),
+  flow: flow({ name: "accepted", parse: typed<unknown>(), factory: () => "ok" }),
 })
 
 currentAgent({ name: "accepted", tools: { accepted } })

--- a/pkg/sdk/core/tsconfig.test.json
+++ b/pkg/sdk/core/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*"
+  ]
+}

--- a/pkg/sdk/core/tsconfig.test.json
+++ b/pkg/sdk/core/tsconfig.test.json
@@ -6,5 +6,6 @@
   "include": [
     "src/**/*",
     "tests/**/*"
-  ]
+  ],
+  "exclude": []
 }

--- a/pkg/sdk/pi/README.md
+++ b/pkg/sdk/pi/README.md
@@ -5,19 +5,38 @@
 In-process `@earendil-works/pi-ai` provider for `@pumped-fn/sdk`.
 
 ```ts
-import { createScope } from "@pumped-fn/lite"
-import { agent } from "@pumped-fn/sdk"
+import { createScope, flow, typed } from "@pumped-fn/lite"
+import { currentAgent, currentTool, turn, validation } from "@pumped-fn/sdk"
 import { pi, piConfig } from "@pumped-fn/sdk-pi"
+import * as z from "zod"
 
-const triage = agent({ name: "triage" })
-const scope = createScope({
-  tags: [pi, piConfig({ provider: "anthropic", modelId: "claude-sonnet-4-5" })],
+const inspect = currentTool({
+  description: "Inspect a ticket by ID.",
+  inputSchema: z.object({ ticketId: z.string().min(1) }),
+  flow: flow({
+    name: "ticket.inspect",
+    parse: typed<{ ticketId: string }>(),
+    factory: (ctx) => ({ id: ctx.input.ticketId, status: "open" }),
+  }),
 })
+const triage = currentAgent({ name: "triage", tools: { inspect } })
+const run = turn({ agent: triage })
+const scope = createScope({
+  tags: [
+    pi,
+    piConfig({ provider: "anthropic", modelId: "claude-sonnet-4-5" }),
+    validation.engine(validation.standard<z.ZodType>((schema) => z.toJSONSchema(schema))),
+  ],
+})
+const ctx = scope.createContext()
+
+await ctx.exec({ flow: run, input: { prompt: "Inspect ticket T-42." } })
 ```
 
 Set `apiKeyEnv` to resolve an explicit provider key through the environment adapter. Without it,
 pi-ai uses its provider auth chain. `supportedModels` lists the catalog, while `models` is the
-scope-owned collection edge. Native model tool calls become SDK tool, skill, and subagent calls;
+scope-owned collection edge. Managed-tool JSON Schema is forwarded to pi-ai, then tool input is
+validated again through the scope-selected engine before its flow starts. Native model tool calls become SDK tool, skill, and subagent calls;
 usage and cost are copied to the SDK event buffer.
 
 ---

--- a/pkg/sdk/pi/package.json
+++ b/pkg/sdk/pi/package.json
@@ -42,7 +42,8 @@
     "tsdown": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod": "catalog:"
   },
   "engines": {
     "node": ">=22.19.0"

--- a/pkg/sdk/pi/src/index.ts
+++ b/pkg/sdk/pi/src/index.ts
@@ -150,8 +150,15 @@ function capabilityTool(capability: Capability): Tool {
   return {
     name: capability.name,
     description: capability.description,
-    parameters: Type.Object({}, { additionalProperties: true }),
+    parameters: parametersOf(capability),
   }
+}
+
+function parametersOf(capability: Capability): Tool["parameters"] {
+  if (capability.inputSchema === undefined) return Type.Object({}, { additionalProperties: true })
+  if (capability.inputSchema === true) return {} as Tool["parameters"]
+  if (capability.inputSchema === false) return { not: {} } as Tool["parameters"]
+  return capability.inputSchema as Tool["parameters"]
 }
 
 function skillTool(skills: readonly Capability[]): Tool {

--- a/pkg/sdk/pi/tests/pi.test.ts
+++ b/pkg/sdk/pi/tests/pi.test.ts
@@ -2,6 +2,7 @@ import type {
   AssistantMessage,
   AssistantMessageEventStream,
   Api,
+  Context,
   Model as PiModel,
   MutableModels,
 } from "@earendil-works/pi-ai"
@@ -46,7 +47,7 @@ const response: AssistantMessage = {
   timestamp: 1,
 }
 
-function collection(result = response): MutableModels {
+function collection(result = response, capture?: (context: Context) => void): MutableModels {
   return {
     getProviders: () => [],
     getProvider: () => undefined,
@@ -55,7 +56,10 @@ function collection(result = response): MutableModels {
     refresh: async () => undefined,
     getAuth: async () => undefined,
     stream: () => unavailable(),
-    complete: async () => result,
+    complete: async (_model, context) => {
+      capture?.(context)
+      return result
+    },
     streamSimple: () => unavailable(),
     completeSimple: async () => result,
     setProvider: () => undefined,
@@ -69,8 +73,9 @@ function unavailable(): AssistantMessageEventStream {
 }
 
 it("maps native pi-ai tool calls and records usage", async () => {
+  let received: Context | undefined
   const scope = createScope({
-    presets: [preset(models, collection())],
+    presets: [preset(models, collection(response, (context) => { received = context }))],
     tags: [piConfig({ provider: "test", modelId: "test-model" })],
   })
   const ctx = scope.createContext()
@@ -81,7 +86,16 @@ it("maps native pi-ai tool calls and records usage", async () => {
       agentName: "planner",
       instructions: "Plan.",
       messages: [{ role: "user", content: "start" }],
-      tools: [{ name: "lookup", description: "Look up a value." }],
+      tools: [{
+        name: "lookup",
+        description: "Look up a value.",
+        inputSchema: {
+          type: "object",
+          properties: { id: { type: "integer" } },
+          required: ["id"],
+          additionalProperties: false,
+        },
+      }],
       skills: [{ name: "search", description: "Search sources." }],
       loadedSkills: [],
       subagents: [{ name: "reviewer", description: "Review the plan." }],
@@ -95,6 +109,12 @@ it("maps native pi-ai tool calls and records usage", async () => {
     skillCalls: [{ name: "search", id: "skill-1" }],
     subagentCalls: [{ name: "reviewer", input: { prompt: "check" }, id: "sub-1" }],
     stop: false,
+  })
+  expect(received?.tools?.[0]?.parameters).toEqual({
+    type: "object",
+    properties: { id: { type: "integer" } },
+    required: ["id"],
+    additionalProperties: false,
   })
   expect((await ctx.resolve(events)).events.at(-1)?.output).toMatchObject({
     provider: "test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ catalogs:
     '@opentelemetry/api':
       specifier: 1.9.1
       version: 1.9.1
+    '@standard-schema/spec':
+      specifier: 1.1.0
+      version: 1.1.0
     '@tanstack/react-start':
       specifier: 1.168.26
       version: 1.168.26
@@ -90,6 +93,9 @@ catalogs:
     '@typescript/vfs':
       specifier: 1.6.4
       version: 1.6.4
+    '@valibot/to-json-schema':
+      specifier: 1.7.1
+      version: 1.7.1
     '@valtown/codemirror-ts':
       specifier: 2.3.1
       version: 2.3.1
@@ -177,6 +183,9 @@ catalogs:
     unrun:
       specifier: 0.3.1
       version: 0.3.1
+    valibot:
+      specifier: 1.4.2
+      version: 1.4.2
     vite:
       specifier: 8.0.16
       version: 8.0.16
@@ -260,7 +269,6 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
-
   examples/invoice-triage:
     dependencies:
       '@hono/node-server':
@@ -333,7 +341,6 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
-
   pkg/core/lite:
     devDependencies:
       '@types/node':
@@ -934,6 +941,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
 
   pkg/sdk/codex:
     dependencies:
@@ -968,12 +978,18 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
 
   pkg/sdk/core:
     dependencies:
       '@pumped-fn/lite-extension-suspense':
         specifier: workspace:^
         version: link:../../ext/suspense
+      '@standard-schema/spec':
+        specifier: 'catalog:'
+        version: 1.1.0
     devDependencies:
       '@pumped-fn/lite':
         specifier: workspace:*
@@ -984,18 +1000,27 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260526.1
+      '@valibot/to-json-schema':
+        specifier: 'catalog:'
+        version: 1.7.1(valibot@1.4.2(typescript@6.0.3))
       tsdown:
         specifier: 'catalog:'
         version: 0.22.0(@typescript/native-preview@7.0.0-dev.20260526.1)(tsx@4.22.3)(typescript@6.0.3)(unrun@0.3.1)
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+      valibot:
+        specifier: 'catalog:'
+        version: 1.4.2(typescript@6.0.3)
       vite:
         specifier: 'catalog:'
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
 
   pkg/sdk/mcp:
     dependencies:
@@ -1058,6 +1083,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@25.9.1)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(happy-dom@20.9.0)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
 
   pkg/sdk/test:
     dependencies:
@@ -2614,6 +2642,11 @@ packages:
     resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
     peerDependencies:
       typescript: '*'
+
+  '@valibot/to-json-schema@1.7.1':
+    resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
+    peerDependencies:
+      valibot: ^1.4.0
 
   '@valtown/codemirror-ts@2.3.1':
     resolution: {integrity: sha512-v5XiI4WA+bUy0XDgkrqZksqBWgIUeyLZuC94Px/rhXBph8ASmVXaimlGDtt0vH/9t8aDdIZYdr59r9H3oKMFOg==}
@@ -4747,6 +4780,14 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
@@ -6714,6 +6755,10 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
+    dependencies:
+      valibot: 1.4.2(typescript@6.0.3)
 
   '@valtown/codemirror-ts@2.3.1(@codemirror/autocomplete@6.20.3)(@codemirror/lint@6.9.7)(@codemirror/state@6.7.1)(@codemirror/view@6.43.6)':
     dependencies:
@@ -8760,6 +8805,10 @@ snapshots:
 
   util-deprecate@1.0.2:
     optional: true
+
+  valibot@1.4.2(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
 
   vary@1.1.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,6 +62,8 @@ peerDependencyRules:
     typescript: ^5.0.0 || ^6.0.0
 
 catalog:
+  "@standard-schema/spec": 1.1.0
+  "@valibot/to-json-schema": 1.7.1
   "@agentclientprotocol/sdk": 1.2.1
   "@codemirror/autocomplete": 6.20.3
   "@codemirror/lint": 6.9.7
@@ -119,6 +121,7 @@ catalog:
   tsx: 4.22.3
   typescript: 6.0.3
   unrun: 0.3.1
+  valibot: 1.4.2
   vite: 8.0.16
   vitest: 4.1.8
   zod: 4.3.6


### PR DESCRIPTION
## Summary\n\n- add current-owned tool and agent resources with one resolved tool snapshot per turn\n- validate every managed-tool call through a scope-injected Standard Schema engine\n- advertise the same JSON Schema through Claude, Codex, and pi-ai providers\n- show Zod in provider and invoice-triage examples, with a Valibot engine alternative\n- preserve host-owned tags, approval, workflow step policy, and context lifecycle cleanup\n\n## Anti-goals held\n\n- no pkg/core/lite changes\n- no MCP or automatic tool collection\n- no built-in validation engine or implicit provider binding\n- no provider, permission, root, or approval authority inferred from model input\n- legacy tool() and agent().turn remain compatible\n\n## Verification\n\n- pnpm lint (one existing untouched invoice-triage warning)\n- pnpm verify\n- pnpm install --frozen-lockfile\n- focused core, Claude, Codex, Pi, and invoice-triage tests/typechecks\n- authenticated global Claude integration: 1 passed\n- authenticated global Codex CLI/ACP integration: 2 passed\n- independent Sol medium review found the Pi propagation/docs gaps; focused re-review: PASS\n- changeset covers five intended patch releases\n