### PR TITLE
fix(scheduler): make timer-driven tests wait on the condition, not the clock

### DIFF
--- a/.changeset/no-release-scheduler-test-timing.md
+++ b/.changeset/no-release-scheduler-test-timing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test timing and contributor documentation only. `pkg/ext/scheduler` ships no source change, so no package needs a release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,9 +24,20 @@ No:
 ## Testing Rule
 The scope is the single seam: given only `createScope({presets, tags, extensions})` + the public API, all logic is testable. Inside-out vs outside-in = same seam, different radius (preset a unit's deps vs preset only edge adapters). A test needing more than a scope (global patches, module mocks, internal reaches) means the design leaked — fix the design. Sole exception: an adapter atom's own unit test may fake the global it wraps (below the seam).
 
+## Change Safety
+- Adding or changing a failure mode obliges you to enumerate every caller before merging. A function that could not throw and now throws, or a lifecycle that ended and now continues, silently invalidates the assumptions its callers were written under. Passing tests do not cover this; the call sites do.
+- Release order is implement, review the diff by reading, adversarial pass, verify each finding independently, then release. Adversarial findings are evidence, never authority — treat a clean report and an alarming one with equal suspicion, and reproduce a finding before it changes a decision.
+- A test may never assert a guarantee the release does not ship, and a test fake must behave like the real dependency. A fake that ignores a signal the real process honors will prove a fix that does not work.
+- Gates either block or they do not. A gate that fails for reasons unrelated to the change trains everyone to re-run it, and eventually someone re-runs past a real failure. Poll for a condition instead of sleeping a fixed interval in timing-dependent tests.
+
+## Release Policy
+- Defect fixes ship on the current line. Renames and consistency changes batch into a major consumers opt into. Never make a consumer accept a breaking migration to receive a correctness or security fix.
+- Raising a peer floor is breaking. Requiring a newer peer forces a major even when the change itself reads as additive.
+
 ## PR Checklist
 - `README.md` diagram reflects changes
 - PR has docs, slop-free
+- If a public example avoids a helper this repo ships, the helper is wrong — fix the helper, not the example
 
 ## Lite Main Adoption Ledger
 

--- a/pkg/ext/scheduler/tests/in-process.test.ts
+++ b/pkg/ext/scheduler/tests/in-process.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest"
 import { scheduler } from "../src"
 
+async function until(predicate: () => boolean, budgetMs: number): Promise<void> {
+  const deadline = Date.now() + budgetMs
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
+}
+
 function gate(): { promise: Promise<void>; resolve: () => void } {
   let resolve!: () => void
   const promise = new Promise<void>((r) => {
@@ -109,7 +116,7 @@ describe("inProcess backend", () => {
       }
     )
 
-    await new Promise((r) => setTimeout(r, 50))
+    await until(() => seen.length > 0, 5000)
     await registration.stop()
 
     expect(seen.length).toBeGreaterThan(0)
@@ -125,11 +132,11 @@ describe("inProcess backend", () => {
       }
     )
 
-    await new Promise((r) => setTimeout(r, 1100))
+    await until(() => seen.length > 0, 8000)
     await registration.stop()
 
     expect(seen.length).toBeGreaterThan(0)
-  }, 3000)
+  }, 12000)
 
   it("throws for a non-numeric every cadence", () => {
     const backend = scheduler.inProcess()


### PR DESCRIPTION
Closes #363.

## The failure

`pkg/ext/scheduler` gates on 100% function coverage. Its publish run failed with:

```
ERROR: Coverage for functions (95.83%) does not meet global threshold (100%)
```

95.83% is exactly 23 of 24 functions — one function never ran.

## Which one, and why

I measured it rather than guessed. Four functions are hit exactly once, so losing any single one produces that number. The fragile one is the cron callback at `pkg/ext/scheduler/src/index.ts:133`, reached only by the "fires on its own timer for a cron cadence" test — which gave a `* * * * * *` cadence a fixed 1100ms window. That is ~100ms of slack for a one-second timer. The release workflow runs `pnpm -r --workspace-concurrency=2 test` right after two browser installs, and on a loaded runner that slack is gone: the callback never fires, the function drops to zero hits, and coverage lands on 23/24.

## The fix

Wait on the condition instead of the clock. Both timer tests now poll every 5ms up to a generous budget.

Suite duration is unchanged at ~2.8s, because polling returns the moment the callback fires. Tolerance for a slow runner grows roughly sevenfold. The assertions are untouched, so the tests still prove the scheduler fires on its own timer rather than only via `trigger()`.

Verified: 22 tests pass, `Functions: 100% (24/24)`.

## Also: process rules from this release cycle

4.0.0 shipped three defects, and 4.0.1 corrected them hours later. Every one traced to the same gap — a fix changed a failure mode without auditing the callers written under the old assumption. This adds `Change Safety` and `Release Policy` sections to `AGENTS.md` recording what that cycle taught:

- Enumerate callers when a failure mode changes; passing tests do not cover this, call sites do.
- Adversarial findings are evidence, never authority. A 4.0.1 review returned a confident "do not publish" that was a false positive and would have shipped a regression.
- Never assert a guarantee the release does not ship, and keep fakes faithful to the real dependency — a fake that ignored SIGINT once proved a Claude fix that did not work.
- Gates either block or they do not; one that fails for unrelated reasons trains people to re-run past real failures.
- Ship defect fixes on the current line; batch renames into a major. Never make a consumer take a breaking migration to receive a correctness or security fix.
- Raising a peer floor is breaking, even when the change reads as additive.

Plus a PR-checklist line drawn from the sharpest DX finding of the cycle: if a public example avoids a helper this repo ships, the helper is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)