### PR TITLE
fix(release): publish lite-hmr

### DIFF
--- a/.changeset/publish-lite-hmr.md
+++ b/.changeset/publish-lite-hmr.md
@@ -1,0 +1,5 @@
+---
+"@pumped-fn/lite-hmr": patch
+---
+
+Publish Lite HMR so `@pumped-fn/pumped` resolves its runtime dependency from npm.

--- a/pkg/ext/hmr/LICENSE
+++ b/pkg/ext/hmr/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2025 Duke
+
+Permission is hereby granted, free of
+charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/pkg/ext/hmr/package.json
+++ b/pkg/ext/hmr/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@pumped-fn/lite-hmr",
   "version": "1.0.1",
-  "private": true,
   "description": "Vite HMR plugin for @pumped-fn/lite atoms",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -20,7 +19,9 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "LICENSE",
+    "CHANGELOG.md"
   ],
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Why

Release PR #352 would publish `@pumped-fn/pumped@0.2.1` with an exact runtime dependency on `@pumped-fn/lite-hmr@1.0.2`, but Changesets skips HMR while it is private. npm currently has only HMR `1.0.0`.

## Change

- Make `@pumped-fn/lite-hmr` publishable.
- Add a patch changeset. It coalesces with the existing patch into `1.0.2`; it does not create a double bump.

## Proof

- HMR build, 23 tests, and typecheck pass.
- Release-policy check reports 0 gaps.
- `pnpm pack --dry-run` includes both index/runtime builds and declarations.
- Two independent release reviews found no repo-owned P0-P2 issue.

## Separate external gate

Do not merge release PR #352 until npm authority is ready:

- Confirm the `release.yml` trusted publisher for existing `@pumped-fn/lite-hmr`.
- First-publish `@pumped-fn/sdk-pi` and `@pumped-fn/sdk-mcp` with npm org authority, then configure their trusted publishers.

Both SDK package names still return npm E404, and the prior bootstrap run failed for insufficient permission.
