### PR TITLE
feat(sdk)!: userland DX pass — correctness fixes, test factories, naming consistency

### DIFF
--- a/.changeset/sdk-userland-dx.md
+++ b/.changeset/sdk-userland-dx.md
@@ -1,0 +1,19 @@
+---
+"@pumped-fn/sdk": major
+"@pumped-fn/sdk-claude": major
+"@pumped-fn/sdk-codex": major
+"@pumped-fn/sdk-pi": major
+"@pumped-fn/sdk-just-bash": major
+"@pumped-fn/sdk-test": major
+"@pumped-fn/sdk-mcp": major
+---
+
+Fix userland correctness defects and reduce public-surface ceremony across the SDK.
+
+MCP tools now advertise their real input schemas instead of type-erased `z.unknown()` shapes. Codex ACP permission grants match only the stable tool-call `kind`, never the agent-controlled `title`. A Claude prompt abort or timeout sends the in-band `control_request` interrupt and leaves the session usable, and the always-throwing `isolate` option is gone. `parseModelResponse` throws `ModelResponseParseError` on malformed model output instead of ending the turn as a silent success, and JSON extraction scans balanced objects. `runCli` always settles even when cleanup rejects; `CliResult.exitCode` is `0` and failures expose `CliFailureResult` through `CliWorkerError.result`. `sandbox.exec` enforces `timeoutMs` and `maxOutputBytes`, and the `run` binding owns network enforcement. Pi provider errors carry the configured provider and model.
+
+`@pumped-fn/sdk-test` adds `initialRecord`, `testAuthority`, `modelRequest`, `validationStub`, and `sessionKit`, which supplies the full session and agent tag bundle for executing agent turns against stubs.
+
+Breaking renames: `Runtime` merges into `WorkflowContext` with tag label `workflow.context`; only `SuspendSignal` is exported; `sandbox.ExecEvent` becomes `sandbox.CommandOutputEvent`; `judge()`, `formatStepKey()`, and Claude's single-value `permission` field are removed. Adapters share one `auth: { kind, env? }` shape, so Pi's `apiKeyEnv` is gone. Claude's `engine` becomes `spawnProcess`, Bash's `engine` becomes `interpreter`, Codex barrel aliases follow the CLI flavor, ACP `additionalDirectories` becomes `roots`, and Bash error classes gain the `Bash` prefix.
+
+`session.run` work input accepts an omitted `branchId`, which resolves from the session record's current branch at admission and is stored explicitly. `id`, `role`, and `policy` remain required.

--- a/.changeset/sdk-userland-dx.md
+++ b/.changeset/sdk-userland-dx.md
@@ -5,7 +5,7 @@
 "@pumped-fn/sdk-pi": major
 "@pumped-fn/sdk-just-bash": major
 "@pumped-fn/sdk-test": major
-"@pumped-fn/sdk-mcp": major
+"@pumped-fn/sdk-mcp": minor
 ---
 
 Fix userland correctness defects and reduce public-surface ceremony across the SDK.

--- a/examples/issue-triage/bin/daemon.ts
+++ b/examples/issue-triage/bin/daemon.ts
@@ -67,7 +67,7 @@ const scope = createScope({
     session.clock({ now: () => new Date().toISOString() }),
     session.execution.turn({ flow: agent.turn }),
     sdkValidation.engine(createZodSdkEngine()),
-    pi.piConfig(values.model),
+    pi.piConfig({ auth: { kind: "api-key" }, ...values.model }),
     pi.piAttemptBinding,
     logging.runtime({
       flow: "all",

--- a/examples/issue-triage/src/process.ts
+++ b/examples/issue-triage/src/process.ts
@@ -9,7 +9,7 @@ export const process: sandbox.Run = flow({
   parse: typed<sandbox.ExecInput>(),
   deps: { policy: tags.required(sandbox.policy), spawn: spawnProcess, timers },
   tags: step({ workflow: true, kind: "sandbox" }),
-  factory: async function* (ctx, { policy, spawn, timers }): AsyncGenerator<sandbox.ExecEvent, sandbox.ExecResult, unknown> {
+  factory: async function* (ctx, { policy, spawn, timers }): AsyncGenerator<sandbox.CommandOutputEvent, sandbox.ExecResult, unknown> {
     const child = spawn(ctx.input.command, [...(ctx.input.args ?? [])], {
       signal: ctx.signal,
       stdio: ["ignore", "pipe", "pipe"],

--- a/pkg/framework/pumped/README.md
+++ b/pkg/framework/pumped/README.md
@@ -47,7 +47,12 @@ import { app } from "@pumped-fn/pumped/app"
 import { claude, claudeConfig } from "@pumped-fn/sdk-claude"
 
 export default app({
-  tags: [claude, claudeConfig({ auth: { kind: "global" } })],
+  tags: [claude, claudeConfig({
+    auth: { kind: "global" },
+    cwd: process.cwd(),
+    roots: [],
+    shutdownTimeoutMs: 1_000,
+  })],
 })
 ```
 

--- a/pkg/sdk/bash/README.md
+++ b/pkg/sdk/bash/README.md
@@ -1,5 +1,7 @@
 # @pumped-fn/sdk-just-bash
 
+> **Status: experimental.** APIs change without notice; not recommended for production yet.
+
 `just-bash` implements the session-mediated `@pumped-fn/sdk/sandbox` port. It exports named flows and resources, not a sandbox method bag.
 
 ```text
@@ -7,7 +9,7 @@ session authority -> sandbox.read/write/exec -> sandbox.impl tags
                                                 |
                          just-bash read/write/run flows
                                                 |
-                authority -> readiness -> workspace -> engine
+              authority -> readiness -> workspace -> interpreter
 ```
 
 ```ts
@@ -65,7 +67,7 @@ const scope = createScope({
       timeoutMs: 5_000,
       maxOutputBytes: 64 * 1024,
     }),
-    bash.config.engine({
+    bash.config.interpreter({
       options: {
         files: { "/workspace/README.md": "ship it" },
       },
@@ -104,9 +106,19 @@ await sessionCtx.close()
 await scope.dispose()
 ```
 
-`sandbox.exec` checks the session authority and policy before the implementation runs. Recursive entry activation reaches the selected sandbox implementation, authority, readiness, workspace, and engine before the sandbox flow starts. `just-bash.run` forwards the active `abortSignal` and enforces the timeout and UTF-8 output cap. The physical `just-bash` API returns buffered output, so this adapter yields at most one stdout event and one stderr event after the command completes. Use another `sandbox.impl.run` implementation when live command deltas or backpressure are required. Each session owns its current-owned `engine` and `workspace`, so deactivating one session does not close another.
+`sandbox.exec` checks the session authority and policy before the implementation runs. Recursive entry activation reaches the selected sandbox implementation, authority, readiness, workspace, and interpreter before the sandbox flow starts. `just-bash.run` forwards the active `abortSignal` and enforces the timeout and UTF-8 output cap. The physical `just-bash` API returns buffered output, so this adapter yields at most one stdout event and one stderr event after the command completes. Use another `sandbox.impl.run` implementation when live command deltas or backpressure are required. Each session owns its current-owned `interpreter` and `workspace`, so deactivating one session does not close another.
 
-Replace `engine`, `workspace`, `readiness`, or any named flow with `preset()` in tests. No module mock or shared scope is needed.
+There is no generic `engine` alias. Replace `interpreter`, `workspace`, `readiness`, or any named flow with `preset()` in tests. No module mock or shared scope is needed.
+
+## Current prerelease migration
+
+| Before | Now |
+|---|---|
+| `engine` | `interpreter` |
+| `config.engine` | `config.interpreter` |
+| `EngineConfig` | `InterpreterConfig` |
+| `OutputLimitError` | `BashOutputLimitError` |
+| `WorkspaceError` | `BashWorkspaceError` |
 
 ## Migration to 3.0.0
 

--- a/pkg/sdk/bash/README.md
+++ b/pkg/sdk/bash/README.md
@@ -110,7 +110,7 @@ await scope.dispose()
 
 There is no generic `engine` alias. Replace `interpreter`, `workspace`, `readiness`, or any named flow with `preset()` in tests. No module mock or shared scope is needed.
 
-## Current prerelease migration
+## Migration to 4.0.0
 
 | Before | Now |
 |---|---|

--- a/pkg/sdk/bash/package.json
+++ b/pkg/sdk/bash/package.json
@@ -35,7 +35,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@pumped-fn/sdk": "^3.0.0",
+    "@pumped-fn/sdk": "^4.0.0",
     "@pumped-fn/lite": "^6.0.0"
   },
   "dependencies": {

--- a/pkg/sdk/bash/src/index.ts
+++ b/pkg/sdk/bash/src/index.ts
@@ -8,8 +8,8 @@ import { atom, flow, resource, tag, tags, typed } from "@pumped-fn/lite"
 
 export type BashOptions = ConstructorParameters<typeof Bash>[0]
 
-/** Configures creation and default options for the in-memory Bash engine. */
-export interface EngineConfig {
+/** Configures creation and default options for the in-memory Bash interpreter. */
+export interface InterpreterConfig {
   readonly create?: (options: BashOptions) => Bash
   readonly options?: BashOptions
 }
@@ -25,7 +25,7 @@ export interface SandboxAuthority {
   readonly policy: sandbox.Policy
 }
 
-/** Exposes an initialized in-memory Bash engine at its workspace root. */
+/** Exposes an initialized in-memory Bash interpreter at its workspace root. */
 export interface Workspace {
   readonly root: string
   readonly bash: Bash
@@ -37,22 +37,22 @@ export interface Readiness {
   readonly root: string
 }
 
-export class OutputLimitError extends Error {
+export class BashOutputLimitError extends Error {
   constructor(readonly limit: number) {
     super(`Sandbox output exceeds ${limit} bytes`)
-    this.name = "OutputLimitError"
+    this.name = "BashOutputLimitError"
   }
 }
 
-export class WorkspaceError extends Error {
+export class BashWorkspaceError extends Error {
   constructor(message: string) {
     super(message)
-    this.name = "WorkspaceError"
+    this.name = "BashWorkspaceError"
   }
 }
 
 export const config = {
-  engine: tag<EngineConfig>({ label: "just-bash.config.engine" }),
+  interpreter: tag<InterpreterConfig>({ label: "just-bash.config.interpreter" }),
   workspace: tag<WorkspaceConfig>({ label: "just-bash.config.workspace" }),
 }
 
@@ -87,16 +87,16 @@ export const authority = resource({
   },
 })
 
-export const engine = resource({
-  name: "just-bash.engine",
+export const interpreter = resource({
+  name: "just-bash.interpreter",
   ownership: "current",
   deps: {
     authority,
-    engine: tags.required(config.engine),
+    config: tags.required(config.interpreter),
     workspace: tags.required(config.workspace),
   },
-  factory: (_ctx, { authority, engine, workspace }) => {
-    const options = engine.options ?? {}
+  factory: (_ctx, { authority, config, workspace }) => {
+    const options = config.options ?? {}
     const executionLimits = {
       ...options.executionLimits,
       maxOutputSize: Math.min(
@@ -104,7 +104,7 @@ export const engine = resource({
         authority.policy.maxOutputBytes,
       ),
     }
-    return (engine.create ?? ((value) => new Bash(value)))({
+    return (config.create ?? ((value) => new Bash(value)))({
       ...options,
       cwd: workspace.root,
       executionLimits,
@@ -119,17 +119,17 @@ export const workspace = resource({
   ownership: "current",
   deps: {
     authority,
-    engine,
+    interpreter,
     config: tags.required(config.workspace),
     platform,
   },
-  factory: (_ctx, { authority, config, engine, platform }) => {
-    if (!config.root.startsWith("/")) throw new WorkspaceError("Sandbox workspace root must be absolute")
+  factory: (_ctx, { authority, config, interpreter, platform }) => {
+    if (!config.root.startsWith("/")) throw new BashWorkspaceError("Sandbox workspace root must be absolute")
     const root = platform.normalize(config.root)
     if (!authority.policy.roots.some((allowed) => within(root, platform.normalize(allowed)))) {
-      throw new WorkspaceError("Sandbox workspace root is outside allowed roots")
+      throw new BashWorkspaceError("Sandbox workspace root is outside allowed roots")
     }
-    return Object.freeze({ root, bash: engine })
+    return Object.freeze({ root, bash: interpreter })
   },
 })
 
@@ -185,7 +185,7 @@ export const run: sandbox.Run = flow({
     workspace,
   },
   tags: [step({ workflow: true, kind: "sandbox" })],
-  factory: async function* (ctx, { authority, clock, platform, workspace }): AsyncGenerator<sandbox.ExecEvent, sandbox.ExecResult, unknown> {
+  factory: async function* (ctx, { authority, clock, platform, workspace }): AsyncGenerator<sandbox.CommandOutputEvent, sandbox.ExecResult, unknown> {
     const policy = authority.policy
     if (!policy.commands.includes(ctx.input.command)) {
       throw new sandbox.PolicyError(`command ${JSON.stringify(ctx.input.command)} is not allowed`)
@@ -217,7 +217,7 @@ export const run: sandbox.Run = flow({
       unregister()
     }
     if (platform.byteLength(result.stdout) + platform.byteLength(result.stderr) > policy.maxOutputBytes) {
-      throw new OutputLimitError(policy.maxOutputBytes)
+      throw new BashOutputLimitError(policy.maxOutputBytes)
     }
     if (result.stdout) yield { type: "stdout", content: result.stdout }
     if (result.stderr) yield { type: "stderr", content: result.stderr }

--- a/pkg/sdk/bash/tests/just-bash.test.ts
+++ b/pkg/sdk/bash/tests/just-bash.test.ts
@@ -10,11 +10,11 @@ import * as sandbox from "@pumped-fn/sdk/sandbox"
 import * as session from "@pumped-fn/sdk/session"
 import { expect, it } from "vitest"
 import {
-  OutputLimitError,
+  BashOutputLimitError,
   authority as bashAuthority,
   binding,
   config,
-  engine,
+  interpreter,
   read,
   readiness,
   run,
@@ -28,7 +28,7 @@ it("runs read, write, and buffered exec through named sandbox flows", async () =
   const scope = createScope({
     tags: [
       sandbox.policy(policy),
-      config.engine({ options: { files: { "/workspace/input.txt": "ready" } } }),
+      config.interpreter({ options: { files: { "/workspace/input.txt": "ready" } } }),
       config.workspace({ root: "/workspace" }),
       binding.read,
       binding.write,
@@ -38,7 +38,7 @@ it("runs read, write, and buffered exec through named sandbox flows", async () =
   const ctx = context(scope, "session-a", authority)
 
   await ctx.resolve(session.session)
-  const physical = await ctx.resolve(engine)
+  const physical = await ctx.resolve(interpreter)
   await expect(ctx.resolve(workspace)).resolves.toMatchObject({ root: "/workspace", bash: physical })
   await expect(ctx.resolve(readiness)).resolves.toEqual({
     authorityFingerprint: authority.fingerprint,
@@ -61,7 +61,7 @@ it("runs read, write, and buffered exec through named sandbox flows", async () =
     flow: sandbox.exec,
     input: { command: "printf", args: ["streamed"] },
   })
-  const events: sandbox.ExecEvent[] = []
+  const events: sandbox.CommandOutputEvent[] = []
   for await (const event of stream) events.push(event)
   expect(events).toEqual([{ type: "stdout", content: "streamed" }])
   await expect(stream.result).resolves.toEqual({ stdout: "streamed", stderr: "", exitCode: 0 })
@@ -70,16 +70,16 @@ it("runs read, write, and buffered exec through named sandbox flows", async () =
   await scope.dispose()
 })
 
-it("denies authority and policy violations before resolving the physical engine", async () => {
+it("denies authority and policy violations before resolving the physical interpreter", async () => {
   let creates = 0
   const authority = sandboxAuthority({ write: false, commands: [] })
   const scope = createScope({
     tags: [
       sandbox.policy({ ...sandboxPolicy(), write: true, commands: [] }),
-      config.engine({
+      config.interpreter({
         create: (options) => {
           creates++
-          throw new Error(`engine should not resolve: ${String(options.cwd)}`)
+          throw new Error(`interpreter should not resolve: ${String(options.cwd)}`)
         },
       }),
       config.workspace({ root: "/workspace" }),
@@ -104,7 +104,7 @@ it("enforces policy when provider flows are executed directly", async () => {
   const scope = createScope({
     tags: [
       sandbox.policy(sandboxPolicy()),
-      config.engine({ options: { files: { "/workspace/input.txt": "ready" } } }),
+      config.interpreter({ options: { files: { "/workspace/input.txt": "ready" } } }),
       config.workspace({ root: "/workspace" }),
     ],
   })
@@ -136,7 +136,7 @@ it("enforces policy when provider flows are executed directly", async () => {
     flow: run,
     input: { command: "printf", args: ["ready"] },
   })
-  const events: sandbox.ExecEvent[] = []
+  const events: sandbox.CommandOutputEvent[] = []
   for await (const event of allowed) events.push(event)
   expect(events).toEqual([{ type: "stdout", content: "ready" }])
   await expect(allowed.result).resolves.toEqual({ stdout: "ready", stderr: "", exitCode: 0 })
@@ -147,7 +147,7 @@ it("enforces policy when provider flows are executed directly", async () => {
   const readOnlyScope = createScope({
     tags: [
       sandbox.policy({ ...sandboxPolicy(), write: false }),
-      config.engine({}),
+      config.interpreter({}),
       config.workspace({ root: "/workspace" }),
     ],
   })
@@ -169,7 +169,7 @@ it("binds direct flows to the validated policy snapshot", async () => {
   const scope = createScope({
     tags: [
       sandbox.policy(policy),
-      config.engine({ options: { files: { "/outside/secret.txt": "secret" } } }),
+      config.interpreter({ options: { files: { "/outside/secret.txt": "secret" } } }),
       config.workspace({ root: "/workspace" }),
     ],
   })
@@ -216,7 +216,7 @@ it("denies symlink escapes while preserving in-root and new write paths", async 
   const scope = createScope({
     tags: [
       sandbox.policy(sandboxPolicy()),
-      config.engine({ create: () => physical }),
+      config.interpreter({ create: () => physical }),
       config.workspace({ root: "/workspace" }),
     ],
   })
@@ -259,7 +259,7 @@ it("rejects a dangling custom-filesystem symlink before write follows it", async
   const scope = createScope({
     tags: [
       sandbox.policy(sandboxPolicy()),
-      config.engine({ create: () => physical }),
+      config.interpreter({ create: () => physical }),
       config.workspace({ root: "/workspace" }),
     ],
   })
@@ -282,7 +282,7 @@ it("rejects output above the declared byte cap", async () => {
   const scope = createScope({
     tags: [
       sandbox.policy({ ...sandboxPolicy(), maxOutputBytes: 4 }),
-      config.engine({}),
+      config.interpreter({}),
       config.workspace({ root: "/workspace" }),
       binding.read,
       binding.write,
@@ -299,8 +299,8 @@ it("rejects output above the declared byte cap", async () => {
   })
   await expect(async () => {
     for await (const _event of stream) void _event
-  }).rejects.toBeInstanceOf(OutputLimitError)
-  await expect(stream.result).rejects.toBeInstanceOf(OutputLimitError)
+  }).rejects.toBeInstanceOf(BashOutputLimitError)
+  await expect(stream.result).rejects.toBeInstanceOf(BashOutputLimitError)
 
   await ctx.close({ ok: false, error: new Error("expected") })
   await scope.dispose()
@@ -316,7 +316,7 @@ it("settles cancellation in session A without closing session B", async () => {
   const scope = createScope({
     tags: [
       sandbox.policy({ ...sandboxPolicy(), commands: ["printf", "sleep"] }),
-      config.engine({ options: { sleep: () => held } }),
+      config.interpreter({ options: { sleep: () => held } }),
       config.workspace({ root: "/workspace" }),
       binding.read,
       binding.write,
@@ -327,9 +327,9 @@ it("settles cancellation in session A without closing session B", async () => {
   const sessionB = context(scope, "session-b", authority)
   await sessionA.resolve(session.session)
   await sessionB.resolve(session.session)
-  const engineA = await sessionA.resolve(engine)
-  const engineB = await sessionB.resolve(engine)
-  expect(engineA).not.toBe(engineB)
+  const interpreterA = await sessionA.resolve(interpreter)
+  const interpreterB = await sessionB.resolve(interpreter)
+  expect(interpreterA).not.toBe(interpreterB)
   await sessionA.resolve(workspace)
   await sessionB.resolve(workspace)
 

--- a/pkg/sdk/claude/README.md
+++ b/pkg/sdk/claude/README.md
@@ -105,7 +105,7 @@ await scope.dispose()
 `claudeAttemptBinding` when composing `agent.turn`; `provider` remains the scalar model tag. Tests
 can preset `claudeAttempt`, `claudeLeases`, or `spawnProcess` through `createScope` without changing the caller.
 
-## Current prerelease migration
+## Migration to 4.0.0
 
 | Before | Now |
 |---|---|

--- a/pkg/sdk/claude/README.md
+++ b/pkg/sdk/claude/README.md
@@ -18,7 +18,6 @@ const scope = createScope({
     auth: { kind: "global" },
     cwd: process.cwd(),
     roots: [],
-    permission: "deny",
     shutdownTimeoutMs: 1_000,
   }),
 })
@@ -51,7 +50,6 @@ claude.config({
   auth: { kind: "token", env: "MY_CLAUDE_TOKEN" },
   cwd: process.cwd(),
   roots: [],
-  permission: "deny",
   shutdownTimeoutMs: 1_000,
 })
 ```
@@ -64,15 +62,17 @@ releases only the selected session lease. A child process error poisons its leas
 prompt settles, so queued prompts reject without starting.
 
 The scalar turn drains `claudeAttempt`. `claudeRun` and `claudeSession` remain direct prompt
-compatibility handles. `roots` lists extra absolute roots; `[]` means no extra roots. Permission policy is explicit and fail-closed. This
+compatibility handles. `roots` lists extra absolute roots; `[]` means no extra roots. Permission is
+always denied and is not configurable. This
 integration exposes no Claude tools or MCP servers. The managed config has no free-form CLI argument
-escape hatch. Abort and cleanup request graceful shutdown, wait `shutdownTimeoutMs`, send `SIGKILL`,
-then wait the same bound again. A child still alive after the second bound makes cleanup reject with
-`ClaudeShutdownError`; it is never reported as closed.
+escape hatch. Prompt abort sends an in-band interrupt and keeps the process alive. Cleanup requests
+graceful shutdown, waits `shutdownTimeoutMs`, sends `SIGKILL`, then waits the same bound again. A child
+still alive after the second bound makes cleanup reject with `ClaudeShutdownError`; it is never
+reported as closed.
 
 The stable handles remain `claude`, `claudeTurn`, `claudeRun`, and `claudeConfig`. The streaming
 handles are `claudeAttempt`, `claudeAttemptBinding`, and `claudeLeases`. Tests can replace
-`claudeAttempt`, `claudeLeases`, or the process `engine` with a scope preset. Package-module imports also expose aligned
+`claudeAttempt`, `claudeLeases`, or `spawnProcess` with a scope preset. Package-module imports also expose aligned
 aliases:
 
 ```ts
@@ -84,7 +84,6 @@ const scope = createScope({
     auth: { kind: "global" },
     cwd: process.cwd(),
     roots: [],
-    permission: "deny",
     shutdownTimeoutMs: 1_000,
   }),
 })
@@ -101,9 +100,17 @@ await ctx.close()
 await scope.dispose()
 ```
 
-`config`, `engine`, `run`, `turn`, and `provider` are aliases to the same graph handles. Use
+`config`, `run`, `turn`, and `provider` are aliases to the same graph handles. There is no generic
+`engine` alias; `spawnProcess` names the process seam that tests preset. Use
 `claudeAttemptBinding` when composing `agent.turn`; `provider` remains the scalar model tag. Tests
-can preset `claudeAttempt`, `claudeLeases`, or `engine` through `createScope` without changing the caller.
+can preset `claudeAttempt`, `claudeLeases`, or `spawnProcess` through `createScope` without changing the caller.
+
+## Current prerelease migration
+
+| Before | Now |
+|---|---|
+| `permission: "deny"` | remove the field; deny is hardcoded |
+| `engine` | `spawnProcess` |
 
 ## Migration to 3.0.0
 

--- a/pkg/sdk/claude/package.json
+++ b/pkg/sdk/claude/package.json
@@ -35,7 +35,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@pumped-fn/sdk": "^3.0.0",
+    "@pumped-fn/sdk": "^4.0.0",
     "@pumped-fn/lite": "^6.0.0"
   },
   "devDependencies": {

--- a/pkg/sdk/claude/src/index.ts
+++ b/pkg/sdk/claude/src/index.ts
@@ -8,7 +8,6 @@ import {
   model,
   parseModelResponse,
   step,
-  type CliIsolateOptions,
   type ModelRequest,
   type PromptInput,
 } from "@pumped-fn/sdk"
@@ -19,14 +18,12 @@ export type ClaudeAuth =
   | { kind: "token"; env?: string }
   | { kind: "global" }
 
-/** Configures Claude authentication, roots, isolation, permission, and process timeouts. */
+/** Configures Claude authentication, roots, and process timeouts. */
 export interface ClaudeConfig {
   auth: ClaudeAuth
   command?: string
   cwd: string
   roots: readonly string[]
-  permission: "deny"
-  isolate?: boolean | CliIsolateOptions
   shutdownTimeoutMs: number
   timeoutMs?: number
 }
@@ -45,7 +42,7 @@ export class ClaudeShutdownError extends Error {
 
 export const claudeConfig = tag<ClaudeConfig>({ label: "claude.config" })
 
-export const engine = atom({
+export const spawnProcess = atom({
   factory: () => spawn,
 })
 
@@ -88,19 +85,19 @@ export const claudeSession = resource({
     branch: tags.optional(session.current.branch),
     config: tags.required(claudeConfig),
     clock,
-    engine,
+    spawnProcess,
     environment,
     epoch: tags.optional(session.current.epoch),
     lineReader,
     runtime: tags.optional(session.current.session),
     work: tags.optional(session.current.work),
   },
-  factory: (ctx, { attempt, authority, branch, clock, config, engine, environment, epoch, lineReader, runtime, work }) => {
+  factory: (ctx, { attempt, authority, branch, clock, config, spawnProcess, environment, epoch, lineReader, runtime, work }) => {
     assertClaudeProvenance(runtime, work, attempt, branch, authority, epoch)
     const boundAuthority = bindClaudeAuthority(authority, work)
     const effectiveConfig = boundAuthority ? authorizeClaudeConfig(config, boundAuthority) : config
     const resolved = resolveConfig(effectiveConfig, environment)
-    const child = engine(resolved.command, [...resolved.args], {
+    const child = spawnProcess(resolved.command, [...resolved.args], {
       cwd: resolved.cwd,
       env: resolved.env,
       stdio: ["pipe", "pipe", "pipe"],
@@ -122,6 +119,7 @@ export const claudeSession = resource({
     let shutdownPhase: "open" | "graceful" | "force" = "open"
     let stderr = ""
     let tail = Promise.resolve()
+    let nextInterrupt = 0
 
     const settle = (result: { value: string } | { error: Error }) => {
       const transaction = current
@@ -172,7 +170,7 @@ export const claudeSession = resource({
         settle({ error: new ClaudeProcessError("Claude session closed during prompt") })
         return
       }
-      const error = new ClaudeShutdownError(`Claude process did not exit within two ${config.shutdownTimeoutMs}ms shutdown bounds`)
+      const error = new ClaudeShutdownError(`Claude process did not exit after SIGINT and SIGKILL, each with a ${config.shutdownTimeoutMs}ms shutdown bound`)
       lines.close()
       settle({ error })
       throw error
@@ -210,16 +208,14 @@ export const claudeSession = resource({
           return
         }
         const abort = () => {
-          closing = true
-          requestGraceful()
+          child.stdin.write(interruptMessage(nextInterrupt++))
           settle({ error: new DOMException("Claude prompt aborted", "AbortError") })
         }
         current = { resolve, reject, signal, abort }
         signal?.addEventListener("abort", abort, { once: true })
         if (config.timeoutMs !== undefined) {
           current.timeout = clock.set(() => {
-            closing = true
-            requestGraceful()
+            child.stdin.write(interruptMessage(nextInterrupt++))
             settle({ error: new ClaudeProcessError(`Claude prompt timed out after ${config.timeoutMs}ms`) })
           }, config.timeoutMs)
         }
@@ -257,14 +253,14 @@ export const claudeLeases = resource({
     branch: tags.optional(session.current.branch),
     config: tags.required(claudeConfig),
     clock,
-    engine,
+    spawnProcess,
     environment,
     epoch: tags.optional(session.current.epoch),
     lineReader,
     runtime: tags.optional(session.current.session),
     work: tags.optional(session.current.work),
   },
-  factory: (ctx, { attempt, authority, branch, clock, config, engine, environment, epoch, lineReader, runtime, work }): ClaudeLeaseManager => {
+  factory: (ctx, { attempt, authority, branch, clock, config, spawnProcess, environment, epoch, lineReader, runtime, work }): ClaudeLeaseManager => {
     assertClaudeProvenance(runtime, work, attempt, branch, authority, epoch)
     const boundAuthority = bindClaudeAuthority(authority, work)
     const effectiveConfig = boundAuthority ? authorizeClaudeConfig(config, boundAuthority) : config
@@ -273,7 +269,7 @@ export const claudeLeases = resource({
     const lease = (sessionId: string) => {
       const existing = leases.get(sessionId)
       if (existing) return existing
-      const created = createManagedLease(effectiveConfig, { clock, engine, environment, lineReader })
+      const created = createManagedLease(effectiveConfig, { clock, spawnProcess, environment, lineReader })
       leases.set(sessionId, created)
       return created
     }
@@ -381,10 +377,6 @@ export {
 }
 
 function resolveConfig(config: ClaudeConfig, environment: NodeJS.ProcessEnv) {
-  if (config.isolate !== undefined && config.isolate !== false) {
-    throw new ClaudeConfigError("Managed Claude sessions do not support isolated CLI state")
-  }
-  if (config.permission !== "deny") throw new ClaudeConfigError('Claude permission must be explicitly set to "deny"')
   if (!Number.isFinite(config.shutdownTimeoutMs) || config.shutdownTimeoutMs <= 0) {
     throw new ClaudeConfigError("Claude shutdownTimeoutMs must be greater than zero")
   }
@@ -535,6 +527,14 @@ function parseEvent(line: string): { type: string; result: string; is_error: boo
   return { type: "result", result: event["result"], is_error: event["is_error"] }
 }
 
+function interruptMessage(requestId: number): string {
+  return `${JSON.stringify({
+    request_id: `interrupt-${requestId}`,
+    type: "control_request",
+    request: { subtype: "interrupt" },
+  })}\n`
+}
+
 function requiredEnvironment(environment: NodeJS.ProcessEnv, name: string): string {
   const value = environment[name]
   if (!value) throw new ClaudeConfigError(`Claude token environment variable "${name}" is not set`)
@@ -548,13 +548,13 @@ function createManagedLease(
       set(fn: () => void, ms: number): number
       clear(token: number): void
     }
-    readonly engine: typeof spawn
+    readonly spawnProcess: typeof spawn
     readonly environment: NodeJS.ProcessEnv
     readonly lineReader: typeof createInterface
   },
 ) {
   const resolved = resolveConfig(config, deps.environment)
-  const child = deps.engine(resolved.command, [...resolved.args], {
+  const child = deps.spawnProcess(resolved.command, [...resolved.args], {
     cwd: resolved.cwd,
     env: resolved.env,
     stdio: ["pipe", "pipe", "pipe"],
@@ -576,6 +576,7 @@ function createManagedLease(
   let closing = false
   let shutdown: Promise<void> | undefined
   let tail = Promise.resolve()
+  let nextInterrupt = 0
 
   const settle = (result: { value: string } | { error: Error }) => {
     const transaction = current
@@ -611,7 +612,7 @@ function createManagedLease(
       }
       if (!await awaitExit()) {
         child.kill("SIGKILL")
-        if (!await awaitExit()) throw new ClaudeShutdownError(`Claude process did not exit within two ${config.shutdownTimeoutMs}ms shutdown bounds`)
+        if (!await awaitExit()) throw new ClaudeShutdownError(`Claude process did not exit after SIGINT and SIGKILL, each with a ${config.shutdownTimeoutMs}ms shutdown bound`)
       }
       lines.close()
       settle({ error: new ClaudeProcessError("Claude session closed during prompt") })
@@ -655,8 +656,7 @@ function createManagedLease(
         return
       }
       const abort = () => {
-        closing = true
-        child.kill("SIGINT")
+        child.stdin.write(interruptMessage(nextInterrupt++))
         settle({ error: new DOMException("Claude prompt aborted", "AbortError") })
       }
       current = { events, resolve, reject, signal, abort }
@@ -664,8 +664,7 @@ function createManagedLease(
       signal?.addEventListener("abort", abort, { once: true })
       if (config.timeoutMs !== undefined) {
         current.timeout = deps.clock.set(() => {
-          closing = true
-          child.kill("SIGINT")
+          child.stdin.write(interruptMessage(nextInterrupt++))
           settle({ error: new ClaudeProcessError(`Claude prompt timed out after ${config.timeoutMs}ms`) })
         }, config.timeoutMs)
       }

--- a/pkg/sdk/claude/tests/claude.integration.test.ts
+++ b/pkg/sdk/claude/tests/claude.integration.test.ts
@@ -10,7 +10,6 @@ integration("invokes the authenticated Claude CLI", async () => {
       auth: { kind: "global" },
       cwd: process.cwd(),
       roots: [],
-      permission: "deny",
       shutdownTimeoutMs: 1_000,
     })],
   })

--- a/pkg/sdk/claude/tests/claude.test.ts
+++ b/pkg/sdk/claude/tests/claude.test.ts
@@ -18,7 +18,7 @@ import {
   claudeSession,
   claudeTurn,
   clock,
-  engine,
+  spawnProcess,
   ClaudeShutdownError,
   type ClaudeLeaseManager,
 } from "../src/index"
@@ -84,18 +84,18 @@ it("can replace the model tag per context", async () => {
 
 it("exposes aligned package-module handles without a facade", () => {
   expect(claudeModule.config).toBe(claudeConfig)
-  expect(claudeModule.engine).toBe(engine)
+  expect(claudeModule.spawnProcess).toBe(spawnProcess)
   expect(claudeModule.run).toBe(claudeRun)
   expect(claudeModule.turn).toBe(claudeTurn)
   expect(claudeModule.provider).toBe(claude)
-  expectTypeOf(claudeModule.engine).not.toBeAny()
+  expectTypeOf(claudeModule.spawnProcess).not.toBeAny()
 })
 
 it("exposes the canonical turn to attempt graph and retained scalar compatibility graph", () => {
   expect(claudeTurn.deps).toMatchObject({ attempt: { flow: claudeAttempt } })
   expect(claudeAttempt.deps).toMatchObject({ leases: claudeLeases })
   expect(claudeRun.deps).toMatchObject({ session: claudeSession })
-  expect(claudeSession.deps).toMatchObject({ engine })
+  expect(claudeSession.deps).toMatchObject({ spawnProcess })
 })
 
 it("normalizes a managed lease stream and releases its transient process", async () => {
@@ -148,7 +148,7 @@ it("normalizes a managed lease stream and releases its transient process", async
 it("cancels a managed Claude lease when its stream consumer returns", async () => {
   const harness = createHarness()
   const scope = createScope({
-    presets: [preset(engine, harness.engine)],
+    presets: [preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig())],
   })
   const ctx = scope.createContext({ tags: [session.record(sessionRecord("consumer"))] })
@@ -163,7 +163,9 @@ it("cancels a managed Claude lease when its stream consumer returns", async () =
   const result = stream.result.catch(() => undefined)
   await expect(iterator.return?.()).resolves.toMatchObject({ done: true })
   await result
-  expect(harness.signals).toEqual(["SIGINT"])
+  expect(harness.controlInterrupts).toBe(1)
+  expect(harness.signals).toEqual([])
+  expect(harness.ends).toBe(1)
   expect(harness.live).toBe(false)
 
   await ctx.close()
@@ -308,10 +310,10 @@ it("isolates managed leases by branch within one logical session", async () => {
   await scope.dispose()
 })
 
-it("runs sequential stream-json prompts through a scope-owned engine", async () => {
+it("runs sequential stream-json prompts through a scope-owned process", async () => {
   const harness = createHarness()
   const scope = createScope({
-    presets: [preset(engine, harness.engine)],
+    presets: [preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig({ roots: ["/tmp/extra"] }))],
   })
   const ctx = scope.createContext()
@@ -351,7 +353,7 @@ it("runs sequential stream-json prompts through a scope-owned engine", async () 
 it("poisons a managed lease before child failure settles queued prompts", async () => {
   const harness = createHarness()
   const scope = createScope({
-    presets: [preset(engine, harness.engine)],
+    presets: [preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig())],
   })
   const ctx = scope.createContext()
@@ -369,11 +371,11 @@ it("poisons a managed lease before child failure settles queued prompts", async 
   await scope.dispose()
 })
 
-it("interrupts an active prompt and awaits child close", async () => {
-  const harness = createHarness({ closeOnEnd: false, closeOnInterrupt: false })
+it("interrupts an active prompt without closing the child", async () => {
+  const harness = createHarness({ closeOnEnd: false })
   const controller = new AbortController()
   const scope = createScope({
-    presets: [preset(engine, harness.engine)],
+    presets: [preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig())],
   })
   const ctx = scope.createContext()
@@ -383,9 +385,11 @@ it("interrupts an active prompt and awaits child close", async () => {
 
   controller.abort()
   await expect(prompt).rejects.toMatchObject({ name: "AbortError" })
-  await expect(queued).rejects.toThrow("Claude session is closed")
-  expect(harness.interrupts).toBe(1)
+  await expect(queued).rejects.toMatchObject({ name: "AbortError" })
+  expect(harness.controlInterrupts).toBe(1)
+  expect(harness.signals).toEqual([])
   expect(harness.prompts).toEqual(["wait"])
+  expect(harness.live).toBe(true)
 
   let closed = false
   const close = ctx.close().then(() => {
@@ -400,9 +404,37 @@ it("interrupts an active prompt and awaits child close", async () => {
   expect(harness.live).toBe(false)
 })
 
-it("requires config through the graph before the engine starts", async () => {
+it("keeps a session usable after an aborted prompt", async () => {
   const harness = createHarness()
-  const scope = createScope({ presets: [preset(engine, harness.engine)] })
+  const controller = new AbortController()
+  const scope = createScope({
+    presets: [preset(spawnProcess, harness.spawnProcess)],
+    tags: [claudeConfig(managedConfig())],
+  })
+  const ctx = scope.createContext()
+  const aborted = ctx.exec({ flow: claudeRun, input: { prompt: "abort" }, signal: controller.signal })
+  await harness.writes(1)
+
+  controller.abort()
+  await expect(aborted).rejects.toMatchObject({ name: "AbortError" })
+  expect(harness.controlInterrupts).toBe(1)
+  expect(harness.signals).toEqual([])
+  expect(harness.live).toBe(true)
+
+  const next = ctx.exec({ flow: claudeRun, input: { prompt: "next" } })
+  await harness.writes(2)
+  harness.result("done")
+  await expect(next).resolves.toBe("done")
+  expect(harness.prompts).toEqual(["abort", "next"])
+
+  await ctx.close()
+  await scope.dispose()
+  expect(harness.live).toBe(false)
+})
+
+it("requires config through the graph before the process starts", async () => {
+  const harness = createHarness()
+  const scope = createScope({ presets: [preset(spawnProcess, harness.spawnProcess)] })
   const ctx = scope.createContext()
 
   await expect(ctx.exec({ flow: claudeRun, input: { prompt: "blocked" } })).rejects.toThrow()
@@ -413,12 +445,12 @@ it("requires config through the graph before the engine starts", async () => {
 })
 
 it.each([
-  [{ auth: { kind: "global" }, cwd: process.cwd(), roots: ["relative"], permission: "deny", shutdownTimeoutMs: 25 }, "roots must contain only absolute paths"],
-  [{ auth: { kind: "global" }, cwd: "relative", roots: [], permission: "deny", shutdownTimeoutMs: 25 }, "cwd must be an absolute path"],
+  [{ auth: { kind: "global" }, cwd: process.cwd(), roots: ["relative"], shutdownTimeoutMs: 25 }, "roots must contain only absolute paths"],
+  [{ auth: { kind: "global" }, cwd: "relative", roots: [], shutdownTimeoutMs: 25 }, "cwd must be an absolute path"],
 ] as const)("fails closed on incomplete managed authority %#", async (value, message) => {
   const harness = createHarness()
   const scope = createScope({
-    presets: [preset(engine, harness.engine)],
+    presets: [preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(value)],
   })
   const ctx = scope.createContext()
@@ -433,7 +465,7 @@ it.each([
 it("rejects managed Claude roots outside current work authority before spawning", async () => {
   const harness = createHarness()
   const scope = createScope({
-    presets: [preset(engine, harness.engine)],
+    presets: [preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig())],
   })
   const authority = testAuthority([], false, true)
@@ -487,7 +519,7 @@ it("rejects a Claude root that escapes through a symlink", async () => {
   const runtime = { authority, record: sessionProvenanceRecord(authority, branch, work, attempt) } as session.SessionRuntime
   const harness = createHarness()
   const scope = createScope({
-    presets: [preset(engine, harness.engine)],
+    presets: [preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig({ cwd: escape }))],
   })
   const ctx = scope.createContext({ tags: [
@@ -506,10 +538,10 @@ it("rejects a Claude root that escapes through a symlink", async () => {
   await rm(root, { recursive: true })
 })
 
-it("requires a positive shutdown bound before the engine starts", async () => {
+it("requires a positive shutdown bound before the process starts", async () => {
   const harness = createHarness()
   const scope = createScope({
-    presets: [preset(engine, harness.engine)],
+    presets: [preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig({ shutdownTimeoutMs: 0 }))],
   })
   const ctx = scope.createContext()
@@ -525,7 +557,7 @@ it("escalates graceful close to SIGKILL within the second bound", async () => {
   const harness = createHarness({ closeOnEnd: false, closeOnSignals: ["SIGKILL"] })
   const timers = createClock()
   const scope = createScope({
-    presets: [preset(clock, timers.clock), preset(engine, harness.engine)],
+    presets: [preset(clock, timers.clock), preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig())],
   })
   const ctx = scope.createContext()
@@ -545,7 +577,7 @@ it("fails closed when the child ignores SIGKILL past the second bound", async ()
   const harness = createHarness({ closeOnEnd: false, closeOnSignals: [] })
   const timers = createClock()
   const scope = createScope({
-    presets: [preset(clock, timers.clock), preset(engine, harness.engine)],
+    presets: [preset(clock, timers.clock), preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig())],
   })
   const ctx = scope.createContext()
@@ -567,7 +599,7 @@ it("fails closed when the child ignores SIGKILL past the second bound", async ()
 it("terminates exactly once across repeated context close and scope dispose", async () => {
   const harness = createHarness()
   const scope = createScope({
-    presets: [preset(engine, harness.engine)],
+    presets: [preset(spawnProcess, harness.spawnProcess)],
     tags: [claudeConfig(managedConfig())],
   })
   const ctx = scope.createContext()
@@ -586,19 +618,19 @@ function managedConfig(overrides: Partial<Parameters<typeof claudeConfig>[0]> = 
     auth: { kind: "global" },
     cwd: process.cwd(),
     roots: [],
-    permission: "deny",
     shutdownTimeoutMs: 25,
     ...overrides,
   }
 }
 
-function createHarness(options: { closeOnEnd?: boolean; closeOnInterrupt?: boolean; closeOnSignals?: NodeJS.Signals[] } = {}) {
+function createHarness(options: { closeOnEnd?: boolean; closeOnSignals?: NodeJS.Signals[] } = {}) {
   const input = new PassThrough()
   const output = new PassThrough()
   const error = new PassThrough()
   const prompts: string[] = []
   let spawned: { command: string; args: readonly string[]; cwd: string | URL | undefined } | undefined
   const signals: NodeJS.Signals[] = []
+  let controlInterrupts = 0
   let ends = 0
   let live = true
   let buffered = ""
@@ -608,7 +640,13 @@ function createHarness(options: { closeOnEnd?: boolean; closeOnInterrupt?: boole
     const lines = buffered.split("\n")
     buffered = lines.pop() ?? ""
     for (const line of lines) {
-      const message = JSON.parse(line) as { message: { content: string } }
+      const message = JSON.parse(line) as
+        | { type: "control_request"; request: { subtype: "interrupt" } }
+        | { type: "user"; message: { content: string } }
+      if (message.type === "control_request") {
+        controlInterrupts++
+        continue
+      }
       prompts.push(message.message.content)
     }
   })
@@ -625,7 +663,7 @@ function createHarness(options: { closeOnEnd?: boolean; closeOnInterrupt?: boole
     stderr: error,
     kill: (signal: NodeJS.Signals = "SIGTERM") => {
       signals.push(signal)
-      const configured = options.closeOnSignals ?? (options.closeOnInterrupt === false ? [] : ["SIGINT", "SIGTERM", "SIGKILL"])
+      const configured = options.closeOnSignals ?? ["SIGINT", "SIGTERM", "SIGKILL"]
       if (configured.includes(signal)) close()
       return true
     },
@@ -637,9 +675,9 @@ function createHarness(options: { closeOnEnd?: boolean; closeOnInterrupt?: boole
   const replacement = ((command: string, args: readonly string[], spawnOptions: SpawnOptionsWithoutStdio) => {
     spawned = { command, args, cwd: spawnOptions.cwd }
     return child
-  }) as Lite.Utils.AtomValue<typeof engine>
+  }) as Lite.Utils.AtomValue<typeof spawnProcess>
   return {
-    engine: replacement,
+    spawnProcess: replacement,
     prompts,
     result(value: string) {
       output.write(`${JSON.stringify({ type: "result", result: value, is_error: false })}\n`)
@@ -656,8 +694,8 @@ function createHarness(options: { closeOnEnd?: boolean; closeOnInterrupt?: boole
     get options() {
       return spawned
     },
-    get interrupts() {
-      return signals.filter((signal) => signal === "SIGINT").length
+    get controlInterrupts() {
+      return controlInterrupts
     },
     get signals() {
       return signals

--- a/pkg/sdk/codex/README.md
+++ b/pkg/sdk/codex/README.md
@@ -9,13 +9,13 @@ import { createScope } from "@pumped-fn/lite"
 import * as codex from "@pumped-fn/sdk-codex"
 
 const scope = createScope({
-  tags: codex.codexConfig({
+  tags: codex.config({
     auth: { kind: "global" },
     cwd: "/absolute/path/to/project",
   }),
 })
 const ctx = scope.createContext()
-await ctx.exec({ flow: codex.codexTurn, input: {
+await ctx.exec({ flow: codex.turn, input: {
   agentName: "triage",
   instructions: "Triage the ticket.",
   messages: [{ role: "user", content: "Login fails after refresh." }],
@@ -45,7 +45,7 @@ rejected in split and `--flag=value` forms.
 
 ACP uses `@agentclientprotocol/codex-acp` over stdio through the official TypeScript client. Its auth,
 working directory, extra roots, permission policy, and shutdown bound are required. Paths must be
-absolute. An empty `additionalDirectories` array means no extra roots. Every permission decision is
+absolute. An empty `roots` array means no extra roots. Every permission decision is
 emitted as a provider status event by streaming attempts.
 
 ```ts
@@ -53,17 +53,17 @@ import * as codex from "@pumped-fn/sdk-codex"
 import { createScope } from "@pumped-fn/lite"
 
 const scope = createScope({
-  tags: codex.config({
+  tags: codex.codexAcpConfig({
     auth: { kind: "global" },
     cwd: process.cwd(),
-    additionalDirectories: [],
+    roots: [],
     permission: "deny",
     shutdownTimeoutMs: 5_000,
   }),
 })
 const ctx = scope.createContext()
-await ctx.resolve(codex.engine)
-await ctx.exec({ flow: codex.turn, input: {
+await ctx.resolve(codex.acp)
+await ctx.exec({ flow: codex.codexAcpTurn, input: {
   agentName: "triage",
   instructions: "Triage the ticket.",
   messages: [{ role: "user", content: "Login fails after refresh." }],
@@ -73,10 +73,11 @@ await ctx.close()
 await scope.dispose()
 ```
 
-ACP applies the same current-work check to `cwd`, `additionalDirectories`, and granted write and
+ACP applies the same current-work check to `cwd`, `roots`, and granted write and
 network capabilities before starting its process or creating a session.
 
-Each ACP prompt sends `cwd`, `additionalDirectories`, and `mcpServers: []`. Pumped-fn tool collection
+Each ACP prompt maps `roots` to the ACP protocol's `additionalDirectories` field and sends
+`mcpServers: []`. Pumped-fn tool collection
 and MCP projection remain deferred. Abort sends `session/cancel`, releases local correlation state,
 and waits at most `shutdownTimeoutMs` for the remote prompt and cancellation to settle. A timed-out
 prompt terminates and releases its transport before a replacement can start. Failed termination
@@ -99,9 +100,17 @@ no rejected update queue.
 
 The stable CLI handles remain `codex`, `codexTurn`, and `codexRun`; ACP keeps `codexAcp`,
 `codexAcpTurn`, `codexAcpPrompt`, `codexAcpConfig`, and `acp`. Package-module imports expose the
-managed ACP aliases `config`, `engine`, `run`, `turn`, and `provider`. They are the same graph handles,
-not a facade object or shared scope factory. Tests can preset `run` or `engine` through `createScope`
-without changing the agent graph.
+CLI aliases `config`, `run`, `turn`, and `provider`. They are the same graph handles, not a facade
+object or shared scope factory. There is no generic `engine` alias; preset the CLI `run` edge or the
+ACP `acp` resource by its explicit name.
+
+## Current prerelease migration
+
+| Before | Now |
+|---|---|
+| ACP aliases `config`, `run`, `turn`, and `provider` | CLI aliases; use `codexAcpConfig`, `codexAcpPrompt`, `codexAcpTurn`, and `codexAcp` for ACP |
+| `engine` | removed; use `acp` for the ACP process resource |
+| ACP config `additionalDirectories` | `roots` |
 
 ## Migration to 3.0.0
 

--- a/pkg/sdk/codex/README.md
+++ b/pkg/sdk/codex/README.md
@@ -104,7 +104,7 @@ CLI aliases `config`, `run`, `turn`, and `provider`. They are the same graph han
 object or shared scope factory. There is no generic `engine` alias; preset the CLI `run` edge or the
 ACP `acp` resource by its explicit name.
 
-## Current prerelease migration
+## Migration to 4.0.0
 
 | Before | Now |
 |---|---|

--- a/pkg/sdk/codex/package.json
+++ b/pkg/sdk/codex/package.json
@@ -35,7 +35,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@pumped-fn/sdk": "^3.0.0",
+    "@pumped-fn/sdk": "^4.0.0",
     "@pumped-fn/lite": "^6.0.0"
   },
   "dependencies": {

--- a/pkg/sdk/codex/src/index.ts
+++ b/pkg/sdk/codex/src/index.ts
@@ -136,7 +136,7 @@ export interface CodexAcpConfig {
   command?: string
   args?: readonly string[]
   cwd: string
-  additionalDirectories: readonly string[]
+  roots: readonly string[]
   permission: "grant" | "deny"
   shutdownTimeoutMs: number
 }
@@ -162,8 +162,8 @@ export const acp = resource({
     const effectiveConfig = boundAuthority ? authorizeAcpConfig(config, boundAuthority) : config
     if (!effectiveConfig.auth) throw new CodexConfigError("ACP auth must be explicitly set")
     if (!absolutePath(effectiveConfig.cwd)) throw new CodexConfigError("ACP cwd must be absolute")
-    if (effectiveConfig.additionalDirectories.some((directory) => !absolutePath(directory))) {
-      throw new CodexConfigError("ACP additionalDirectories must be absolute")
+    if (effectiveConfig.roots.some((root) => !absolutePath(root))) {
+      throw new CodexConfigError("ACP roots must be absolute")
     }
     if (!Number.isFinite(effectiveConfig.shutdownTimeoutMs) || effectiveConfig.shutdownTimeoutMs <= 0) {
       throw new CodexConfigError("ACP shutdownTimeoutMs must be greater than zero")
@@ -495,11 +495,10 @@ export const codexAcpTurn = flow({
 export const codexAcp = model(codexAcpTurn)
 
 export {
-  codexAcpConfig as config,
-  acp as engine,
-  codexAcpPrompt as run,
-  codexAcpTurn as turn,
-  codexAcp as provider,
+  codexConfig as config,
+  codexRun as run,
+  codexTurn as turn,
+  codex as provider,
 }
 
 function requiredEnvironment(environment: NodeJS.ProcessEnv, name: string): string {
@@ -670,7 +669,7 @@ function authorizeAcpConfig(config: CodexAcpConfig, authority: session.Authority
   return {
     ...config,
     cwd: canonicalPath(config.cwd),
-    additionalDirectories: config.additionalDirectories.map(canonicalPath),
+    roots: config.roots.map(canonicalPath),
   }
 }
 
@@ -731,7 +730,7 @@ function assertCliAuthority(config: CodexConfig, authority: session.Authority): 
 }
 
 function assertAcpAuthority(config: CodexAcpConfig, authority: session.Authority): void {
-  assertRoots("ACP", [config.cwd, ...config.additionalDirectories], authority)
+  assertRoots("ACP", [config.cwd, ...config.roots], authority)
   if (config.permission === "grant" && !authority.sandbox.write) {
     throw new CodexConfigError("ACP write exceeds current work authority")
   }
@@ -741,12 +740,8 @@ function assertAcpAuthority(config: CodexAcpConfig, authority: session.Authority
 }
 
 function permissionAllowed(request: RequestPermissionRequest, authority: session.Authority): boolean {
-  const title = request.toolCall.title ?? ""
   const kind = request.toolCall.kind ?? ""
-  return authority.permissions.includes(title)
-    || authority.permissions.includes(kind)
-    || authority.tools.includes(title)
-    || authority.tools.includes(kind)
+  return authority.permissions.includes(kind) || authority.tools.includes(kind)
 }
 
 function assertRoots(provider: "Codex" | "ACP", roots: readonly string[], authority: session.Authority): void {
@@ -779,7 +774,7 @@ async function createAcpSession(
 ): Promise<string> {
   const pending = agent.buildSession({
     cwd: config.cwd,
-    additionalDirectories: [...config.additionalDirectories],
+    additionalDirectories: [...config.roots],
     mcpServers: [],
   }).start()
   let active: ActiveSession

--- a/pkg/sdk/codex/tests/codex.acp.test.ts
+++ b/pkg/sdk/codex/tests/codex.acp.test.ts
@@ -55,7 +55,8 @@ lines.on("line", (line) => {
     send({ jsonrpc: "2.0", id: pending, result: { stopReason: "cancelled" } })
     pending = undefined
   } else if (message.id === 99) {
-    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "probe-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: JSON.stringify({ cwd: globalThis.session.cwd, additionalDirectories: globalThis.session.additionalDirectories, mcpServers: globalThis.session.mcpServers, permission: message.result, pid: process.pid }) } } } })
+    const payload = JSON.stringify({ cwd: globalThis.session.cwd, additionalDirectories: globalThis.session.additionalDirectories, mcpServers: globalThis.session.mcpServers, permission: message.result, pid: process.pid })
+    send({ jsonrpc: "2.0", method: "session/update", params: { sessionId: "probe-session", update: { sessionUpdate: "agent_message_chunk", content: { type: "text", text: JSON.stringify({ content: payload, stop: true }) } } } })
     send({ jsonrpc: "2.0", id: active, result: { stopReason: "end_turn" } })
   }
 })
@@ -186,10 +187,14 @@ function managedConfig(source = agent, shutdownTimeoutMs = 5_000) {
     command: process.execPath,
     args: ["--input-type=module", "--eval", source],
     cwd: process.cwd(),
-    additionalDirectories: ["/tmp"],
+    roots: ["/tmp"],
     permission: "deny",
     shutdownTimeoutMs,
   })
+}
+
+function modelContent(output: string): string {
+  return (JSON.parse(output) as { content: string }).content
 }
 
 it("passes explicit roots with no MCP servers and leaves no live state after close", async () => {
@@ -198,7 +203,7 @@ it("passes explicit roots with no MCP servers and leaves no live state after clo
     tags: [session.current.authority(testAuthority([process.cwd(), "/tmp"]))],
   })
   const boundary = await ctx.resolve(acp)
-  const output = JSON.parse(await ctx.exec({ flow: codexAcpPrompt, input: request })) as {
+  const output = JSON.parse(modelContent(await ctx.exec({ flow: codexAcpPrompt, input: request }))) as {
     cwd: string
     additionalDirectories: string[]
     mcpServers: unknown[]
@@ -721,13 +726,42 @@ it("never selects an allow_always ACP permission", async () => {
       command: process.execPath,
       args: ["--input-type=module", "--eval", allowAlwaysAgent],
       cwd,
-      additionalDirectories: [],
+      roots: [],
       permission: "grant",
       shutdownTimeoutMs: 5_000,
     })],
   })
   const ctx = scope.createContext({ tags: [session.current.authority(authority)] })
-  const output = JSON.parse(await ctx.exec({ flow: codexAcpPrompt, input: request })) as { permission: unknown }
+  const output = JSON.parse(modelContent(await ctx.exec({ flow: codexAcpPrompt, input: request }))) as { permission: unknown }
+
+  expect(output.permission).toEqual({ outcome: { outcome: "cancelled" } })
+  await ctx.close()
+  await scope.dispose()
+})
+
+it("does not grant an ACP permission from a spoofed title", async () => {
+  const cwd = process.cwd()
+  const authority = session.createAuthority({
+    tenant: "codex-acp-test",
+    roots: [cwd],
+    permissions: ["write"],
+    tools: [],
+    sandbox: { roots: [cwd], commands: [], write: true, network: true },
+  })
+  const scope = createScope({
+    presets: [preset(spawnProcess, managedProcess(agent))],
+    tags: [codexAcpConfig({
+      auth: { kind: "global" },
+      command: process.execPath,
+      args: ["--input-type=module", "--eval", agent],
+      cwd,
+      roots: [],
+      permission: "grant",
+      shutdownTimeoutMs: 5_000,
+    })],
+  })
+  const ctx = scope.createContext({ tags: [session.current.authority(authority)] })
+  const output = JSON.parse(modelContent(await ctx.exec({ flow: codexAcpPrompt, input: request }))) as { permission: unknown }
 
   expect(output.permission).toEqual({ outcome: { outcome: "cancelled" } })
   await ctx.close()
@@ -745,7 +779,7 @@ it("rejects an ACP directory that escapes authority through a symlink", async ()
   const scope = createScope({ tags: [codexAcpConfig({
     auth: { kind: "global" },
     cwd: allowed,
-    additionalDirectories: [escape],
+    roots: [escape],
     permission: "deny",
     shutdownTimeoutMs: 10,
   })] })
@@ -769,7 +803,7 @@ it.each([
     tags: [codexAcpConfig({
       auth: { kind: "global" },
       cwd,
-      additionalDirectories: [],
+      roots: [],
       permission: "grant",
       shutdownTimeoutMs: 25,
     })],
@@ -784,13 +818,13 @@ it.each([
 
 it.each([
   ["cwd", ".", [], "ACP cwd must be absolute"],
-  ["additional directory", process.cwd(), ["relative"], "ACP additionalDirectories must be absolute"],
-])("rejects a relative ACP %s before spawning", async (_label, cwd, additionalDirectories, message) => {
+  ["root", process.cwd(), ["relative"], "ACP roots must be absolute"],
+])("rejects a relative ACP %s before spawning", async (_label, cwd, roots, message) => {
   const scope = createScope({
     tags: [codexAcpConfig({
       auth: { kind: "global" },
       cwd,
-      additionalDirectories,
+      roots,
       permission: "deny",
       shutdownTimeoutMs: 5_000,
     })],
@@ -817,7 +851,7 @@ it("fails closed without explicit ACP auth", async () => {
     presets: [preset(spawnProcess, harness.spawn)],
     tags: [codexAcpConfig({
       cwd: process.cwd(),
-      additionalDirectories: [],
+      roots: [],
       permission: "deny",
       shutdownTimeoutMs: 5_000,
     } as Parameters<typeof codexAcpConfig>[0])],
@@ -843,7 +877,7 @@ it("declares API-key environment and escalates a stubborn child once", async () 
     tags: [codexAcpConfig({
       auth: { kind: "api-key", env: "MY_CODEX_KEY" },
       cwd: process.cwd(),
-      additionalDirectories: [],
+      roots: [],
       permission: "deny",
       shutdownTimeoutMs: 10,
     })],
@@ -877,7 +911,7 @@ it("rejects with a typed error after both shutdown bounds", async () => {
     tags: [codexAcpConfig({
       auth: { kind: "global" },
       cwd: process.cwd(),
-      additionalDirectories: [],
+      roots: [],
       permission: "deny",
       shutdownTimeoutMs: 10,
     })],
@@ -1023,6 +1057,13 @@ function managedProcess(source: string): Lite.Utils.AtomValue<typeof spawnProces
             pending.delete(id)
           }
         } else if (message.id === 99 && activePrompt !== undefined) {
+          const payload = JSON.stringify({
+            cwd: sessionConfig?.cwd,
+            additionalDirectories: sessionConfig?.additionalDirectories,
+            mcpServers: sessionConfig?.mcpServers,
+            permission: message.result,
+            pid: 2_147_483_647,
+          })
           send({
             jsonrpc: "2.0",
             method: "session/update",
@@ -1032,13 +1073,7 @@ function managedProcess(source: string): Lite.Utils.AtomValue<typeof spawnProces
                 sessionUpdate: "agent_message_chunk",
                 content: {
                   type: "text",
-                  text: JSON.stringify({
-                    cwd: sessionConfig?.cwd,
-                    additionalDirectories: sessionConfig?.additionalDirectories,
-                    mcpServers: sessionConfig?.mcpServers,
-                    permission: message.result,
-                    pid: 2_147_483_647,
-                  }),
+                  text: JSON.stringify({ content: payload, stop: true }),
                 },
               },
             },

--- a/pkg/sdk/codex/tests/codex.integration.test.ts
+++ b/pkg/sdk/codex/tests/codex.integration.test.ts
@@ -31,7 +31,7 @@ integration("invokes Codex through ACP", async () => {
     tags: [codexAcpConfig({
       auth: { kind: "global" },
       cwd: process.cwd(),
-      additionalDirectories: [],
+      roots: [],
       permission: "deny",
       shutdownTimeoutMs: 5_000,
     })],

--- a/pkg/sdk/codex/tests/codex.test.ts
+++ b/pkg/sdk/codex/tests/codex.test.ts
@@ -8,6 +8,7 @@ import { expect, expectTypeOf, it } from "vitest"
 import * as session from "@pumped-fn/sdk/session"
 import * as codexModule from "../src/index"
 import {
+  acp,
   codex,
   codexAttempt,
   codexAcp,
@@ -18,7 +19,6 @@ import {
   codexConfig,
   codexRun,
   codexTurn,
-  engine,
   type CodexConfig,
 } from "../src/index"
 
@@ -100,10 +100,10 @@ it("normalizes the CLI attempt without changing its scalar response", async () =
 it("provides ACP through a preset prompt edge", async () => {
   const scope = createScope({
     presets: [preset(codexAcpAttempt, fakeAcp)],
-    tags: [codexModule.provider, codexModule.config({
+    tags: [codexAcp, codexAcpConfig({
       auth: { kind: "global" },
       cwd: process.cwd(),
-      additionalDirectories: [],
+      roots: [],
       permission: "deny",
       shutdownTimeoutMs: 5_000,
     })],
@@ -371,25 +371,24 @@ it("binds the ACP resource before spawning its child", async () => {
       auth: { kind: "global" },
       command: "must-not-start",
       cwd: root,
-      additionalDirectories: [],
+      roots: [],
       permission: "deny",
       shutdownTimeoutMs: 100,
     })],
   })
   const ctx = scope.createContext({ tags: [session.current.authority(broad), session.current.work(work)] })
 
-  await expect(ctx.resolve(engine)).rejects.toThrow("Codex authority does not match current work")
+  await expect(ctx.resolve(acp)).rejects.toThrow("Codex authority does not match current work")
   await ctx.close()
   await scope.dispose()
   await rm(root, { recursive: true })
 })
 
-it("exports the managed ACP path as module namespace handles", () => {
-  expect(codexModule.config).toBe(codexAcpConfig)
-  expect(codexModule.engine).toBe(engine)
-  expect(codexModule.run).toBe(codexAcpPrompt)
-  expect(codexModule.turn).toBe(codexAcpTurn)
-  expect(codexModule.provider).toBe(codexAcp)
+it("exports the CLI path as module namespace handles", () => {
+  expect(codexModule.config).toBe(codexConfig)
+  expect(codexModule.run).toBe(codexRun)
+  expect(codexModule.turn).toBe(codexTurn)
+  expect(codexModule.provider).toBe(codex)
   expectTypeOf(codexModule.turn).toMatchTypeOf<Model>()
 })
 

--- a/pkg/sdk/core/README.md
+++ b/pkg/sdk/core/README.md
@@ -2,6 +2,19 @@
 
 Agent and session primitives built on Lite. Lite owns graph resolution, execution, streaming, lifetimes, and the `createScope` seam. The SDK supplies stable definitions and durable data contracts.
 
+## Migration to 4.0.0
+
+| Before | Now |
+|---|---|
+| `Runtime` type, `runtime` tag, tag label `workflow.runtime` | `WorkflowContext` type, `workflow` tag, tag label `workflow.context` |
+| `SuspenseSignal` | `SuspendSignal` |
+| `sandbox.ExecEvent` | `sandbox.CommandOutputEvent` |
+| `judge(options)` | pass the `Judge` object directly |
+| `formatStepKey(key)` | `formatSuspenseStepKey` from `@pumped-fn/lite-extension-suspense` |
+| `parseModelResponse` returning prose on malformed output | throws `ModelResponseParseError` |
+| `CliResult.exitCode: number \| null` | `CliResult.exitCode: 0`; failures carry `CliFailureResult` on `CliWorkerError.result` |
+| `work.branchId` required | optional; resolves from the record's current branch at admission |
+
 ## Migration to 3.0.0
 
 3.0.0 removes the `Agent` facade and the material `session()` object. Every capability is now a

--- a/pkg/sdk/core/README.md
+++ b/pkg/sdk/core/README.md
@@ -142,6 +142,22 @@ A step `timeoutMs` rejects at the deadline and aborts the `abortSignal` tag. Ste
 | `session.store.*`, `session.memory.*`, `session.scheduler.*` | Effect implementors |
 | `session.observation.*` | Safe execution projection for extensions |
 
+### Work admission
+
+`session.run` requires a stable work identity, role, and failure policy. Branch has an unconditional default:
+
+```ts
+const work: session.AdmitWorkInput = {
+  id: "review-42",
+  role: "reviewer",
+  policy: "all",
+}
+```
+
+At admission, an omitted `branchId` resolves to `session.record.currentBranchId`. The resulting `WorkRecord` stores the effective branch and explicit policy. A ready work item may resume with the same omitted branch, but a later explicit branch that resolves differently fails the resume contract.
+
+`id` stays required because it is the deduplication and resume key. `role` stays required because admission has no unconditional, recorded source from which to choose one. `policy` stays required because it controls failure handling. Defaulting it to `"all"` would be fail-open: an orchestrator carrying `work.policy` into `session.join` would leave sibling work running after a child fails.
+
 Executing the entry flow recursively activates its complete declared dependency tree before its factory starts. Required tags are checked at runtime during activation. Missing role config, validation, provider, session, tool backend, or store bindings fail at that boundary. Static missing-tag analysis is not part of this release.
 
 The full-tree activation is also the test model. A test supplies tags or presets at `createScope`, executes the public entry flow, and gets the same tree with selected edges replaced. It does not mock every descendant.

--- a/pkg/sdk/core/README.md
+++ b/pkg/sdk/core/README.md
@@ -16,41 +16,7 @@ with this table:
 | `send(message)` | `ctx.exec({ flow: session.run, input })` |
 | `new Sandbox(policy)` | `sandbox.read`, `sandbox.write`, `sandbox.exec` flows with `sandbox.impl.*` bindings |
 
-Before, the 2.x facade wired provider, tools, and session state implicitly:
-
-```ts
-const a = agent({ role, model, tools })
-const before = await a.turn({ prompt: "Triage the ticket." })
-```
-
-In 3.0.0, the application declares the complete tree and then executes the entry flow:
-
-```ts
-const scope = createScope({
-  tags: [
-    session.authority(boundAuthority),
-    session.record(loadedRecord),
-    session.clock(clock),
-    session.store.commit(commitSession),
-    validation.engine(validationEngine),
-    agent.config.role({ name: "triage", version: "1", instructions: "Triage the ticket." }),
-    agent.impl.attempt(agent.fromModel),
-    model(myScalarModel),
-    session.execution.turn({ flow: agent.turn }),
-  ],
-})
-const ctx = scope.createContext()
-await ctx.resolve(session.session)
-const after = await ctx.exec({
-  flow: session.run,
-  input: {
-    work: { id: "t-1", branchId: "main", role: "triage", policy: "all" },
-    input: { prompt: "Triage the ticket." },
-  },
-})
-await ctx.close()
-await scope.dispose()
-```
+Before, the 2.x facade wired provider, tools, and session state implicitly. In 3.0.0, the application declares those definitions and bindings in `createScope`. The minimal setup below shows the required validation and session bindings.
 
 No facade auto-collects tools or MCP servers, injects implicit dependencies, or passes `ctx`/`scope`
 into callbacks. Tool selection stays tag-driven and fails closed when a required binding is absent.
@@ -65,6 +31,17 @@ into callbacks. Tool selection stays tag-driven and fails closed when a required
 | `@pumped-fn/sdk/validation` | Configurable Standard Schema validation |
 | `@pumped-fn/sdk/sandbox` | Session-mediated read, write, and command port flows |
 
+The root entry groups these public helpers:
+
+| Export | Use |
+|---|---|
+| `workflowExtension`, `extension` | Add workflow replay and timeout behavior, then SDK remote-step behavior |
+| `step`, `workflowRun`, `workflow`, `abortSignal` | Tag steps and read the active workflow identity or cancellation signal |
+| `model`, `complete` | Bind and execute a scalar model flow |
+| `suite`, `runEval`, `summary` | Define, run, and serialize deterministic agent evaluations |
+| `inspect`, `RunLog` | Reconstruct one stored workflow run from a queryable event log |
+| `runCli`, `CliWorkerError` | Run a CLI adapter and inspect typed failure details |
+
 Import related tags as a namespace:
 
 ```ts
@@ -72,6 +49,72 @@ import * as agent from "@pumped-fn/sdk/agent"
 import * as session from "@pumped-fn/sdk/session"
 import * as validation from "@pumped-fn/sdk/validation"
 import * as sandbox from "@pumped-fn/sdk/sandbox"
+```
+
+## Minimal setup
+
+```ts
+import { createScope } from "@pumped-fn/lite"
+import * as z from "zod"
+import * as session from "@pumped-fn/sdk/session"
+import * as validation from "@pumped-fn/sdk/validation"
+
+const validationEngine = validation.standard<z.ZodType>({
+  id: "zod@4",
+  toJsonSchema: (schema) => z.toJSONSchema(schema),
+})
+
+const authority = session.createAuthority({
+  tenant: "acme",
+  roots: ["/workspace"],
+  permissions: [],
+  tools: [],
+  sandbox: {
+    roots: ["/workspace"],
+    commands: [],
+    write: false,
+    network: false,
+  },
+})
+
+const record: session.SessionRecord = {
+  id: "session-1",
+  version: 0,
+  schemaVersion: 1,
+  status: "open",
+  authorityFingerprint: authority.fingerprint,
+  authorityConstraints: authority,
+  currentBranchId: "main",
+  branches: [{
+    id: "main",
+    version: 0,
+    createdBy: "bootstrap",
+    authorityFingerprint: authority.fingerprint,
+    authority,
+    evidence: [],
+  }],
+  work: [],
+  attempts: [],
+  invocations: [],
+  artifacts: [],
+  memory: [],
+  schedules: [],
+  providerContinuations: {},
+  nextEventSequence: 1,
+}
+
+const scope = createScope({
+  tags: [
+    validation.engine(validationEngine),
+    session.authority(authority),
+    session.record(record),
+    session.clock({ now: () => new Date().toISOString() }),
+  ],
+})
+const ctx = scope.createContext()
+await ctx.resolve(session.session)
+await ctx.close()
+await scope.dispose()
 ```
 
 ## Execution model
@@ -85,6 +128,10 @@ session context -> session.run -> agent.turn
 ```
 
 `session.run`, `agent.turn`, `agent.role`, and `agent.fromModel` are module-level definitions. Composition happens through namespaced tags:
+
+Register `workflowExtension(...)` before `extension(...)` in `createScope({ extensions })`. The SDK extension reads the workflow context set by the workflow extension, so the reverse order fails on the first execution.
+
+A step `timeoutMs` rejects at the deadline and aborts the `abortSignal` tag. Step work must observe that signal to stop; JavaScript work that ignores it cannot be forcibly cancelled.
 
 | Namespace | Meaning |
 |---|---|
@@ -104,12 +151,9 @@ The full-tree activation is also the test model. A test supplies tags or presets
 The tool below can inspect a schema and explain a query. It cannot apply DDL. Both physical backend flows and their readiness fact are required dependencies of the tool flows.
 
 ```ts
-import { createScope, flow, tag, tags, typed, type Lite } from "@pumped-fn/lite"
-import { model } from "@pumped-fn/sdk"
+import { flow, tag, tags, typed, type Lite } from "@pumped-fn/lite"
 import * as z from "zod"
 import * as agent from "@pumped-fn/sdk/agent"
-import * as session from "@pumped-fn/sdk/session"
-import * as validation from "@pumped-fn/sdk/validation"
 
 interface InspectInput {
   readonly schema: string
@@ -155,44 +199,13 @@ const explainQuery = flow({
   factory: (ctx, { explain }) => explain.exec({ input: ctx.input }),
 })
 
-const scope = createScope({
-  tags: [
-    session.authority(boundAuthority),
-    session.record(loadedRecord),
-    session.clock(clock),
-    session.store.commit(commitSession),
-    validation.engine(zodEngine),
-    agent.config.role({
-      name: "database-analyst",
-      version: "1",
-      instructions: "Recommend query changes. Never apply schema changes.",
-    }),
-    agent.impl.tool(inspectSchema),
-    agent.impl.tool(explainQuery),
-    agent.impl.attempt(agent.fromModel),
-    model(databaseModel),
-    session.execution.turn({ flow: agent.turn }),
-    database.ready({ serverVersion: "16" }),
-    database.inspect(inspectDatabase),
-    database.explain(explainDatabaseQuery),
-  ],
-})
-
-const ctx = scope.createContext()
-await ctx.resolve(session.session)
-await ctx.exec({
-  flow: session.run,
-  input: {
-    work: { id: "analysis-1", branchId: "main", role: "database-analyst", policy: "all" },
-    input: { prompt: "Find the slow query and recommend an index." },
-  },
-})
-await ctx.exec({ flow: session.finish })
-await ctx.close()
-await scope.dispose()
+const toolBindings = [
+  agent.impl.tool(inspectSchema),
+  agent.impl.tool(explainQuery),
+]
 ```
 
-Activation reaches `inspectSchema` and `explainQuery`, then their readiness and backend tags, before `session.run` emits `work.started` or `agent.turn` calls the model. Tests prove that an absent readiness binding produces no model or database calls.
+Add `toolBindings` to the session scope from the minimal setup, along with application-owned `database.ready`, `database.inspect`, and `database.explain` bindings. Activation reaches the selected tool and its readiness and backend tags before its factory starts. Tests prove that an absent readiness binding produces no model or database calls.
 
 ## GitHub issue triage
 
@@ -237,37 +250,46 @@ The session resource registers `deactivate()` as cleanup. Cleanup does not commi
 `agent.impl.attempt` selects the provider attempt flow. Its neutral stream contains content deltas, reasoning deltas, and provider status. `agent.fromModel` adapts the scalar root `model` tag without inventing deltas.
 
 ```ts
+import { createScope, flow, typed } from "@pumped-fn/lite"
+import { model, type Model, type ModelRequest } from "@pumped-fn/sdk"
+import * as agent from "@pumped-fn/sdk/agent"
+
+const scalarModel: Model = flow({
+  name: "model.local",
+  parse: typed<ModelRequest>(),
+  factory: () => ({ content: "Done.", stop: true }),
+})
+
 const scope = createScope({
   tags: [
-    model(myScalarModel),
+    model(scalarModel),
     agent.impl.attempt(agent.fromModel),
   ],
 })
+
+await scope.dispose()
 ```
 
 Claude, Codex, and Pi export native attempt bindings for the same tag.
 
 ## Sandboxing
 
-Sandbox policy and implementors are separate:
+Sandbox policy and implementors are separate. This creates the policy binding:
 
 ```ts
-const tags = [
-  sandbox.policy({
-    roots: ["/workspace"],
-    write: false,
-    network: false,
-    commands: ["git"],
-    timeoutMs: 30_000,
-    maxOutputBytes: 1_000_000,
-  }),
-  sandbox.impl.read(readFile),
-  sandbox.impl.write(writeFile),
-  sandbox.impl.run(runCommand),
-]
+import * as sandbox from "@pumped-fn/sdk/sandbox"
+
+const sandboxPolicy = sandbox.policy({
+  roots: ["/workspace"],
+  write: false,
+  network: false,
+  commands: ["git"],
+  timeoutMs: 30_000,
+  maxOutputBytes: 1_000_000,
+})
 ```
 
-The policy must fit the bound session authority. A missing implementation or wider policy fails before the effect.
+Add `sandboxPolicy` and application flows bound through `sandbox.impl.read`, `sandbox.impl.write`, and `sandbox.impl.run` to the session scope. The policy must fit the bound session authority. A missing implementation or wider policy fails before the effect. The SDK aborts `sandbox.exec` after `timeoutMs` and truncates its streamed and returned UTF-8 output to `maxOutputBytes`. The `sandbox.impl.run` binding must observe its execution signal to stop timed-out work and must enforce the `network` setting in its process or runtime isolation.
 
 ## Deliberate absences
 

--- a/pkg/sdk/core/src/index.ts
+++ b/pkg/sdk/core/src/index.ts
@@ -1,7 +1,6 @@
 import { flow, tag, tags, typed, type Lite } from "@pumped-fn/lite"
 import {
   extension as suspenseExtension,
-  formatSuspenseStepKey,
   stepCounter,
   type SuspenseEventLog,
   type SuspenseExecEvent,
@@ -14,7 +13,7 @@ import { model } from "./model.js"
 
 export { model }
 
-export type WorkerKind = "code" | "llm" | "cli" | string
+export type WorkerKind = "code" | "llm" | "cli" | (string & {})
 
 export type StepCounter = SuspenseStepCounter
 export type WorkflowStepKey = SuspenseStepKey
@@ -29,7 +28,7 @@ export interface ExecEvent {
   readonly targetName: string
   readonly input: unknown
 }
-/** Configures workflow, remote, durability, worker kind, and timeout behavior for a step. */
+/** Configures workflow, remote, durability, worker kind, and cooperative timeout behavior for a step. */
 export interface Step {
   workflow?: boolean
   remote?: boolean
@@ -38,7 +37,7 @@ export interface Step {
   timeoutMs?: number
 }
 
-export { SuspendSignal, SuspenseSignal } from "@pumped-fn/lite-extension-suspense"
+export { SuspendSignal } from "@pumped-fn/lite-extension-suspense"
 
 /** Delegates a traced execution while preserving the local continuation. */
 export interface RemoteRunner {
@@ -59,10 +58,6 @@ export interface ExtensionOptions {
 
 export const step = tag<Step>({ label: "agent.step", default: {} })
 
-export function formatStepKey(key: WorkflowStepKey): string {
-  return formatSuspenseStepKey(key)
-}
-
 /** Identifies the task and run attached to an execution scope. */
 export interface WorkflowRunOptions {
   taskId: string
@@ -75,15 +70,8 @@ export interface WorkflowContext {
   readonly runId: string
 }
 
-/** Exposes the task and run identity resolved for agent execution. */
-export interface Runtime {
-  readonly taskId: string
-  readonly runId: string
-}
-
 export const workflowRun = tag<WorkflowRunOptions>({ label: "workflow.run" })
-export const workflow = tag<WorkflowContext>({ label: "workflow.runtime" })
-export const runtime = tag<Runtime>({ label: "agent.runtime" })
+export const workflow = tag<WorkflowContext>({ label: "workflow.context" })
 export const abortSignal = tag<AbortSignal>({ label: "workflow.abortSignal" })
 
 const activeWorkflowEvent = tag<WorkflowExecEvent>({ label: "workflow.event" })
@@ -100,8 +88,8 @@ export function workflowExtension(options: WorkflowExtensionOptions): Lite.Exten
     ...base,
     async wrapExec(next, target, ctx) {
       const wrapExec = base.wrapExec
-      if (!wrapExec) return withRuntimeTag(ctx, workflow, workflowRuntimeOf(ctx, options), next)
-      return withRuntimeTag(ctx, workflow, workflowRuntimeOf(ctx, options), () => wrapExec(next, target, ctx))
+      if (!wrapExec) return withTag(ctx, workflow, workflowContextOf(ctx, options), next)
+      return withTag(ctx, workflow, workflowContextOf(ctx, options), () => wrapExec(next, target, ctx))
     },
   }
 }
@@ -110,11 +98,10 @@ export function extension(options: ExtensionOptions = {}): Lite.Extension {
   return {
     name: "sdk",
     async wrapExec(next, target, ctx) {
-      return withRuntimeTag(ctx, runtime, runtimeOf(ctx), async () => {
-        if (stepOf(target, ctx).remote !== true) return next()
-        if (!options.remoteRunner) throw new Error("Remote step requires remoteRunner")
-        return options.remoteRunner.run(execEvent(target, ctx), next)
-      })
+      if (!ctx.data.seekTag(workflow)) throw new Error("sdk extension requires workflow extension to run first")
+      if (stepOf(target, ctx).remote !== true) return next()
+      if (!options.remoteRunner) throw new Error("Remote step requires remoteRunner")
+      return options.remoteRunner.run(execEvent(target, ctx), next)
     },
   }
 }
@@ -179,7 +166,7 @@ function nextWorkflowKey(
   return { taskId: foundTaskId, runId: foundRunId, step: counter.next++ }
 }
 
-function workflowRuntimeOf(
+function workflowContextOf(
   ctx: Lite.ExecutionContext,
   options: Pick<WorkflowExtensionOptions, "defaultTaskId" | "defaultRunId">
 ): WorkflowContext {
@@ -190,27 +177,18 @@ function workflowRuntimeOf(
   }
 }
 
-function runtimeOf(ctx: Lite.ExecutionContext): Runtime {
-  const config = ctx.data.seekTag(workflow)
-  if (!config) throw new Error("agent extension requires workflow extension")
-  return {
-    taskId: config.taskId,
-    runId: config.runId,
-  }
-}
-
-function withRuntimeTag<T, R>(
+function withTag<T, R>(
   ctx: Lite.ExecutionContext,
-  runtimeTag: Lite.Tag<T, boolean>,
+  targetTag: Lite.Tag<T, boolean>,
   value: T,
   next: () => Promise<R>
 ): Promise<R> {
-  const hadPrevious = ctx.data.hasTag(runtimeTag)
-  const previous = ctx.data.getTag(runtimeTag)
-  ctx.data.setTag(runtimeTag, value)
+  const hadPrevious = ctx.data.hasTag(targetTag)
+  const previous = ctx.data.getTag(targetTag)
+  ctx.data.setTag(targetTag, value)
   return next().finally(() => {
-    if (hadPrevious) ctx.data.setTag(runtimeTag, previous as T)
-    else ctx.data.deleteTag(runtimeTag)
+    if (hadPrevious) ctx.data.setTag(targetTag, previous as T)
+    else ctx.data.deleteTag(targetTag)
   })
 }
 
@@ -240,7 +218,7 @@ function runTimer(target: Lite.ExecTarget, ctx: Lite.ExecutionContext, next: () 
   if (timeoutMs === undefined) return next()
   const controller = new AbortController()
   let timer: ReturnType<typeof setTimeout> | undefined
-  return withRuntimeTag(ctx, abortSignal, controller.signal, () =>
+  return withTag(ctx, abortSignal, controller.signal, () =>
     Promise.race([
       next(),
       new Promise<never>((_, reject) => {
@@ -280,18 +258,27 @@ export interface CliIsolateOptions {
   env?: Record<string, string | undefined>
 }
 
-/** Captures a CLI worker's output, exit code, and terminating signal. */
+/** Captures a successful CLI worker run. Failures throw CliWorkerError with details in error.result. */
 export interface CliResult {
+  stdout: string
+  stderr: string
+  exitCode: 0
+  signal: null
+}
+
+/** Captures output and process status for a failed CLI worker run. */
+export interface CliFailureResult {
   stdout: string
   stderr: string
   exitCode: number | null
   signal: string | null
 }
 
+/** Reports a CLI worker failure and exposes its process details through result. */
 export class CliWorkerError extends Error {
   override readonly name = "CliWorkerError"
 
-  constructor(message: string, readonly result: CliResult) {
+  constructor(message: string, readonly result: CliFailureResult) {
     super(message)
   }
 }
@@ -311,36 +298,35 @@ export interface RunCliOptions {
 export async function runCli(options: RunCliOptions): Promise<CliResult> {
   const { execFile } = await import("node:child_process")
   const prepared = await prepareCli(options)
-  return new Promise((resolve, reject) => {
+  return new Promise<CliResult>((resolve, reject) => {
     const child = execFile(prepared.command, [...prepared.args], {
       cwd: prepared.cwd,
       env: prepared.env,
       timeout: options.timeoutMs,
       signal: options.signal,
-    }, async (error, stdout, stderr) => {
-      await prepared.cleanup()
+    }, (error, stdout, stderr) => {
       const execError = error as ExecFileError | null
-      const exitCode = typeof execError?.code === "number" ? execError.code : error ? null : 0
-      const signal = execError?.signal ?? null
-      const result = { stdout: String(stdout), stderr: String(stderr), exitCode, signal }
-      if (execError?.killed && options.timeoutMs !== undefined) {
+      if (!execError) {
+        resolve({ stdout: String(stdout), stderr: String(stderr), exitCode: 0, signal: null })
+        return
+      }
+      const exitCode = typeof execError.code === "number" ? execError.code : null
+      const signal = execError.signal ?? null
+      const result: CliFailureResult = { stdout: String(stdout), stderr: String(stderr), exitCode, signal }
+      if (execError.killed && options.timeoutMs !== undefined) {
         reject(new CliWorkerError(`CLI command timed out after ${options.timeoutMs}ms`, result))
         return
       }
-      if (execError?.name === "AbortError") {
+      if (execError.name === "AbortError") {
         reject(new CliWorkerError("CLI command aborted", result))
         return
       }
-      if (error) {
-        const label = exitCode === null ? error.message : `CLI command failed with exit code ${exitCode}`
-        reject(new CliWorkerError(label, result))
-        return
-      }
-      resolve(result)
+      const label = exitCode === null ? execError.message : `CLI command failed with exit code ${exitCode}`
+      reject(new CliWorkerError(label, result))
     })
 
     child.stdin?.end(options.stdin)
-  })
+  }).finally(() => prepared.cleanup())
 }
 
 interface PreparedCli {
@@ -530,9 +516,9 @@ export function formatModelPrompt(request: ModelRequest): string {
 
 export function parseModelResponse(output: string): ModelResponse {
   const value = readJson(output)
-  if (!isRecord(value)) return { content: output, stop: true }
+  if (!isModelResponseRecord(value)) throw new ModelResponseParseError(output)
   const response: ModelResponse = {
-    content: typeof value["content"] === "string" ? value["content"] : output,
+    content: value.content,
     stop: typeof value["stop"] === "boolean" ? value["stop"] : true,
   }
   const guard = guardTextOf(value["guard"] ?? value["antiGoal"])
@@ -546,25 +532,62 @@ export function parseModelResponse(output: string): ModelResponse {
   return response
 }
 
+/** Reports model output that does not contain a valid JSON response object. */
+export class ModelResponseParseError extends Error {
+  override readonly name = "ModelResponseParseError"
+
+  constructor(readonly output: string) {
+    super("Model response must contain a valid JSON object")
+  }
+}
+
 function readJson(output: string): unknown {
   const trimmed = output.trim()
   if (!trimmed) return undefined
-  try {
-    return JSON.parse(trimmed) as unknown
-  } catch {
-    const start = trimmed.indexOf("{")
-    const end = trimmed.lastIndexOf("}")
-    if (start === -1 || end <= start) return undefined
-    try {
-      return JSON.parse(trimmed.slice(start, end + 1)) as unknown
-    } catch {
-      return undefined
-    }
+  const direct = parseJson(trimmed)
+  if (isModelResponseRecord(direct)) return direct
+  for (let start = trimmed.indexOf("{"); start !== -1; start = trimmed.indexOf("{", start + 1)) {
+    const end = jsonObjectEnd(trimmed, start)
+    if (end === undefined) continue
+    const value = parseJson(trimmed.slice(start, end))
+    if (isModelResponseRecord(value)) return value
   }
+  return undefined
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+function jsonObjectEnd(value: string, start: number): number | undefined {
+  let depth = 0
+  let quoted = false
+  let escaped = false
+  for (let index = start; index < value.length; index++) {
+    const character = value[index]!
+    if (quoted) {
+      if (escaped) escaped = false
+      else if (character === "\\") escaped = true
+      else if (character === '"') quoted = false
+      continue
+    }
+    if (character === '"') quoted = true
+    else if (character === "{") depth++
+    else if (character === "}" && --depth === 0) return index + 1
+  }
+  return undefined
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isModelResponseRecord(value: unknown): value is Record<string, unknown> & { content: string } {
+  return isRecord(value) && typeof value["content"] === "string"
 }
 
 function skillCallsOf(value: unknown): SkillCall[] | undefined {
@@ -817,10 +840,6 @@ export interface RunRecord {
 /** Provides workflow event storage with task and run filtering. */
 export interface RunLog extends WorkflowEventLog {
   entries(query?: Partial<RunQuery>): MaybePromise<readonly WorkflowStepEntry[]>
-}
-
-export function judge(options: Judge): Judge {
-  return options
 }
 
 export function suite(options: SuiteOptions): Suite {

--- a/pkg/sdk/core/src/sandbox.ts
+++ b/pkg/sdk/core/src/sandbox.ts
@@ -3,10 +3,11 @@ import { posix } from "node:path"
 import { flow, tag, tags, typed, type Lite } from "@pumped-fn/lite"
 import * as session from "./session.js"
 
-/** Defines the roots, effects, commands, and resource limits enforced by a sandbox. */
+/** Defines sandbox limits enforced by the SDK. The run binding must enforce physical network access. */
 export interface Policy {
   readonly roots: readonly string[]
   readonly write: boolean
+  /** Declares network access; the sandbox.impl.run binding must enforce this setting. */
   readonly network: boolean
   readonly commands: readonly string[]
   readonly timeoutMs: number
@@ -37,13 +38,13 @@ export interface ExecResult {
   readonly exitCode: number
 }
 
-export type ExecEvent =
+export type CommandOutputEvent =
   | { readonly type: "stdout"; readonly content: string }
   | { readonly type: "stderr"; readonly content: string }
 
 export type Read = Lite.Flow<string, ReadInput>
 export type Write = Lite.Flow<void, WriteInput>
-export type Run = Lite.Flow<ExecResult, ExecInput, never, ExecEvent>
+export type Run = Lite.Flow<ExecResult, ExecInput, never, CommandOutputEvent>
 
 export class PolicyError extends Error {
   constructor(readonly reason: string) {
@@ -102,16 +103,49 @@ export const exec: Run = flow({
     policy: tags.required(policy),
     run: tags.required(impl.run),
   },
-  factory: async function* (ctx, { authority, runtime, policy: value, run }): AsyncGenerator<ExecEvent, ExecResult, unknown> {
+  factory: async function* (ctx, { authority, runtime, policy: value, run }): AsyncGenerator<CommandOutputEvent, ExecResult, unknown> {
     assertPolicy(authority ?? runtime.authority, value)
     if (!value.commands.includes(ctx.input.command)) {
       throw new PolicyError(`command ${JSON.stringify(ctx.input.command)} is not allowed`)
     }
-    const stream = run.execStream({ input: ctx.input })
-    for await (const event of stream) yield event
-    return stream.result
+    const controller = new AbortController()
+    const timer = setTimeout(() => {
+      controller.abort(new Error(`Sandbox command timed out after ${value.timeoutMs}ms`))
+    }, value.timeoutMs)
+    const budget = { remaining: value.maxOutputBytes }
+    try {
+      const stream = run.execStream({ input: ctx.input, signal: controller.signal })
+      for await (const event of stream) {
+        const content = truncateUtf8(event.content, budget)
+        if (content) yield { ...event, content }
+      }
+      controller.signal.throwIfAborted()
+      return truncateExecResult(await stream.result, value.maxOutputBytes)
+    } finally {
+      clearTimeout(timer)
+    }
   },
 })
+
+function truncateExecResult(result: ExecResult, maxOutputBytes: number): ExecResult {
+  const budget = { remaining: maxOutputBytes }
+  return {
+    stdout: truncateUtf8(result.stdout, budget),
+    stderr: truncateUtf8(result.stderr, budget),
+    exitCode: result.exitCode,
+  }
+}
+
+function truncateUtf8(content: string, budget: { remaining: number }): string {
+  const encoded = new TextEncoder().encode(content)
+  if (encoded.byteLength <= budget.remaining) {
+    budget.remaining -= encoded.byteLength
+    return content
+  }
+  const selected = encoded.subarray(0, budget.remaining)
+  budget.remaining = 0
+  return new TextDecoder().decode(selected, { stream: true })
+}
 
 function assertPolicy(authority: session.Authority, value: Policy): void {
   if (!Number.isFinite(value.timeoutMs) || value.timeoutMs <= 0) {

--- a/pkg/sdk/core/src/session.ts
+++ b/pkg/sdk/core/src/session.ts
@@ -194,7 +194,8 @@ export interface AttemptSettlement {
 export interface AdmitWorkInput {
   readonly id: WorkId
   readonly parentId?: WorkId
-  readonly branchId: BranchId
+  /** Defaults to the session record's current branch. */
+  readonly branchId?: BranchId
   readonly role: string
   readonly policy: "all" | "fail-fast"
   readonly authority?: AuthorityConstraints
@@ -1436,17 +1437,24 @@ class Runtime implements SessionRuntime {
   private admit(input: AdmitWorkInput): ActiveAttempt {
     this.assertActive()
     if (this.#status !== "open") throw new Error(`Session ${this.#record.id} does not admit work while ${this.#status}`)
+    const branchId = input.branchId ?? this.#record.currentBranchId
     const existing = this.#record.work.find((item) => item.id === input.id)
     if (existing) {
       if (existing.status !== "ready") throw new Error(`Work ${input.id} already exists`)
-      return this.resume(existing, input)
+      return this.resume(existing, input, branchId)
     }
-    const branch = this.branch(input.branchId)
+    const branch = this.branch(branchId)
     const parent = input.parentId === undefined ? undefined : this.workRecord(input.parentId)
     if (parent && parent.branchId !== branch.id) throw new Error(`Work ${parent.id} is not on branch ${branch.id}`)
     const authority = narrowAuthority(parent?.authority ?? branch.authority, input.authority ?? {})
 
-    const work = Object.freeze({ ...input, status: "working" as const, attempt: 1, authority })
+    const work: WorkRecord = Object.freeze({
+      ...input,
+      branchId,
+      status: "working",
+      attempt: 1,
+      authority,
+    })
     const attempt = Object.freeze({
       workId: work.id,
       attempt: work.attempt,
@@ -1479,9 +1487,9 @@ class Runtime implements SessionRuntime {
     return value
   }
 
-  private resume(existing: WorkRecord, input: AdmitWorkInput): ActiveAttempt {
+  private resume(existing: WorkRecord, input: AdmitWorkInput, branchId: BranchId): ActiveAttempt {
     if (
-      existing.branchId !== input.branchId
+      existing.branchId !== branchId
       || existing.role !== input.role
       || existing.policy !== input.policy
       || existing.parentId !== input.parentId

--- a/pkg/sdk/core/tests/index.test.ts
+++ b/pkg/sdk/core/tests/index.test.ts
@@ -1,6 +1,21 @@
+import { createScope, flow, tags } from "@pumped-fn/lite"
 import { describe, expect, it } from "vitest"
 import * as agent from "../src/agent"
-import { formatModelPrompt, model } from "../src/index"
+import {
+  CliWorkerError,
+  ModelResponseParseError,
+  abortSignal,
+  extension,
+  formatModelPrompt,
+  model,
+  parseModelResponse,
+  runCli,
+  step,
+  workflow,
+  workflowExtension,
+  workflowRun,
+  type WorkflowEventLog,
+} from "../src/index"
 
 describe("sdk public surface", () => {
   it("shares the model tag with the agent subpath", () => {
@@ -26,5 +41,94 @@ describe("sdk public surface", () => {
     expect(prompt).toContain(
       'Input schema: {"properties":{"z":{"type":"string"},"é":{"type":"number"}},"type":"object"}',
     )
+  })
+
+  it("reports malformed model responses instead of stopping silently", () => {
+    expect(() => parseModelResponse("model returned plain text")).toThrowError(ModelResponseParseError)
+    expect(() => parseModelResponse('{"content":broken,"toolCalls":[{"name":"inspect"}]}')).toThrowError(
+      ModelResponseParseError,
+    )
+  })
+
+  it("finds a valid response object without joining unrelated braces", () => {
+    expect(parseModelResponse('prefix {not json} middle {"content":"done {now}","stop":false} suffix')).toEqual({
+      content: "done {now}",
+      stop: false,
+    })
+  })
+
+  it("returns only successful CLI results and carries failures on CliWorkerError", async () => {
+    await expect(runCli({
+      command: process.execPath,
+      args: ["-e", "process.stdout.write('ready')"],
+    })).resolves.toEqual({ stdout: "ready", stderr: "", exitCode: 0, signal: null })
+
+    const failed = runCli({ command: process.execPath, args: ["-e", "process.exit(7)"] })
+    await expect(failed).rejects.toBeInstanceOf(CliWorkerError)
+    await expect(failed).rejects.toMatchObject({ result: { exitCode: 7, signal: null } })
+  })
+
+  it("names the SDK extension when workflow ordering is wrong", async () => {
+    const target = flow({ name: "sdk-order", factory: () => "ready" })
+    const scope = createScope({ extensions: [extension()] })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: target })).rejects.toThrow("sdk extension requires workflow extension to run first")
+    await ctx.close({ ok: false, error: new Error("expected") })
+    await scope.dispose()
+  })
+
+  it("shares one workflow context tag across workflow and SDK extensions", async () => {
+    const log = {
+      get: () => Promise.resolve(undefined),
+      putPending: () => Promise.resolve(),
+      putCompleted: () => Promise.resolve(),
+      resolve: () => Promise.resolve(),
+    } satisfies WorkflowEventLog
+    const target = flow({
+      name: "sdk-workflow-context",
+      tags: [step({ remote: true })],
+      deps: { context: tags.required(workflow) },
+      factory: (_ctx, { context }) => `${context.taskId}:${context.runId}`,
+    })
+    const scope = createScope({
+      extensions: [
+        workflowExtension({ log }),
+        extension({ remoteRunner: { run: (_event, next) => next() } }),
+      ],
+    })
+    const ctx = scope.createContext({ tags: [workflowRun({ taskId: "task-1", runId: "run-1" })] })
+
+    await expect(ctx.exec({ flow: target })).resolves.toBe("task-1:run-1")
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("aborts the public signal when a workflow step times out", async () => {
+    const log = {
+      get: () => Promise.resolve(undefined),
+      putPending: () => Promise.resolve(),
+      putCompleted: () => Promise.resolve(),
+      resolve: () => Promise.resolve(),
+    } satisfies WorkflowEventLog
+    let aborted = false
+    const target = flow({
+      name: "sdk-timeout",
+      tags: [step({ workflow: true, timeoutMs: 5 })],
+      deps: { signal: tags.required(abortSignal) },
+      factory: (_ctx, { signal }) => new Promise<never>((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          aborted = true
+          reject(signal.reason)
+        }, { once: true })
+      }),
+    })
+    const scope = createScope({ extensions: [workflowExtension({ log })] })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({ flow: target })).rejects.toThrow("Workflow step timed out after 5ms")
+    expect(aborted).toBe(true)
+    await ctx.close({ ok: false, error: new Error("expected") })
+    await scope.dispose()
   })
 })

--- a/pkg/sdk/core/tests/session-kernel.test.ts
+++ b/pkg/sdk/core/tests/session-kernel.test.ts
@@ -338,6 +338,181 @@ describe("session runtime", () => {
     await scope.dispose()
   })
 
+  it("stores the session.run branch default explicitly and still deduplicates by work id", async () => {
+    const bound = authorityValue()
+    const turn = flow({ name: "test.defaulted-work", factory: () => "done" })
+    const scope = createScope({ tags: [
+      authority(bound),
+      record(initial(bound)),
+      clock(fixedClock),
+      execution.turn({ flow: turn }),
+    ] })
+    const ctx = scope.createContext()
+    const runtime = await ctx.resolve(session)
+
+    await expect(ctx.exec({
+      flow: run,
+      input: {
+        work: { id: "defaulted", role: "test", policy: "all" },
+        input: undefined,
+      },
+    })).resolves.toBe("done")
+    expect(runtime.record.work).toMatchObject([{
+      id: "defaulted",
+      branchId: "main",
+      role: "test",
+      policy: "all",
+      status: "completed",
+    }])
+    await expect(ctx.exec({
+      flow: run,
+      input: {
+        work: { id: "defaulted", role: "test", policy: "all" },
+        input: undefined,
+      },
+    })).rejects.toThrow("Work defaulted already exists")
+    expect(runtime.record.work).toHaveLength(1)
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("compares the resolved branch default when ready work resumes", async () => {
+    const bound = authorityValue()
+    const inspect = flow({
+      name: "test.defaulted-resume",
+      deps: {
+        work: tags.required(current.work),
+        attempt: tags.required(current.attempt),
+      },
+      factory: (_ctx, { work, attempt }) => `${work.branchId}:${work.policy}:${attempt.attempt}`,
+    })
+    const scope = createScope({ tags: [
+      authority(bound),
+      record(initial(bound)),
+      clock(fixedClock),
+      execution.turn({ flow: inspect }),
+    ] })
+    const ctx = scope.createContext()
+    const runtime = await ctx.resolve(session)
+    const creator = runtime.work.admit({ id: "creator", role: "test", policy: "all" })
+    runtime.work.settle("creator", creator.record.attempt, { status: "completed" })
+    const child = runtime.branches.fork({
+      id: "child",
+      parentId: "main",
+      workId: "creator",
+      authority: {},
+    })
+    runtime.park({
+      work: { id: "resumable", role: "test", policy: "all" },
+      intent: {
+        id: "resume-defaults",
+        dueAt: "2026-07-15T00:00:00.000Z",
+        priority: 1,
+        expectedSessionVersion: 0,
+      },
+    })
+    runtime.wake("resume-defaults", runtime.previewWake("resume-defaults"))
+
+    await expect(ctx.exec({
+      flow: run,
+      input: {
+        work: { id: "resumable", branchId: child.id, role: "test", policy: "all" },
+        input: undefined,
+      },
+    })).rejects.toThrow("Work resumable resume contract changed")
+    await expect(ctx.exec({
+      flow: run,
+      input: {
+        work: { id: "resumable", role: "test", policy: "fail-fast" },
+        input: undefined,
+      },
+    })).rejects.toThrow("Work resumable resume contract changed")
+    expect(runtime.record.work.find((work) => work.id === "resumable")).toMatchObject({
+      branchId: "main",
+      policy: "all",
+      status: "ready",
+      attempt: 2,
+    })
+    await expect(ctx.exec({
+      flow: run,
+      input: {
+        work: { id: "resumable", role: "test", policy: "all" },
+        input: undefined,
+      },
+    })).resolves.toBe("main:all:2")
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("derives an omitted branch from the recorded current branch", async () => {
+    const bound = authorityValue()
+    const setupScope = createScope({ tags: [authority(bound), record(initial(bound)), clock(fixedClock)] })
+    const setup = setupScope.createContext()
+    const setupRuntime = await setup.resolve(session)
+    const creator = setupRuntime.work.admit({ id: "creator", role: "test", policy: "all" })
+    setupRuntime.work.settle("creator", creator.record.attempt, { status: "completed" })
+    const child = setupRuntime.branches.fork({
+      id: "current-child",
+      parentId: "main",
+      workId: "creator",
+      authority: {},
+    })
+    const loaded = Object.freeze({ ...setupRuntime.record, currentBranchId: child.id })
+    await setup.close()
+    await setupScope.dispose()
+
+    const turn = flow({ name: "test.current-branch-default", factory: () => "done" })
+    const scope = createScope({ tags: [
+      authority(bound),
+      record(loaded),
+      clock(fixedClock),
+      execution.turn({ flow: turn }),
+    ] })
+    const ctx = scope.createContext()
+    const runtime = await ctx.resolve(session)
+
+    await expect(ctx.exec({
+      flow: run,
+      input: {
+        work: { id: "child-work", role: "test", policy: "all" },
+        input: undefined,
+      },
+    })).resolves.toBe("done")
+    expect(runtime.record.work.find((work) => work.id === "child-work")).toMatchObject({
+      branchId: "current-child",
+      policy: "all",
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("joins multiple work items admitted with the branch default", async () => {
+    const bound = authorityValue()
+    const scope = createScope({ tags: [authority(bound), record(initial(bound)), clock(fixedClock)] })
+    const ctx = scope.createContext()
+    const runtime = await ctx.resolve(session)
+    const first = runtime.work.admit({ id: "first-defaulted", role: "test", policy: "all" })
+    const second = runtime.work.admit({ id: "second-defaulted", role: "test", policy: "all" })
+    const joined = ctx.exec({
+      flow: join,
+      input: { workIds: [first.record.workId, second.record.workId], policy: "all" },
+    })
+
+    runtime.work.settle(second.record.workId, second.record.attempt, { status: "completed" })
+    runtime.work.settle(first.record.workId, first.record.attempt, { status: "completed" })
+    await expect(joined).resolves.toEqual([{ status: "completed" }, { status: "completed" }])
+    expect(runtime.record.work.filter((work) => work.id.endsWith("-defaulted"))).toMatchObject([
+      { branchId: "main", policy: "all" },
+      { branchId: "main", policy: "all" },
+    ])
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
   it("requires a turn binding when the run graph activates", async () => {
     const bound = authorityValue()
     const scope = createScope({ tags: [authority(bound), record(initial(bound)), clock(fixedClock)] })

--- a/pkg/sdk/core/tests/session-review-regressions.test.ts
+++ b/pkg/sdk/core/tests/session-review-regressions.test.ts
@@ -287,6 +287,95 @@ describe("session review regressions", () => {
     }
   })
 
+  it("truncates sandbox command events and results to the UTF-8 output limit", async () => {
+    const bound = createAuthority({
+      tenant: "tenant-a",
+      roots: ["/workspace"],
+      permissions: [],
+      tools: [],
+      sandbox: { roots: ["/workspace"], commands: ["echo"], write: false, network: false },
+    })
+    const execute = flow({
+      name: "review.sandbox.exec-output",
+      parse: typed<sandbox.ExecInput>(),
+      factory: async function* (): AsyncGenerator<sandbox.CommandOutputEvent, sandbox.ExecResult, unknown> {
+        yield { type: "stdout", content: "éé" }
+        yield { type: "stderr", content: "abc" }
+        return { stdout: "éé", stderr: "abc", exitCode: 0 }
+      },
+    })
+    const scope = createScope({ tags: [
+      authority(bound),
+      record(initial(bound)),
+      clock(fixedClock),
+      sandbox.policy({
+        roots: ["/workspace"],
+        write: false,
+        network: false,
+        commands: ["echo"],
+        timeoutMs: 1_000,
+        maxOutputBytes: 5,
+      }),
+      sandbox.impl.run(execute),
+    ] })
+    const ctx = scope.createContext()
+    const stream = ctx.execStream({ flow: sandbox.exec, input: { command: "echo" } })
+    const events: sandbox.CommandOutputEvent[] = []
+
+    for await (const event of stream) events.push(event)
+    await expect(stream.result).resolves.toEqual({ stdout: "éé", stderr: "a", exitCode: 0 })
+    expect(events).toEqual([
+      { type: "stdout", content: "éé" },
+      { type: "stderr", content: "a" },
+    ])
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("aborts sandbox command bindings at the policy timeout", async () => {
+    const bound = createAuthority({
+      tenant: "tenant-a",
+      roots: ["/workspace"],
+      permissions: [],
+      tools: [],
+      sandbox: { roots: ["/workspace"], commands: ["wait"], write: false, network: false },
+    })
+    const execute = flow({
+      name: "review.sandbox.exec-timeout",
+      parse: typed<sandbox.ExecInput>(),
+      factory: async function* (ctx): AsyncGenerator<sandbox.CommandOutputEvent, sandbox.ExecResult, unknown> {
+        await new Promise<never>((_resolve, reject) => {
+          ctx.signal.addEventListener("abort", () => reject(ctx.signal.reason), { once: true })
+        })
+        return { stdout: "", stderr: "", exitCode: 0 }
+      },
+    })
+    const scope = createScope({ tags: [
+      authority(bound),
+      record(initial(bound)),
+      clock(fixedClock),
+      sandbox.policy({
+        roots: ["/workspace"],
+        write: false,
+        network: false,
+        commands: ["wait"],
+        timeoutMs: 5,
+        maxOutputBytes: 1_024,
+      }),
+      sandbox.impl.run(execute),
+    ] })
+    const ctx = scope.createContext()
+
+    await expect(ctx.exec({
+      flow: sandbox.exec,
+      input: { command: "wait" },
+    })).rejects.toThrow("Sandbox command timed out after 5ms")
+
+    await ctx.close({ ok: false, error: new Error("expected") })
+    await scope.dispose()
+  })
+
   it("rejects invalid merge inputs without changing branch state", async () => {
     const bound = authorityValue()
     const scope = createScope({ tags: [authority(bound), record(initial(bound)), clock(fixedClock)] })

--- a/pkg/sdk/core/tests/workflow-adapters.test.ts
+++ b/pkg/sdk/core/tests/workflow-adapters.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest"
 import {
   delegated,
   includes,
-  judge,
   loaded,
   runEval,
   suite,
@@ -63,8 +62,8 @@ describe("retained eval helpers", () => {
         }],
       }),
     })
-    const approved = judge({ name: "approved", evaluate: () => ({ name: "approved", passed: true, score: 1 }) })
-    const grounded = judge({ name: "grounded", evaluate: () => ({ name: "grounded", passed: true, score: 1 }) })
+    const approved = { name: "approved", evaluate: () => ({ name: "approved", passed: true, score: 1 }) }
+    const grounded = { name: "grounded", evaluate: () => ({ name: "grounded", passed: true, score: 1 }) }
     const target = suite({
       name: "database-eval",
       turn,

--- a/pkg/sdk/mcp/README.md
+++ b/pkg/sdk/mcp/README.md
@@ -38,11 +38,10 @@ const server = await ctx.resolve(mcpServer)
 await server.connect(new StdioServerTransport())
 ```
 
-The MCP SDK validates and coerces arguments against each flow's `inputSchema`, then the handler
-execs the flow with that value as raw input. A flow's own `parse` re-runs on it, so put any
-coercion in `inputSchema` and keep the exposed flow `typed<T>()` (or its `parse` non-transforming) —
-otherwise a `z.string().transform(Number)` would transform twice. A thrown error's message becomes
-the `isError` result text sent to the client, so throw client-safe messages. Cleanup closes the
+The MCP SDK validates arguments against each flow's `inputSchema`, then the handler execs the flow
+with the validated value as raw input. A flow's own `parse` runs after MCP validation, so its input
+must match the schema's output. A thrown error's message becomes the `isError` result text sent to
+the client, so throw client-safe messages. Cleanup closes the
 server and drains in-flight calls; for a clean shutdown, close the client before disposing the
 scope. For tests, connect an `InMemoryTransport.createLinkedPair()` instead of stdio.
 

--- a/pkg/sdk/mcp/src/index.ts
+++ b/pkg/sdk/mcp/src/index.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import { resource, tag, tags, type Lite } from "@pumped-fn/lite"
-import { z, type ZodRawShape, type ZodType } from "zod"
+import type { ZodRawShape } from "zod"
 
 /** Supplies the MCP description and Zod input shape for a tool flow. */
 export interface McpToolMeta {
@@ -41,7 +41,7 @@ export const mcpServer = resource({
         name,
         {
           description: meta.description,
-          inputSchema: validationShape(meta.inputSchema),
+          inputSchema: meta.inputSchema,
         },
         async (args) => {
           if (closing) throw new McpToolError("MCP server is closing")
@@ -64,26 +64,6 @@ export const mcpServer = resource({
     return instance
   },
 })
-
-function validationShape(shape: ZodRawShape): ZodRawShape {
-  return Object.fromEntries(
-    Object.entries(shape).map(([key, schema]) => [
-      key,
-      z.unknown().superRefine(async (value, ctx) => {
-        const result = await (schema as ZodType).safeParseAsync(value)
-        if (!result.success) {
-          for (const issue of result.error.issues) {
-            ctx.addIssue({
-              code: "custom",
-              message: issue.message,
-              path: [...issue.path],
-            })
-          }
-        }
-      }),
-    ])
-  )
-}
 
 function toolResult(output: unknown): CallToolResult {
   return { content: [{ type: "text", text: encode(output) }] }

--- a/pkg/sdk/mcp/tests/mcp.test.ts
+++ b/pkg/sdk/mcp/tests/mcp.test.ts
@@ -12,7 +12,7 @@ class ProbeError extends Error {
 
 const rate = atom({ factory: () => 1 })
 
-const amount = { amount: z.number() }
+const amount = { amount: z.number().describe("Amount to convert") }
 
 const convert = flow({
   name: "convert",
@@ -40,7 +40,7 @@ const boom = flow({
 
 const coerce = flow({
   name: "coerce",
-  parse: (raw) => z.object({ n: z.string().transform(Number) }).parse(raw),
+  parse: typed<{ n: number }>(),
   tags: [mcpToolMeta({ description: "Double a numeric string", inputSchema: { n: z.string().transform(Number) } })],
   factory: (ctx) => ({ doubled: ctx.input.n * 2 }),
 })
@@ -110,6 +110,20 @@ it("exposes multiple flows as MCP tools and runs them inside the resolving scope
 
   const pinged = await client.callTool({ name: "ping", arguments: { x: 3 } })
   expect(pinged.content).toEqual([{ type: "text", text: "pong:3" }])
+
+  await close()
+})
+
+it("advertises tool property types and descriptions", async () => {
+  const { client, close } = await serve([convert])
+  const listed = await client.listTools()
+
+  expect(listed.tools[0]?.inputSchema).toMatchObject({
+    type: "object",
+    properties: {
+      amount: { type: "number", description: "Amount to convert" },
+    },
+  })
 
   await close()
 })

--- a/pkg/sdk/pi/README.md
+++ b/pkg/sdk/pi/README.md
@@ -9,7 +9,11 @@ import { createScope } from "@pumped-fn/lite"
 import * as pi from "@pumped-fn/sdk-pi"
 
 const scope = createScope({
-  tags: pi.piConfig({ provider: "anthropic", modelId: "claude-sonnet-4-5" }),
+  tags: pi.piConfig({
+    auth: { kind: "api-key" },
+    provider: "anthropic",
+    modelId: "claude-sonnet-4-5",
+  }),
 })
 const ctx = scope.createContext()
 await ctx.exec({ flow: pi.piTurn, input: {
@@ -22,14 +26,22 @@ await ctx.close()
 await scope.dispose()
 ```
 
-Set `apiKeyEnv` to resolve an explicit provider key through the environment adapter. Without it,
+Set `auth.env` to resolve an explicit provider key through the environment adapter. Without it,
 pi-ai uses its provider auth chain. `supportedModels` lists the catalog, while `models` is the
 scope-owned collection edge. Native model tool calls become SDK tool, skill, and subagent calls;
 the session runtime owns the resulting model lifecycle event.
 
 `piAttempt` maps pi-ai text, thinking, and lifecycle events to the provider-neutral SDK `ModelEvent`
 stream. Its final result is the same `ModelResponse` returned by `piTurn`; the scalar turn drains the
-attempt. `piAttemptBinding` injects the stream through `agent.impl.attempt`.
+attempt. `piAttemptBinding` injects the stream through `agent.impl.attempt`. There is no generic
+`engine` alias; `models` names the collection seam that tests preset.
+
+## Current prerelease migration
+
+| Before | Now |
+|---|---|
+| `apiKeyEnv: "ANTHROPIC_API_KEY"` | `auth: { kind: "api-key", env: "ANTHROPIC_API_KEY" }` |
+| no `apiKeyEnv` | `auth: { kind: "api-key" }` |
 
 ## Migration to 3.0.0
 

--- a/pkg/sdk/pi/README.md
+++ b/pkg/sdk/pi/README.md
@@ -36,7 +36,7 @@ stream. Its final result is the same `ModelResponse` returned by `piTurn`; the s
 attempt. `piAttemptBinding` injects the stream through `agent.impl.attempt`. There is no generic
 `engine` alias; `models` names the collection seam that tests preset.
 
-## Current prerelease migration
+## Migration to 4.0.0
 
 | Before | Now |
 |---|---|

--- a/pkg/sdk/pi/package.json
+++ b/pkg/sdk/pi/package.json
@@ -29,7 +29,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@pumped-fn/sdk": "^3.0.0",
+    "@pumped-fn/sdk": "^4.0.0",
     "@pumped-fn/lite": "^6.0.0"
   },
   "dependencies": {

--- a/pkg/sdk/pi/src/index.ts
+++ b/pkg/sdk/pi/src/index.ts
@@ -26,12 +26,14 @@ import {
 import * as agent from "@pumped-fn/sdk/agent"
 import * as session from "@pumped-fn/sdk/session"
 
-/** Selects a Pi provider, model, thinking level, and API-key environment variable. */
+export type PiAuth = { kind: "api-key"; env?: string }
+
+/** Selects Pi authentication, provider, model, and thinking level. */
 export interface PiConfig {
+  auth: PiAuth
   provider: string
   modelId: string
   thinking?: "minimal" | "low" | "medium" | "high" | "xhigh"
-  apiKeyEnv?: string
 }
 
 export class PiProviderError extends Error {
@@ -106,7 +108,7 @@ export const piAttempt: agent.Attempt = flow({
       messages: ctx.input.messages.flatMap((message, index) => messagesOf(message, selected, clock(), index)),
       ...(tools.length ? { tools } : {}),
     }
-    const apiKey = config.apiKeyEnv ? requireEnvironment(environment, config.apiKeyEnv, config) : undefined
+    const apiKey = config.auth.env ? requireEnvironment(environment, config.auth.env, config) : undefined
     const controller = new AbortController()
     const abort = () => controller.abort(signal.reason)
     signal.addEventListener("abort", abort, { once: true })
@@ -128,7 +130,7 @@ export const piAttempt: agent.Attempt = flow({
         throw new PiProviderError(response.errorMessage ?? `pi-ai ${response.stopReason}`, config.provider, config.modelId)
       }
       completed = true
-      return responseOf(response, tools)
+      return responseOf(response, tools, config)
     } finally {
       signal.removeEventListener("abort", abort)
       if (!completed) controller.abort(new DOMException("Pi attempt stream closed", "AbortError"))
@@ -365,7 +367,7 @@ function emptyUsage(): AssistantMessage["usage"] {
   }
 }
 
-function responseOf(response: AssistantMessage, tools: Tool[]): ModelResponse {
+function responseOf(response: AssistantMessage, tools: Tool[], config: PiConfig): ModelResponse {
   const calls = response.content.filter((item): item is PiToolCall => item.type === "toolCall")
   for (const call of calls) validateToolCall(tools, call)
   const toolCalls = calls.filter((call) => call.name !== "load_skill" && call.name !== "call_subagent")
@@ -377,11 +379,11 @@ function responseOf(response: AssistantMessage, tools: Tool[]): ModelResponse {
       .map((item) => item.text)
       .join(""),
     ...(toolCalls.length ? { toolCalls: toolCalls.map((call) => ({ name: call.name, input: call.arguments, id: call.id })) } : {}),
-    ...(skillCalls.length ? { skillCalls: skillCalls.map((call) => ({ name: stringArgument(call, "name"), id: call.id })) } : {}),
+    ...(skillCalls.length ? { skillCalls: skillCalls.map((call) => ({ name: stringArgument(call, "name", config), id: call.id })) } : {}),
     ...(subagentCalls.length ? {
       subagentCalls: subagentCalls.map((call) => ({
-        name: stringArgument(call, "name"),
-        input: { prompt: stringArgument(call, "prompt") },
+        name: stringArgument(call, "name", config),
+        input: { prompt: stringArgument(call, "prompt", config) },
         id: call.id,
       })),
     } : {}),
@@ -389,8 +391,8 @@ function responseOf(response: AssistantMessage, tools: Tool[]): ModelResponse {
   }
 }
 
-function stringArgument(call: PiToolCall, name: string): string {
+function stringArgument(call: PiToolCall, name: string, config: PiConfig): string {
   const value: unknown = call.arguments[name]
   if (typeof value === "string") return value
-  throw new PiProviderError(`pi-ai tool "${call.name}" requires string argument "${name}"`, call.name, name)
+  throw new PiProviderError(`pi-ai tool "${call.name}" requires string argument "${name}"`, config.provider, config.modelId)
 }

--- a/pkg/sdk/pi/tests/pi.integration.test.ts
+++ b/pkg/sdk/pi/tests/pi.integration.test.ts
@@ -10,7 +10,7 @@ const integration = it.skipIf(
 
 integration("invokes pi-ai with a configured provider key", async () => {
   const scope = createScope({
-    tags: [piConfig({ provider: "anthropic", modelId: selected!.id, apiKeyEnv: "ANTHROPIC_API_KEY" })],
+    tags: [piConfig({ auth: { kind: "api-key", env: "ANTHROPIC_API_KEY" }, provider: "anthropic", modelId: selected!.id })],
   })
   const ctx = scope.createContext()
 

--- a/pkg/sdk/pi/tests/pi.test.ts
+++ b/pkg/sdk/pi/tests/pi.test.ts
@@ -10,7 +10,7 @@ import { createScope, preset } from "@pumped-fn/lite"
 import { type Model, type ModelRequest } from "@pumped-fn/sdk"
 import * as session from "@pumped-fn/sdk/session"
 import { expect, expectTypeOf, it } from "vitest"
-import { models, piAttempt, piConfig, piTurn, supportedModels } from "../src/index"
+import { models, piAttempt, piConfig, PiProviderError, piTurn, supportedModels } from "../src/index"
 
 const selected: PiModel<Api> = {
   id: "test-model",
@@ -150,7 +150,7 @@ it("requires session provenance before using a bound provider", async () => {
   })
   const scope = createScope({
     presets: [preset(models, collection())],
-    tags: [piConfig({ provider: "test", modelId: "test-model" })],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "test-model" })],
   })
   const ctx = scope.createContext({ tags: [session.current.authority(authority)] })
 
@@ -171,7 +171,7 @@ it("rejects a forged authority body before using a bound provider", async () => 
   const provenance = piProvenance(authority)
   const scope = createScope({
     presets: [preset(models, collection())],
-    tags: [piConfig({ provider: "test", modelId: "test-model" })],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "test-model" })],
   })
   const ctx = scope.createContext({ tags: [
     session.current.authority(forged),
@@ -202,7 +202,7 @@ it("rejects a bound provider when runtime membership is stale", async () => {
   } as session.SessionRuntime
   const scope = createScope({
     presets: [preset(models, collection())],
-    tags: [piConfig({ provider: "test", modelId: "test-model" })],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "test-model" })],
   })
   const ctx = scope.createContext({ tags: [
     session.current.authority(authority),
@@ -221,7 +221,7 @@ it("rejects a bound provider when runtime membership is stale", async () => {
 it("maps native pi-ai tool calls", async () => {
   const scope = createScope({
     presets: [preset(models, collection())],
-    tags: [piConfig({ provider: "test", modelId: "test-model" })],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "test-model" })],
   })
   const ctx = scope.createContext()
 
@@ -253,10 +253,37 @@ it("maps native pi-ai tool calls", async () => {
   await scope.dispose()
 })
 
+it("reports the configured provider and model for malformed built-in tool arguments", async () => {
+  const malformed: AssistantMessage = {
+    ...response,
+    content: [{ type: "toolCall", id: "skill-1", name: "load_skill", arguments: { name: 7 } }],
+  }
+  const scope = createScope({
+    presets: [preset(models, collection(malformed))],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "test-model" })],
+  })
+  const ctx = scope.createContext()
+
+  await expect(ctx.exec({
+    flow: piTurn,
+    input: {
+      ...request(),
+      skills: [{ name: "7", description: "Numeric skill name." }],
+    },
+  })).rejects.toMatchObject({
+    name: "PiProviderError",
+    provider: "test",
+    modelId: "test-model",
+  } satisfies Partial<PiProviderError>)
+
+  await ctx.close({ ok: false, error: new Error("expected") })
+  await scope.dispose()
+})
+
 it("normalizes pi-ai stream events without changing the scalar result", async () => {
   const scope = createScope({
     presets: [preset(models, collection())],
-    tags: [piConfig({ provider: "test", modelId: "test-model" })],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "test-model" })],
   })
   const ctx = scope.createContext()
   const input: ModelRequest = {
@@ -294,7 +321,7 @@ it("publishes resolved capability schemas to pi-ai", async () => {
   }
   const scope = createScope({
     presets: [preset(models, collectionWithSchema)],
-    tags: [piConfig({ provider: "test", modelId: "test-model" })],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "test-model" })],
   })
   const ctx = scope.createContext()
   const inputSchema = {
@@ -334,7 +361,7 @@ it("aborts the pi-ai producer when the consumer stops", async () => {
   }
   const scope = createScope({
     presets: [preset(models, waiting)],
-    tags: [piConfig({ provider: "test", modelId: "test-model" })],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "test-model" })],
   })
   const ctx = scope.createContext()
   const stream = ctx.execStream({ flow: piAttempt, input: {
@@ -369,7 +396,7 @@ it("isolates consumer aborts across pi-ai attempt contexts", async () => {
   }
   const scope = createScope({
     presets: [preset(models, waiting)],
-    tags: [piConfig({ provider: "test", modelId: "test-model" })],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "test-model" })],
   })
   const firstContext = scope.createContext()
   const secondContext = scope.createContext()
@@ -399,7 +426,7 @@ it("isolates consumer aborts across pi-ai attempt contexts", async () => {
 it("lists models and rejects unsupported selections", async () => {
   const scope = createScope({
     presets: [preset(models, collection())],
-    tags: [piConfig({ provider: "test", modelId: "missing" })],
+    tags: [piConfig({ auth: { kind: "api-key" }, provider: "test", modelId: "missing" })],
   })
   const ctx = scope.createContext()
 

--- a/pkg/sdk/test/README.md
+++ b/pkg/sdk/test/README.md
@@ -54,6 +54,16 @@ The existing workflow helpers remain: `kit`, `suspense`, `MemoryWorkflowLog`, `M
 
 The issue-triage example uses the same scope seam for independent tests of `agent.turn`, evidence backends, verification, publication, and queue concurrency.
 
+## Migration to 4.0.0
+
+| Before | Now |
+|---|---|
+| hand-written `SessionRecord` literal | `initialRecord(id, authority, overrides?)` |
+| full `session.createAuthority` object | `testAuthority(overrides?)` with deny-all defaults |
+| eight-field `ModelRequest` literal | `modelRequest(overrides?)` |
+| local `validation.standard({ id: "test", toJsonSchema: () => true })` | `validationStub` |
+| hand-wired session and agent tag list | `sessionKit(options?).tags` |
+
 ## Migration to 3.0.0
 
 3.0.0 tracks the `@pumped-fn/sdk` facade removal. The test helpers no longer own or cache a scope;

--- a/pkg/sdk/test/README.md
+++ b/pkg/sdk/test/README.md
@@ -6,86 +6,49 @@ In-memory test helpers for `@pumped-fn/sdk`. Every helper keeps `createScope` as
 config.model / modelStub ---------> scalar provider seam
 config.attempt / attemptStub -----> streaming provider seam
 sessionStoreStub ----------------> configured load and commit ports
+sessionKit ----------------------> complete agent turn tag bundle
 createScope ----------------------> explicit test-owned session seam
 ```
 
 ```ts
 import * as session from "@pumped-fn/sdk/session"
 import { createScope } from "@pumped-fn/lite"
-import {
-  attemptStubConfig,
-  sessionStoreStub,
-} from "@pumped-fn/sdk-test"
+import { sessionKit } from "@pumped-fn/sdk-test"
 
-const authority = session.createAuthority({
-  tenant: "tenant-a",
-  roots: ["/workspace"],
-  permissions: [],
-  tools: [],
-  sandbox: {
-    roots: ["/workspace"],
-    commands: [],
-    write: false,
-    network: false,
+const bundle = sessionKit({
+  id: "test-session",
+  role: {
+    name: "reviewer",
+    version: "1",
+    instructions: "Review the request.",
+    maxRounds: 1,
+  },
+  respond: {
+    events: [{ type: "content_delta", content: "ready" }],
+    result: { content: "ready", stop: true },
   },
 })
-const record: session.SessionRecord = {
-  id: "test-session",
-  version: 0,
-  schemaVersion: 1,
-  status: "open",
-  authorityFingerprint: authority.fingerprint,
-  authorityConstraints: authority,
-  currentBranchId: "main",
-  branches: [{
-    id: "main",
-    version: 0,
-    createdBy: "bootstrap",
-    authorityFingerprint: authority.fingerprint,
-    authority,
-    evidence: [],
-  }],
-  work: [],
-  attempts: [],
-  invocations: [],
-  artifacts: [],
-  memory: [],
-  schedules: [],
-  providerContinuations: {},
-  nextEventSequence: 1,
-}
-const provider = attemptStubConfig({
-  events: [{ type: "content_delta", content: "ready" }],
-  result: { content: "ready", stop: true },
-})
-const store = sessionStoreStub([record])
-const scope = createScope({
-  tags: [
-    provider,
-    store.config,
-    store.binding.load,
-    store.binding.commit,
-  ],
-})
-const root = scope.createContext()
-const owner = scope.createContext({
-  parent: root,
-  tags: [
-    session.authority(authority),
-    session.record(record),
-    session.clock({ now: () => new Date().toISOString() }),
-  ],
+const scope = createScope({ tags: bundle.tags })
+const owner = scope.createContext()
+await owner.resolve(session.session)
+
+const result = await owner.exec({
+  flow: session.run,
+  input: {
+    work: { id: "review", branchId: "main", role: "reviewer", policy: "all" },
+    input: { prompt: "Check this." },
+  },
 })
 
-await owner.resolve(session.session)
 await owner.close()
-await root.close()
 await scope.dispose()
 ```
 
-Every test creates its own scope and owner context with exactly the extensions, presets, and tags it needs. Resolve `session.session` on that owner before execution so current-owned resources share the intended session lifecycle. Close the owner, root, and scope in that order.
+Every test creates its own scope and owner context with exactly the extensions, presets, and tags it needs. `sessionKit` supplies the authority, record, clock, turn, store, attempt, role, and validation tags. Resolve `session.session` on the owner before execution, then close the owner and scope in that order.
 
-`modelStub` and `attemptStub` are stable module-level flows configured by `config.model` and `config.attempt`. `attemptStubConfig` supplies the attempt response and implementation tags together. `sessionStoreStub` owns an isolated record map and supplies its config plus named load and commit bindings. None of these helpers creates or caches a scope.
+Pass `respond` to configure `attemptStub`, or pass `attempt` to replace it with a custom flow. Every other tag value can also be replaced through the matching option. The returned `record` and `store` make state checks direct. `validationStub` is the default trivial validation engine and can also be used by tests that wire tags themselves.
+
+`initialRecord`, `testAuthority`, and `modelRequest` supply valid defaults with shallow overrides. `testAuthority` denies all sandbox access unless the test grants it. `modelStub` and `attemptStub` are stable module-level flows configured by `config.model` and `config.attempt`. `attemptStubConfig` supplies the attempt response and implementation tags together. `sessionStoreStub` owns an isolated record map and supplies its config plus named load and commit bindings. None of these helpers creates or caches a scope.
 
 The existing workflow helpers remain: `kit`, `suspense`, `MemoryWorkflowLog`, `MemorySuspenseLog`, and `localRemoteRunner`.
 

--- a/pkg/sdk/test/package.json
+++ b/pkg/sdk/test/package.json
@@ -35,7 +35,7 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "@pumped-fn/sdk": "^3.0.0",
+    "@pumped-fn/sdk": "^4.0.0",
     "@pumped-fn/lite": "^6.0.0"
   },
   "dependencies": {

--- a/pkg/sdk/test/src/index.ts
+++ b/pkg/sdk/test/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@pumped-fn/sdk"
 import * as agent from "@pumped-fn/sdk/agent"
 import * as session from "@pumped-fn/sdk/session"
+import * as validation from "@pumped-fn/sdk/validation"
 import {
   extension as suspenseExtension,
   formatSuspenseStepKey,
@@ -24,6 +25,80 @@ import {
 import { flow, tag, tags, typed, type Lite } from "@pumped-fn/lite"
 
 type MaybePromise<T> = T | Promise<T>
+
+export function initialRecord(
+  id: session.SessionId,
+  authority: session.Authority,
+  overrides: Partial<session.SessionRecord> = {},
+): session.SessionRecord {
+  return Object.freeze({
+    id,
+    version: 0,
+    schemaVersion: 1,
+    status: "open",
+    authorityFingerprint: authority.fingerprint,
+    authorityConstraints: authority,
+    currentBranchId: "main",
+    branches: [{
+      id: "main",
+      version: 0,
+      createdBy: "root",
+      authorityFingerprint: authority.fingerprint,
+      authority,
+      evidence: [],
+    }],
+    work: [],
+    attempts: [],
+    invocations: [],
+    artifacts: [],
+    memory: [],
+    schedules: [],
+    providerContinuations: {},
+    nextEventSequence: 1,
+    ...overrides,
+  })
+}
+
+export function testAuthority(
+  overrides: Omit<Partial<session.AuthorityInput>, "sandbox"> & {
+    sandbox?: Partial<session.SandboxAuthority>
+  } = {},
+): session.Authority {
+  const { sandbox, ...authority } = overrides
+  return session.createAuthority({
+    tenant: "test",
+    roots: [],
+    permissions: [],
+    tools: [],
+    ...authority,
+    sandbox: {
+      roots: [],
+      commands: [],
+      write: false,
+      network: false,
+      ...sandbox,
+    },
+  })
+}
+
+export function modelRequest(overrides: Partial<ModelRequest> = {}): ModelRequest {
+  return {
+    agentName: "test",
+    instructions: "",
+    messages: [],
+    tools: [],
+    skills: [],
+    loadedSkills: [],
+    subagents: [],
+    round: 0,
+    ...overrides,
+  }
+}
+
+export const validationStub = validation.standard({
+  id: "test",
+  toJsonSchema: () => true,
+})
 
 export const config = {
   model: tag<(request: ModelRequest) => MaybePromise<ModelResponse>>({ label: "sdk.test.config.model" }),
@@ -119,6 +194,59 @@ export function sessionStoreStub(records: readonly session.SessionRecord[] = [])
       load: session.store.load(sessionStoreLoad),
       commit: session.store.commit(sessionStoreCommit),
     },
+  }
+}
+
+export function sessionKit(
+  options: {
+    id?: session.SessionId
+    authority?: session.Authority
+    record?: session.SessionRecord
+    clock?: session.Clock
+    role?: agent.RoleConfig
+    respond?: Parameters<typeof attemptStubConfig>[0]
+    attempt?: agent.Attempt
+    turn?: Lite.AnyFlow
+    load?: session.Load
+    commit?: session.Commit
+    validation?: validation.Engine
+  } = {},
+): {
+  authority: session.Authority
+  record: session.SessionRecord
+  store: ReturnType<typeof sessionStoreStub>
+  tags: Lite.TagInput[]
+} {
+  const authority = options.authority ?? (
+    options.record === undefined
+      ? testAuthority()
+      : session.createAuthority(options.record.authorityConstraints)
+  )
+  const record = options.record ?? initialRecord(options.id ?? "test-session", authority)
+  const store = sessionStoreStub([record])
+  const request = modelRequest()
+  return {
+    authority,
+    record,
+    store,
+    tags: [
+      session.authority(authority),
+      session.record(record),
+      session.clock(options.clock ?? { now: () => "2000-01-01T00:00:00.000Z" }),
+      session.execution.turn({ flow: options.turn ?? agent.turn }),
+      store.config,
+      session.store.load(options.load ?? store.load),
+      session.store.commit(options.commit ?? store.commit),
+      options.attempt === undefined
+        ? attemptStubConfig(options.respond ?? { events: [], result: { content: "", stop: true } })
+        : agent.impl.attempt(options.attempt),
+      agent.config.role(options.role ?? {
+        name: request.agentName,
+        version: "1",
+        instructions: request.instructions,
+      }),
+      validation.engine(options.validation ?? validationStub),
+    ],
   }
 }
 

--- a/pkg/sdk/test/tests/runtime.test.ts
+++ b/pkg/sdk/test/tests/runtime.test.ts
@@ -45,7 +45,7 @@ describe("agent runtime tags", () => {
     })
     const scope = createScope()
     const ctx = scope.createContext({ tags: [workflowRun({ taskId: "workflow-missing-extension", runId: "run" })] })
-    await expect(ctx.exec({ flow: root })).rejects.toThrow('Tag "workflow.runtime" not found')
+    await expect(ctx.exec({ flow: root })).rejects.toThrow('Tag "workflow.context" not found')
     await ctx.close({ ok: false, error: new Error("expected") })
     await scope.dispose()
   })

--- a/pkg/sdk/test/tests/session.test.ts
+++ b/pkg/sdk/test/tests/session.test.ts
@@ -2,7 +2,15 @@ import { createScope } from "@pumped-fn/lite"
 import * as agent from "@pumped-fn/sdk/agent"
 import * as session from "@pumped-fn/sdk/session"
 import { expect, it } from "vitest"
-import { attemptStubConfig, sessionStoreStub } from "../src/index"
+import {
+  attemptStubConfig,
+  initialRecord,
+  modelRequest,
+  sessionKit,
+  sessionStoreStub,
+  testAuthority,
+  validationStub,
+} from "../src/index"
 
 it("streams attempt events and returns the final model response", async () => {
   const attempt = attemptStubConfig({
@@ -14,7 +22,7 @@ it("streams attempt events and returns the final model response", async () => {
   })
   const scope = createScope({ tags: attempt })
   const ctx = scope.createContext()
-  const stream = ctx.execStream({ flow: agent.invoke, input: request() })
+  const stream = ctx.execStream({ flow: agent.invoke, input: modelRequest() })
   const events: agent.ModelEvent[] = []
 
   for await (const event of stream) events.push(event)
@@ -29,9 +37,10 @@ it("streams attempt events and returns the final model response", async () => {
 })
 
 it("provides isolated session stores through explicit flow bindings", async () => {
-  const record = sessionRecord("session-a")
+  const authority = testAuthority({ tenant: "tenant-a" })
+  const record = initialRecord("session-a", authority)
   const first = sessionStoreStub([record])
-  const second = sessionStoreStub([sessionRecord("session-b")])
+  const second = sessionStoreStub([initialRecord("session-b", authority)])
   const scope = createScope({ tags: [first.config, first.binding.load, first.binding.commit] })
   const ctx = scope.createContext()
 
@@ -52,33 +61,27 @@ it("provides isolated session stores through explicit flow bindings", async () =
 })
 
 it("creates a new test-owned scope and bound session context at each use site", async () => {
-  const authority = session.createAuthority({
+  const authority = testAuthority({
     tenant: "tenant-a",
     roots: ["/workspace"],
-    permissions: [],
-    tools: [],
-    sandbox: { roots: ["/workspace"], commands: [], write: false, network: false },
+    sandbox: { roots: ["/workspace"] },
   })
-  const firstScope = createScope()
+  const firstBundle = sessionKit({
+    id: "session-a",
+    authority,
+    clock: { now: () => "2026-07-14T00:00:00.000Z" },
+  })
+  const firstScope = createScope({ tags: firstBundle.tags })
   const firstRoot = firstScope.createContext()
-  const first = firstScope.createContext({
-    parent: firstRoot,
-    tags: [
-      session.authority(authority),
-      session.record(sessionRecord("session-a", authority)),
-      session.clock({ now: () => "2026-07-14T00:00:00.000Z" }),
-    ],
+  const first = firstScope.createContext({ parent: firstRoot })
+  const secondBundle = sessionKit({
+    id: "session-b",
+    authority,
+    clock: { now: () => "2026-07-14T00:00:00.000Z" },
   })
-  const secondScope = createScope()
+  const secondScope = createScope({ tags: secondBundle.tags })
   const secondRoot = secondScope.createContext()
-  const second = secondScope.createContext({
-    parent: secondRoot,
-    tags: [
-      session.authority(authority),
-      session.record(sessionRecord("session-b", authority)),
-      session.clock({ now: () => "2026-07-14T00:00:00.000Z" }),
-    ],
-  })
+  const second = secondScope.createContext({ parent: secondRoot })
 
   await expect(first.resolve(session.session)).resolves.toMatchObject({ record: { id: "session-a" } })
   await expect(second.resolve(session.session)).resolves.toMatchObject({ record: { id: "session-b" } })
@@ -93,49 +96,92 @@ it("creates a new test-owned scope and bound session context at each use site", 
   await secondScope.dispose()
 })
 
-function request() {
-  return {
-    agentName: "test",
+it("executes agent turns with one session test bundle", async () => {
+  const bundle = sessionKit({
+    id: "turn-session",
+    role: {
+      name: "greeter",
+      version: "1",
+      instructions: "Greet the caller.",
+      maxRounds: 1,
+    },
+    respond: (request) => ({
+      events: [{ type: "content_delta", content: "hello" }],
+      result: { content: `reply:${request.messages.at(-1)?.content ?? ""}`, stop: true },
+    }),
+  })
+  const scope = createScope({ tags: bundle.tags })
+  const ctx = scope.createContext()
+  await ctx.resolve(session.session)
+
+  await expect(ctx.exec({
+    flow: session.run,
+    input: {
+      work: { id: "greeter-work", branchId: "main", role: "greeter", policy: "all" },
+      input: { prompt: "hi" },
+    },
+  })).resolves.toMatchObject({
+    role: "greeter",
+    content: "reply:hi",
+    rounds: 1,
+  })
+  await expect(ctx.exec({
+    flow: session.load,
+    input: { id: bundle.record.id },
+  })).resolves.toBe(bundle.record)
+  expect(bundle.store.records.get(bundle.record.id)).toBe(bundle.record)
+  expect(validationStub.id).toBe("test")
+
+  await ctx.close()
+  await scope.dispose()
+})
+
+it("builds minimal session, authority, and model request fixtures", () => {
+  expect(testAuthority()).toMatchObject({
+    tenant: "test",
+    roots: [],
+    permissions: [],
+    tools: [],
+    sandbox: {
+      roots: [],
+      commands: [],
+      write: false,
+      network: false,
+    },
+  })
+  const authority = testAuthority({
+    tenant: "tenant-a",
+    roots: ["/workspace"],
+    sandbox: { roots: ["/workspace"] },
+  })
+
+  expect(authority).toMatchObject({
+    tenant: "tenant-a",
+    roots: ["/workspace"],
+    permissions: [],
+    tools: [],
+    sandbox: {
+      roots: ["/workspace"],
+      commands: [],
+      write: false,
+      network: false,
+    },
+  })
+  expect(initialRecord("session-a", authority, { nextEventSequence: 4 })).toMatchObject({
+    id: "session-a",
+    status: "open",
+    authorityFingerprint: authority.fingerprint,
+    nextEventSequence: 4,
+    branches: [{ id: "main", authority }],
+  })
+  expect(modelRequest({ agentName: "reviewer", round: 2 })).toEqual({
+    agentName: "reviewer",
     instructions: "",
     messages: [],
     tools: [],
     skills: [],
     loadedSkills: [],
     subagents: [],
-    round: 0,
-  }
-}
-
-function sessionRecord(id: string, authority = session.createAuthority({
-  tenant: "tenant-a",
-  roots: [],
-  permissions: [],
-  tools: [],
-  sandbox: { roots: [], commands: [], write: false, network: false },
-})): session.SessionRecord {
-  return Object.freeze({
-    id,
-    version: 0,
-    schemaVersion: 1,
-    status: "open",
-    authorityFingerprint: authority.fingerprint,
-    authorityConstraints: authority,
-    currentBranchId: "main",
-    branches: [{
-      id: "main",
-      version: 0,
-      createdBy: "root",
-      authorityFingerprint: authority.fingerprint,
-      authority,
-      evidence: [],
-    }],
-    work: [],
-    attempts: [],
-    invocations: [],
-    artifacts: [],
-    memory: [],
-    schedules: [],
-    providerContinuations: {},
-    nextEventSequence: 0,
+    round: 2,
   })
-}
+})

--- a/pkg/sdk/test/tests/work-defaults-counterexamples.policy.test.ts
+++ b/pkg/sdk/test/tests/work-defaults-counterexamples.policy.test.ts
@@ -1,0 +1,137 @@
+import { createScope, flow } from "@pumped-fn/lite"
+import * as session from "@pumped-fn/sdk/session"
+import { describe, expect, it } from "vitest"
+import { sessionKit } from "../src/index"
+
+describe("load-bearing work identity and policy", () => {
+  it("shows default all waiting where explicit fail-fast cancels a sibling", async () => {
+    const bundle = sessionKit({ id: "join-policy" })
+    const scope = createScope({ tags: bundle.tags })
+    const ctx = scope.createContext()
+    const runtime = await ctx.resolve(session.session)
+
+    const allParent = runtime.work.admit({ id: "all-parent", role: "parent", policy: "all" })
+    runtime.work.settle(allParent.record.workId, allParent.record.attempt, { status: "completed" })
+    const allFailed = runtime.work.admit({
+      id: "all-failed",
+      parentId: "all-parent",
+      role: "child",
+      policy: "all",
+    })
+    const allSibling = runtime.work.admit({
+      id: "all-sibling",
+      parentId: "all-parent",
+      role: "child",
+      policy: "all",
+    })
+    runtime.work.settle(allFailed.record.workId, allFailed.record.attempt, { status: "failed" })
+    const allPolicy = runtime.record.work.find((value) => value.id === "all-parent")!.policy
+    let allDone = false
+    const allJoin = ctx.exec({
+      flow: session.join,
+      input: { workIds: ["all-failed", "all-sibling"], policy: allPolicy },
+    }).then((value) => {
+      allDone = true
+      return value
+    })
+    await Promise.resolve()
+
+    expect(allDone).toBe(false)
+    expect(allSibling.signal.aborted).toBe(false)
+    runtime.work.settle(allSibling.record.workId, allSibling.record.attempt, { status: "completed" })
+    await expect(allJoin).resolves.toEqual([{ status: "failed" }, { status: "completed" }])
+
+    const fastParent = runtime.work.admit({
+      id: "fast-parent",
+      branchId: "main",
+      role: "parent",
+      policy: "fail-fast",
+    })
+    runtime.work.settle(fastParent.record.workId, fastParent.record.attempt, { status: "completed" })
+    const fastFailed = runtime.work.admit({
+      id: "fast-failed",
+      parentId: "fast-parent",
+      branchId: "main",
+      role: "child",
+      policy: "fail-fast",
+    })
+    const fastSibling = runtime.work.admit({
+      id: "fast-sibling",
+      parentId: "fast-parent",
+      branchId: "main",
+      role: "child",
+      policy: "fail-fast",
+    })
+    fastSibling.signal.addEventListener("abort", () => {
+      runtime.work.settle(fastSibling.record.workId, fastSibling.record.attempt, { status: "cancelled" })
+    }, { once: true })
+    runtime.work.settle(fastFailed.record.workId, fastFailed.record.attempt, { status: "failed" })
+    const fastPolicy = runtime.record.work.find((value) => value.id === "fast-parent")!.policy
+
+    await expect(ctx.exec({
+      flow: session.join,
+      input: { workIds: ["fast-failed", "fast-sibling"], policy: fastPolicy },
+    })).resolves.toEqual([{ status: "failed" }, { status: "cancelled" }])
+    expect(fastSibling.signal.aborted).toBe(true)
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("shows a constant default id collapsing two distinct calls", async () => {
+    const turn = flow({ name: "counterexample.id.turn", factory: (ctx) => ctx.input })
+    const bundle = sessionKit({ id: "id-default", turn })
+    const scope = createScope({ tags: bundle.tags })
+    const ctx = scope.createContext()
+    const runtime = await ctx.resolve(session.session)
+    const defaultId = `${runtime.record.id}:work`
+
+    await expect(ctx.exec({
+      flow: session.run,
+      input: {
+        work: { id: defaultId, branchId: "main", role: "worker", policy: "all" },
+        input: { call: 1 },
+      },
+    })).resolves.toEqual({ call: 1 })
+    await expect(ctx.exec({
+      flow: session.run,
+      input: {
+        work: { id: defaultId, branchId: "main", role: "worker", policy: "all" },
+        input: { call: 2 },
+      },
+    })).rejects.toThrow(`Work ${defaultId} already exists`)
+    expect(runtime.record.work).toMatchObject([{ id: defaultId, status: "completed" }])
+
+    await ctx.close()
+    await scope.dispose()
+  })
+
+  it("shows a default role disagreeing with the selected agent role", async () => {
+    const bundle = sessionKit({
+      id: "role-default",
+      role: { name: "reviewer", version: "1", maxRounds: 1 },
+      respond: { events: [], result: { content: "reviewed", stop: true } },
+    })
+    const scope = createScope({ tags: bundle.tags })
+    const ctx = scope.createContext()
+    const runtime = await ctx.resolve(session.session)
+
+    await expect(ctx.exec({
+      flow: session.run,
+      input: {
+        work: { id: "review", branchId: "main", role: "default-role", policy: "all" },
+        input: { prompt: "Review this." },
+      },
+    })).resolves.toMatchObject({ role: "reviewer", content: "reviewed" })
+    expect(runtime.record.work.find((value) => value.id === "review")).toMatchObject({
+      role: "default-role",
+      status: "completed",
+    })
+    expect(runtime.eventsFor("review").find((value) => value.type === "agent_role_start")).toMatchObject({
+      targetName: "reviewer",
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+})

--- a/pkg/sdk/test/tests/work-defaults-counterexamples.resume.test.ts
+++ b/pkg/sdk/test/tests/work-defaults-counterexamples.resume.test.ts
@@ -1,0 +1,190 @@
+import { createScope, flow, tags, typed } from "@pumped-fn/lite"
+import * as session from "@pumped-fn/sdk/session"
+import { describe, expect, it } from "vitest"
+import { initialRecord, sessionKit, testAuthority } from "../src/index"
+
+function readyRecord(id: string, authority: session.Authority): session.SessionRecord {
+  return initialRecord(id, authority, {
+    work: [{
+      id: "same-work",
+      branchId: "main",
+      role: "worker",
+      status: "ready",
+      policy: "all",
+      attempt: 1,
+      authority,
+    }],
+  })
+}
+
+describe("candidate branch and policy defaults", () => {
+  it("rejects resume after the current branch changes instead of rebinding stored work", async () => {
+    const authority = testAuthority()
+    let runtime!: session.SessionRuntime
+    const wake: session.Wake = flow({
+      name: "counterexample.resume.wake",
+      parse: typed<{ id: string }>(),
+      factory: () => {
+        const work = runtime.record.work.find((value) => value.id === "resumable")!
+        return Object.freeze({ ...work, status: "ready" as const, attempt: work.attempt + 1 })
+      },
+    })
+    const firstBundle = sessionKit({ id: "branch-switch", authority })
+    const firstScope = createScope({ tags: [firstBundle.tags, session.scheduler.wake(wake)] })
+    const first = firstScope.createContext()
+    runtime = await first.resolve(session.session)
+    const creator = runtime.work.admit({
+      id: "branch-creator",
+      branchId: "main",
+      role: "creator",
+      policy: "all",
+    })
+    runtime.work.settle(creator.record.workId, creator.record.attempt, { status: "completed" })
+    const alternate = await first.exec({
+      flow: session.fork,
+      input: { id: "alternate", parentId: "main", workId: "branch-creator", authority: {} },
+    })
+    await first.exec({
+      flow: session.wait,
+      input: {
+        work: { id: "resumable", role: "worker", policy: "all" },
+        intent: {
+          id: "resume",
+          dueAt: "2026-08-05T00:00:00.000Z",
+          priority: 1,
+          expectedSessionVersion: runtime.record.version,
+        },
+      },
+    })
+    await first.exec({ flow: session.wake, input: { id: "resume" } })
+    expect(runtime.record.work.find((value) => value.id === "resumable")).toMatchObject({
+      branchId: "main",
+      policy: "all",
+      status: "ready",
+    })
+    expect(runtime.eventsFor("resumable").find((value) => value.type === "work.admitted")).toMatchObject({
+      branchId: "main",
+    })
+    const switched = Object.freeze({ ...runtime.snapshot("open"), currentBranchId: alternate.id })
+    await first.close()
+    await firstScope.dispose()
+
+    const resumedBundle = sessionKit({ authority, record: switched })
+    const resumedScope = createScope({ tags: resumedBundle.tags })
+    const resumed = resumedScope.createContext()
+    const resumedRuntime = await resumed.resolve(session.session)
+
+    await expect(resumed.exec({
+      flow: session.run,
+      input: {
+        work: { id: "resumable", role: "worker", policy: "all" },
+        input: undefined,
+      },
+    })).rejects.toThrow("Work resumable resume contract changed")
+    expect(resumedRuntime.record.work.find((value) => value.id === "resumable")).toMatchObject({
+      branchId: "main",
+      policy: "all",
+      status: "ready",
+    })
+
+    await resumed.close()
+    await resumedScope.dispose()
+  })
+
+  it("treats defaulted and explicit effective values the same during ready-work dedup", async () => {
+    const authority = testAuthority()
+    const inspect = flow({
+      name: "counterexample.dedup.inspect",
+      deps: { work: tags.required(session.current.work) },
+      factory: (_ctx, { work }) => ({
+        id: work.id,
+        branchId: work.branchId,
+        role: work.role,
+        policy: work.policy,
+        attempt: work.attempt,
+      }),
+    })
+    const defaultBundle = sessionKit({ authority, record: readyRecord("default-resume", authority), turn: inspect })
+    const defaultScope = createScope({ tags: defaultBundle.tags })
+    const defaultCtx = defaultScope.createContext()
+    const defaultRuntime = await defaultCtx.resolve(session.session)
+    const defaulted = await defaultCtx.exec({
+      flow: session.run,
+      input: {
+        work: { id: "same-work", role: "worker", policy: "all" },
+        input: undefined,
+      },
+    })
+
+    const explicitBundle = sessionKit({ authority, record: readyRecord("explicit-resume", authority), turn: inspect })
+    const explicitScope = createScope({ tags: explicitBundle.tags })
+    const explicitCtx = explicitScope.createContext()
+    await explicitCtx.resolve(session.session)
+    const explicit = await explicitCtx.exec({
+      flow: session.run,
+      input: {
+        work: { id: "same-work", branchId: "main", role: "worker", policy: "all" },
+        input: undefined,
+      },
+    })
+
+    expect(defaulted).toEqual(explicit)
+    expect(defaulted).toEqual({
+      id: "same-work",
+      branchId: "main",
+      role: "worker",
+      policy: "all",
+      attempt: 1,
+    })
+
+    await defaultCtx.close()
+    await defaultScope.dispose()
+    await explicitCtx.close()
+    await explicitScope.dispose()
+  })
+
+  it("keeps defaulted effective values inside the wake boundary", async () => {
+    let runtime!: session.SessionRuntime
+    const wake: session.Wake = flow({
+      name: "counterexample.wake.changed-branch",
+      parse: typed<{ id: string }>(),
+      factory: () => {
+        const work = runtime.record.work.find((value) => value.id === "waiting")!
+        return Object.freeze({
+          ...work,
+          branchId: "changed-by-scheduler",
+          status: "ready" as const,
+          attempt: work.attempt + 1,
+        })
+      },
+    })
+    const bundle = sessionKit({ id: "wake-boundary" })
+    const scope = createScope({ tags: [bundle.tags, session.scheduler.wake(wake)] })
+    const ctx = scope.createContext()
+    runtime = await ctx.resolve(session.session)
+    await ctx.exec({
+      flow: session.wait,
+      input: {
+        work: { id: "waiting", role: "worker", policy: "all" },
+        intent: {
+          id: "wake",
+          dueAt: "2026-08-05T00:00:00.000Z",
+          priority: 1,
+          expectedSessionVersion: runtime.record.version,
+        },
+      },
+    })
+
+    await expect(ctx.exec({ flow: session.wake, input: { id: "wake" } })).rejects.toThrow(
+      "scheduler.wake boundary",
+    )
+    expect(runtime.record.work.find((value) => value.id === "waiting")).toMatchObject({
+      branchId: "main",
+      policy: "all",
+      status: "waiting",
+    })
+
+    await ctx.close()
+    await scope.dispose()
+  })
+})

--- a/research/work-input-null.md
+++ b/research/work-input-null.md
@@ -1,0 +1,57 @@
+# Work input null hypothesis
+
+H0 says every required `AdmitWorkInput` field is load-bearing and cannot be defaulted without losing traceability or fail-closed behavior.
+
+The tests call the current public defaults directly:
+
+- `branchId = record.currentBranchId`
+- `policy = "all"`
+
+Only public tags, flows, records, and the `createScope` seam are used.
+
+## Findings
+
+### Resume identity
+
+A work item is admitted on `main`, parked, and woken to `ready`. The persisted record is then reopened with `currentBranchId` set to `alternate`. Reapplying the candidate default resolves the resumed input to `alternate`.
+
+The runtime compares that effective value with the stored `main` value and throws `Work resumable resume contract changed`. It does not rebind the work. The stored work and its admission event remain on `main`.
+
+This default survives if it is resolved before every admission and the effective branch is stored.
+
+### Dedup and idempotence
+
+A ready work item resumed with omitted candidate fields behaves exactly like one resumed with explicit `branchId: "main"` and `policy: "all"`. Comparison is based on effective values once defaults are resolved.
+
+An `id` default does not have an equivalent safe rule. A stable constant collapses two distinct calls into one identity and the second call fails as a duplicate. Generating a fresh value has the opposite problem: a retry no longer deduplicates. The generic input does not provide a stable, universal identity key.
+
+### Join and fail-fast
+
+`session.join` currently has its own required policy. It does not read `WorkRecord.policy` automatically.
+
+The test models an orchestrator that carries its parent work policy into `session.join`. A defaulted `all` policy leaves a sibling running after another child fails. The join remains pending until that sibling completes. An explicit `fail-fast` policy aborts the sibling and returns failed plus cancelled settlements.
+
+The observable behavior is different. Defaulting to `all` silently chooses continued execution when the caller omitted a failure policy.
+
+### Role attribution
+
+The selected agent can be `reviewer` while a defaulted work role is stored as `default-role`. The result and agent event say `reviewer`; the durable work record says `default-role`.
+
+`session.run` can select arbitrary turn flows, so there is no universal role value to derive from the turn.
+
+### Wake, continuations, and events
+
+The wake boundary compares the stored effective branch and policy. A scheduler that changes the defaulted branch is rejected and the work stays waiting. This supports the branch default rather than H0.
+
+Provider continuations have no dependency on these four work fields, so they add no counterexample. Admission events record the effective branch. They do not record whether it was explicit or defaulted, but they do preserve where execution occurred.
+
+## Verdict
+
+| Field | Verdict | Invariant |
+|---|---|---|
+| `id` | default-unsafe | Stable work identity, retry deduplication, and idempotence require caller intent. |
+| `branchId` | default-safe | Resolving `record.currentBranchId` at admission, storing it, and comparing it on resume preserves branch lineage and fails closed after a branch switch. |
+| `role` | default-unsafe | A guessed role can disagree with the selected turn and corrupt durable attribution. |
+| `policy` | default-unsafe | `"all"` silently replaces a missing failure decision and can keep siblings running where fail-fast cancellation was required. |
+
+H0 is not fully upheld. Three fields remain load-bearing. The proposed `branchId` rule survived the tested resume, dedup, event, and wake boundaries.


### PR DESCRIPTION
## Why

A userland-DX review of `pkg/sdk` surfaced two piles: real correctness bugs in the public surface, and ceremony/naming friction that makes the SDK feel harder than it is. This PR lands both.

## Correctness fixes

| Bug | Fix |
|---|---|
| MCP advertised tool schemas erased to `{}` by a `z.unknown()` wrapper | Pass the real Zod shape; clients and models see property types/descriptions (`pkg/sdk/mcp/src/index.ts`) |
| Codex ACP auto-granted permissions matched on the agent-controlled, spoofable `title` | Grant only on the stable `kind` discriminator (`pkg/sdk/codex/src/index.ts`) |
| One aborted/timed-out Claude prompt permanently poisoned the session | Abort sends the in-band stream-JSON `control_request` interrupt; session stays usable (`pkg/sdk/claude/src/index.ts`) |
| `ClaudeConfig.isolate` typed but always threw | Removed |
| Malformed model output silently ended the turn as success | Typed `ModelResponseParseError`; balanced-brace JSON extraction (`pkg/sdk/core/src/index.ts`) |
| `runCli` hung forever if cleanup rejected; `exitCode: number \| null` implied inspectable failures that actually throw | Always settles; `CliResult.exitCode: 0`, failures expose `CliFailureResult` via `CliWorkerError.result` |
| Sandbox validated `timeoutMs`/`maxOutputBytes` but enforced nothing | SDK enforces timeout + UTF-8-safe output truncation; `network` duty documented on the run binding (`pkg/sdk/core/src/sandbox.ts`) |
| Pi errors stuffed tool/argument names into `provider`/`modelId` | Real provider/model values |

## Test ergonomics (`@pumped-fn/sdk-test`)

- `initialRecord`, `testAuthority` (deny-all defaults), `modelRequest` — replace the hand-copied 25-line `SessionRecord` literal, full authority object, and 8-field request every consumer wrote.
- `sessionKit()` — one call returns the nine session/agent tags to exec real `session.run` → `agent.turn` against stubs; every piece overridable, scope stays the seam.
- `validationStub` — replaces per-repo `validation.standard({id:"test", toJsonSchema: () => true})` copies.

An agent-turn test drops from ~40-60 setup lines to ~10.

## Naming and API consistency (breaking; pre-release packages)

- `Runtime` merged into `WorkflowContext` (tag `workflow.context`); only `SuspendSignal` exported; `sandbox.ExecEvent` → `sandbox.CommandOutputEvent`.
- Removed ceremony: `judge()` identity fn, `formatStepKey` alias, claude's one-legal-value `permission: "deny"` field.
- One auth shape `auth: {kind, env?}` across claude/codex/pi (pi's flat `apiKeyEnv` gone); claude `engine` → `spawnProcess`, bash `engine` → `interpreter`; codex barrel aliases now match the CLI flavor its README demonstrates; `additionalDirectories` → `roots`; bash errors gain the `Bash` prefix.
- Core README gains a runnable minimal setup (required `validation.engine` + `session.*` bindings), root-export table, and extension-ordering docs; adapter READMEs carry migration tables.

## Verification

All suites green: core 91, claude 21+1s, codex 42+2s, pi 10+1s, mcp 9, bash 8, sdk-test 16, framework 67, issue-triage 53. Typecheck and build pass for every touched package. Root README diagram unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)