### PR TITLE
chore(release): correct PR 357 version plan

### DIFF
--- a/pkg/framework/tanstack-start/package.json
+++ b/pkg/framework/tanstack-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pumped-fn/lite-tanstack-start",
-  "version": "1.0.0",
+  "version": "0.2.3",
   "private": false,
   "description": "TanStack Start middleware helpers for @pumped-fn/lite execution contexts",
   "type": "module",

--- a/pkg/react/lite-react/package.json
+++ b/pkg/react/lite-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pumped-fn/lite-react",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "description": "React integration for @pumped-fn/lite",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,8 +16,8 @@
 | `check-packed-lite.mjs` | Pack Lite and Lite React, then verify docs, ESM, CJS, TS7 NodeNext, and Bundler consumers. |
 | `check-published-types.mjs` | Validate every public package root export with strict NodeNext ESM/CJS and Bundler consumers. |
 | `check-public-contract.mjs` | Check package metadata, migration evidence, public interface TSDoc, README fences, changesets, and PR provenance. |
-| `check-release-policy.mjs` | Check Changeset bump size, internal peer alignment, and the repository release policy. |
-| `check-release-policy.test.mjs` | Deterministic release-policy fixtures for core majors, pre-1 graduation, stable minors, widening, and stale peers. |
+| `check-release-policy.mjs` | Check Changeset bump size, corrected early versions, internal peer alignment, and the repository release policy. |
+| `check-release-policy.test.mjs` | Deterministic release-policy fixtures for core majors, pre-1 graduation, early version correction, stable minors, widening, and stale peers. |
 | `check-public-contract.test.mjs` | Deterministic positive and negative fixtures for the public contract checker. |
 | `get-release-title.sh` | Release workflow helper for Changesets PR titles. |
 

--- a/scripts/check-public-contract.mjs
+++ b/scripts/check-public-contract.mjs
@@ -40,18 +40,24 @@ const packageDirectories = readdirSync(join(root, "pkg"), { withFileTypes: true 
   .map((directory) => ({ directory, manifest: readJson(join(directory, "package.json")) }))
   .filter(({ manifest }) => manifest.private !== true);
 const packagesByName = new Map(packageDirectories.map((entry) => [entry.manifest.name, entry]));
-const basePackageDirectories = execFileSync("git", ["ls-tree", "-r", "--name-only", base, "--", "pkg"], {
+const packageManifestsAt = (ref) => execFileSync("git", ["ls-tree", "-r", "--name-only", ref, "--", "pkg"], {
   cwd: root,
   encoding: "utf8",
 })
   .split("\n")
   .filter((path) => /^pkg\/[^/]+\/[^/]+\/package\.json$/u.test(path))
   .map((path) => ({
-    manifest: JSON.parse(execFileSync("git", ["show", `${base}:${path}`], { cwd: root, encoding: "utf8" })),
+    manifest: JSON.parse(execFileSync("git", ["show", `${ref}:${path}`], { cwd: root, encoding: "utf8" })),
     path,
   }))
   .filter(({ manifest }) => manifest.private !== true);
+const basePackageDirectories = packageManifestsAt(base);
 const basePackagesByName = new Map(basePackageDirectories.map((entry) => [entry.manifest.name, entry]));
+const baseParent = execFileSync("git", ["rev-list", "--parents", "-n", "1", base], { cwd: root, encoding: "utf8" })
+  .trim()
+  .split(" ")[1];
+const baseParentPackagesByName = new Map((baseParent ? packageManifestsAt(baseParent) : [])
+  .map((entry) => [entry.manifest.name, entry]));
 
 const escapeRegExp = (value) => value.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
 
@@ -342,8 +348,14 @@ for (const { directory, manifest } of packageDirectories) {
   }
   for (const change of changesets.filter((entry) => entry.package === manifest.name && entry.bump === "major")) {
     const previous = basePackagesByName.get(manifest.name)?.manifest;
+    const ancestor = baseParentPackagesByName.get(manifest.name)?.manifest;
     const currentMajor = Number.parseInt(String(manifest.version).split(".")[0], 10);
-    const previousMajor = previous
+    const previousMajor = previous && ancestor
+      && manifest.version === ancestor.version
+      && Number.parseInt(String(previous.version).split(".")[0], 10)
+        === Number.parseInt(String(ancestor.version).split(".")[0], 10) + 1
+      ? Number.parseInt(String(ancestor.version).split(".")[0], 10)
+      : previous
       ? Number.parseInt(String(previous.version).split(".")[0], 10)
       : currentMajor;
     const targetMajor = previousMajor + 1;

--- a/scripts/check-public-contract.test.mjs
+++ b/scripts/check-public-contract.test.mjs
@@ -75,6 +75,27 @@ describe("public contract checker", () => {
     });
   });
 
+  it("accepts major migration evidence after correcting an early version change", () => {
+    const directory = fixture("valid");
+    const packagePath = join(directory, "pkg/core/demo/package.json");
+    const manifest = JSON.parse(readFileSync(packagePath, "utf8"));
+    manifest.version = "0.2.0";
+    writeFileSync(packagePath, `${JSON.stringify(manifest, null, 2)}\n`);
+    writeFileSync(join(directory, "pkg/core/demo/MIGRATION.md"), "# Migration to 1.0.0\n");
+    writeFileSync(join(directory, "pkg/core/demo/README.md"), "# Fixture\n\n## Migration to 1.0.0\n");
+    execFileSync("git", ["add", "."], { cwd: directory });
+    execFileSync("git", ["commit", "-qm", "published version"], { cwd: directory });
+    manifest.version = "1.0.0";
+    writeFileSync(packagePath, `${JSON.stringify(manifest, null, 2)}\n`);
+    execFileSync("git", ["add", packagePath], { cwd: directory });
+    execFileSync("git", ["commit", "-qm", "premature version"], { cwd: directory });
+    manifest.version = "0.2.0";
+    writeFileSync(packagePath, `${JSON.stringify(manifest, null, 2)}\n`);
+    const result = execute(directory);
+    assert.equal(result.status, 0);
+    assert.equal(result.output.metrics.major_migration_evidence_gap_count, 0);
+  });
+
   it("reports every direct negative fixture metric deterministically", () => {
     const first = run("invalid");
     const second = run("invalid");

--- a/scripts/check-release-policy.mjs
+++ b/scripts/check-release-policy.mjs
@@ -101,17 +101,32 @@ for (const change of changesets) {
   if (!current || rank[change.bump] > rank[current.bump]) bumps.set(change.package, change)
 }
 
-const basePackageDirectories = runGit(["ls-tree", "-r", "--name-only", base, "--", "pkg"])
+const packageManifestsAt = (ref) => runGit(["ls-tree", "-r", "--name-only", ref, "--", "pkg"])
   .split("\n")
   .filter((path) => /^pkg\/[^/]+\/[^/]+\/package\.json$/u.test(path))
-  .map((path) => ({ path, manifest: JSON.parse(runGit(["show", `${base}:${path}`])) }))
+  .map((path) => ({ path, manifest: JSON.parse(runGit(["show", `${ref}:${path}`])) }))
   .filter(({ manifest }) => manifest.private !== true)
+const basePackageDirectories = packageManifestsAt(base)
 const baseManifests = new Map(basePackageDirectories.map((entry) => [entry.manifest.name, entry.manifest]))
+const baseParent = runGit(["rev-list", "--parents", "-n", "1", base]).trim().split(" ")[1]
+const baseParentManifests = new Map((baseParent ? packageManifestsAt(baseParent) : [])
+  .map((entry) => [entry.manifest.name, entry.manifest]))
+const isVersionCorrection = (entry, previous, change) => {
+  const ancestor = baseParentManifests.get(entry.manifest.name)
+  return previous !== undefined
+    && ancestor !== undefined
+    && change !== undefined
+    && entry.manifest.version === ancestor.version
+    && previous.version === nextVersion(ancestor.version, change.bump)
+}
 const releases = new Map([...bumps].flatMap(([name, change]) => {
   const entry = packages.get(name)
   if (!entry) return []
   const previous = baseManifests.get(name)
-  return [[name, nextVersion(previous?.version ?? entry.manifest.version, change.bump)]]
+  const version = isVersionCorrection(entry, previous, change)
+    ? entry.manifest.version
+    : previous?.version ?? entry.manifest.version
+  return [[name, nextVersion(version, change.bump)]]
 }))
 
 const unauthorizedMajors = []
@@ -126,7 +141,10 @@ for (const [name, change] of bumps) {
   const entry = packages.get(name)
   if (!entry || change.bump !== "major") continue
   const previous = baseManifests.get(name)
-  const baseMajor = semver.major(previous?.version ?? entry.manifest.version)
+  const version = isVersionCorrection(entry, previous, change)
+    ? entry.manifest.version
+    : previous?.version ?? entry.manifest.version
+  const baseMajor = semver.major(version)
   if (baseMajor > 0 && !majorReleasePackages.has(name)) {
     unauthorizedMajors.push({ package: name, version: entry.manifest.version, changeset: change.path })
   }
@@ -135,7 +153,7 @@ for (const [name, change] of bumps) {
 for (const entry of packageDirectories) {
   const previous = baseManifests.get(entry.manifest.name)
   const declared = bumps.get(entry.manifest.name)
-  if (previous && previous.version !== entry.manifest.version) {
+  if (previous && previous.version !== entry.manifest.version && !isVersionCorrection(entry, previous, declared)) {
     const expected = declared ? nextVersion(previous.version, declared.bump) : null
     if (entry.manifest.version !== expected) {
       versionDeltaGaps.push({

--- a/scripts/check-release-policy.test.mjs
+++ b/scripts/check-release-policy.test.mjs
@@ -183,6 +183,22 @@ describe("release policy checker", () => {
     assert.equal(result.output.metrics.version_delta_gap_count, 0)
   })
 
+  it("accepts correcting a version applied before Changesets consumes the plan", () => {
+    const directory = createFixture(true)
+    write(directory, "pkg/ext/pre/package.json", manifest("@pumped-fn/fixture-pre", "1.0.0", {
+      "@pumped-fn/fixture-core": "^2.0.0",
+    }))
+    execFileSync("git", ["add", "."], { cwd: directory })
+    execFileSync("git", ["commit", "-qm", "premature version"], { cwd: directory })
+    write(directory, "pkg/ext/pre/package.json", manifest("@pumped-fn/fixture-pre", "0.2.0", {
+      "@pumped-fn/fixture-core": "^2.0.0",
+    }))
+    const result = run(directory)
+    assert.equal(result.status, 0)
+    assert.equal(result.output.metrics.version_delta_gap_count, 0)
+    assert.equal(result.output.metrics.unauthorized_major_count, 0)
+  })
+
   it("recovers a consumed Changesets plan from the base commit", () => {
     const directory = createFixture(true)
     execFileSync("git", ["add", ".changeset/release.md"], { cwd: directory })


### PR DESCRIPTION
## Summary

- restore the published Lite React and TanStack Start versions before Changesets consumes the PR #357 plan
- keep the intended release targets at Lite React 3.1.0 and TanStack Start 1.0.0
- let release policy recognize a version that is safely restored to the base commit's parent
- add a release-policy regression test for early version application

## Release targets

- `@pumped-fn/lite`: 6.1.0 → 6.2.0
- `@pumped-fn/lite-react`: 3.0.1 → 3.1.0
- `@pumped-fn/lite-tanstack-start`: 0.2.3 → 1.0.0

Without this fix, Changesets plans Lite React 3.2.0 and TanStack Start 2.0.0, skipping unpublished versions.

## Evidence

- npm reports Lite React 3.0.1 and TanStack Start 0.2.3 as the latest published versions
- `pnpm changeset status` reports the intended targets above
- release policy tests pass
- release policy check passes against current `main`
- lint passes
