### PR TITLE
feat(lite): add detached stream execution

### DIFF
--- a/.changeset/lite-detached-stream.md
+++ b/.changeset/lite-detached-stream.md
@@ -1,0 +1,5 @@
+---
+"@pumped-fn/lite": minor
+---
+
+Add `ExecutionContext.execDetachedStream()` for streaming work that must release its caller when an uncooperative generator ignores cancellation. Detached streams inherit context data structurally, preserve normal completion and failure, and contain late settlement after abandonment.

--- a/pkg/core/lite/README.md
+++ b/pkg/core/lite/README.md
@@ -20,7 +20,7 @@ Lite owns the application boundary below framework adapters:
 
 - A `Scope` owns long-lived graph values and their cleanup.
 - An `ExecutionContext` owns one request, job, command, action, or UI boundary.
-- Every execution context exposes one effective `signal`; closing a context aborts and joins its descendants before resource cleanup.
+- Every execution context exposes one effective `signal`; closing a context aborts and joins its structured descendants before resource cleanup. An explicit detached stream is aborted and released without joining its eventual settlement.
 - `atom()` defines scope-owned transports, capabilities, state, derived data, and caches.
 - `flow()` defines execution work with optional typed or parsed input.
 - `resource()` defines execution-context-owned values such as transactions, request loggers, spans, action buffers, and drafts.
@@ -503,6 +503,8 @@ caller asks, so backpressure is inherent and no element is dropped. Each invocat
 
 > **Note:** Breaking out of the loop cancels the invocation — the generator's `finally` runs, resources clean up, and `onClose` observes `{ ok: false, aborted: true }`, distinguishable from success and failure. A transaction resource should roll back on both error and abandonment.
 
+`ctx.execDetachedStream(options)` is the opt-in form for work whose caller must stop waiting even when the generator ignores cancellation. It inherits tags and other context data through the same parent chain as `ctx.execStream`. Natural completion and failure retain normal stream settlement. On consumer return or parent close, Lite rejects `result` with `AbortError`, aborts and closes the child context, severs its parent data link, removes the stream from the parent's joined lifetime, and observes the late generator outcome without forwarding it. Lite-owned timers, subscriptions, current-owned resources, and stream registrations are released by child close; boundary-owned resources keep their normal parent lifetime. Parent close and scope disposal do not wait for the generator's eventual settlement. JavaScript work that ignores the signal can still run, but later graph work sees a closed child context and its rejection is contained.
+
 > **Note:** Reading `stream.result` before iterating throws — a caller that only wants the final output uses `exec`. A non-generator factory whose output is an async iterable fails the execution: returned iterables would outlive their context; yield from a generator flow or use an iterable atom with `resolveStream` instead.
 
 > **Note:** Streaming invocations are visible to extensions as `streaming` on the exec target. The suspense extension refuses to journal them (`replay` throws) until stream replay semantics exist.
@@ -562,6 +564,7 @@ composition roots. See [Observability](../../../docs/observability.md).
 | `scope.run(options)` | Execute one flow, traced function, or named inline dependency operation in a temporary context and close it with the outcome |
 | `scope.runStream(options)` | Stream one generator flow from a temporary context; completion or cancellation closes it |
 | `ctx.execStream(options)` | Consume a generator flow's yields; `result` carries the final output, break cancels |
+| `ctx.execDetachedStream(options)` | Stream an inherited child whose abandonment aborts and closes it without joining late settlement |
 | `ctx.exec(options)` | Execute a child flow or function; optional `signal` joins caller cancellation with context lifetime |
 | `flowHandle.prepare(options)` | Activate a controller child with its tags; `ready` resolves after dependencies and resources, then `exec()` or `execStream()` runs once |
 

--- a/pkg/core/lite/src/scope.ts
+++ b/pkg/core/lite/src/scope.ts
@@ -5,7 +5,7 @@ import { isFlow } from "./flow"
 import { isResource } from "./resource"
 import { isTagged, normalizeTags } from "./tag"
 import { latest, type Latest } from "./latest"
-import { assertNoReturnedStream, consumeScalarResult, isAsyncGenerator, isAsyncGeneratorFunction, isPromiseLike, markStreamingExec, registerStreamingExec, requireAsyncGenerator, streamResultBeforeStartError } from "./streaming"
+import { assertNoReturnedStream, consumeScalarResult, detachedStreamResultBeforeStartError, isAsyncGenerator, isAsyncGeneratorFunction, isPromiseLike, markStreamingExec, registerStreamingExec, requireAsyncGenerator, streamResultBeforeStartError } from "./streaming"
 export { isStreamingExec } from "./streaming"
 
 function isPlainObject(value: object): value is Record<PropertyKey, unknown> {
@@ -84,8 +84,12 @@ class ContextDataImpl implements Lite.ContextData {
   private readonly tagValues = new Map<symbol, unknown[]>()
 
   constructor(
-    private readonly parentData?: Lite.ContextData
+    private parentData?: Lite.ContextData
   ) {}
+
+  detachParent(): void {
+    this.parentData = undefined
+  }
 
   get(key: string | symbol): unknown {
     return this.map.get(key)
@@ -293,6 +297,31 @@ type ExecRuntimeOptions = {
   params: unknown[]
   tags?: Lite.TagInput
   signal?: AbortSignal
+}
+
+class StreamAbandonment {
+  readonly pending: Promise<never>
+  private reject!: (error: unknown) => void
+  private abandoned = false
+  reason: unknown
+
+  constructor() {
+    this.pending = new Promise<never>((_resolve, reject) => {
+      this.reject = reject
+    })
+    this.pending.catch(() => {})
+  }
+
+  abandon(error: unknown): void {
+    if (this.abandoned) return
+    this.abandoned = true
+    this.reason = error
+    this.reject(error)
+  }
+
+  get isAbandoned(): boolean {
+    return this.abandoned
+  }
 }
 
 function assertExecutionContextImpl(ctx: Lite.ExecutionContext): asserts ctx is ExecutionContextImpl {
@@ -2588,7 +2617,7 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
   private readonly _execName: string | undefined
   private readonly _flowName: string | undefined
   private readonly boundary: boolean
-  readonly parent: Lite.ExecutionContext | undefined
+  parent: Lite.ExecutionContext | undefined
 
   constructor(
     readonly scope: ScopeImpl,
@@ -2599,6 +2628,7 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
       flowName?: string
       boundary?: boolean
       signal?: AbortSignal
+      detached?: boolean
     }
   ) {
     this.parent = options?.parent
@@ -2607,7 +2637,7 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
     this._flowName = options?.flowName
     this.boundary = options?.boundary ?? true
     if (this.parent) assertExecutionContextImpl(this.parent)
-    this.baselineMode = options?.signal !== undefined || (this.parent?.baselineMode ?? false)
+    this.baselineMode = options?.detached === true || options?.signal !== undefined || (this.parent?.baselineMode ?? false)
     if (this.baselineMode) {
       this.abortController = new AbortController()
       const signals = [this.abortController.signal]
@@ -2615,7 +2645,7 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
       if (options?.signal) signals.push(options.signal)
       this.signalOverride = signals.length === 1 ? signals[0]! : combineAbortSignals(signals)
     }
-    if (this.parent) {
+    if (this.parent && options?.detached !== true) {
       this.parent.children ??= new Set()
       this.parent.children.add(this)
       if (!this.baselineMode && this.parent.abortReason !== pendingAbort) {
@@ -2655,6 +2685,11 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
 
   appendTagValue(key: symbol, value: unknown): void {
     this.dataImpl().appendTagValue(key, value)
+  }
+
+  detachParent(): void {
+    this._data?.detachParent()
+    this.parent = undefined
   }
 
   assertOpen(): void {
@@ -2804,6 +2839,7 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
       get data() { return owner.data },
       exec: owner.exec.bind(owner) as Lite.ResourceContext["exec"],
       execStream: owner.execStream.bind(owner) as Lite.ResourceContext["execStream"],
+      execDetachedStream: owner.execDetachedStream.bind(owner) as Lite.ResourceContext["execDetachedStream"],
       resolve: owner.resolve.bind(owner) as Lite.ResourceContext["resolve"],
       release: owner.release.bind(owner) as Lite.ResourceContext["release"],
       controller: owner.controller.bind(owner),
@@ -2989,6 +3025,84 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
     } as Lite.FlowStream<unknown, unknown>
   }
 
+  execDetachedStream<Output, Yield, Input>(options: Lite.ExecFlowOptions<Output, Input, Yield>): Lite.FlowStream<Yield, Output>
+  execDetachedStream(options: ExecFlowRuntimeOptions): Lite.FlowStream<unknown, unknown>
+  execDetachedStream(options: ExecFlowRuntimeOptions): Lite.FlowStream<unknown, unknown> {
+    this.assertOpen()
+
+    let consumed = false
+    let started = false
+    let settleResult: (value: unknown) => void
+    let failResult: (error: unknown) => void
+    const result = new Promise<unknown>((resolve, reject) => {
+      settleResult = resolve
+      failResult = reject
+    })
+    result.catch(() => {})
+    const owner = this
+
+    return {
+      get result() {
+        if (!started) throw detachedStreamResultBeforeStartError()
+        return result
+      },
+      [Symbol.asyncIterator]() {
+        if (consumed) throw new Error("execDetachedStream() results can be consumed only once.")
+        consumed = true
+        const abandonment = new StreamAbandonment()
+        const iterator = owner.iterateExecStream(
+          { ...options, tags: normalizeTags(options.tags) },
+          result,
+          settleResult!,
+          failResult!,
+          () => { started = true },
+          abandonment,
+        )
+        let active = true
+        const detached: AsyncIterator<unknown, unknown, unknown> = {
+          async next(value?: unknown) {
+            try {
+              const step = await Promise.race([iterator.next(value), abandonment.pending])
+              if (step.done) {
+                active = false
+                owner.activeIterators?.delete(detached)
+              }
+              return step
+            } catch (error) {
+              active = false
+              owner.activeIterators?.delete(detached)
+              throw error
+            }
+          },
+          async return(value?: unknown) {
+            if (!active) return { done: true, value }
+            active = false
+            owner.activeIterators?.delete(detached)
+            const error = new DOMException("Detached flow stream abandoned", "AbortError")
+            abandonment.abandon(error)
+            failResult!(error)
+            void iterator.return?.(value).catch(() => {})
+            return { done: true, value }
+          },
+          async throw(error?: unknown) {
+            if (active) {
+              active = false
+              owner.activeIterators?.delete(detached)
+              abandonment.abandon(error)
+              failResult!(error)
+              if (iterator.throw) void iterator.throw(error).catch(() => {})
+              else void iterator.return?.(undefined).catch(() => {})
+            }
+            throw error
+          },
+        }
+        owner.activeIterators ??= new Set()
+        owner.activeIterators.add(detached)
+        return detached
+      },
+    } as Lite.FlowStream<unknown, unknown>
+  }
+
   private seedTags(
     childCtx: ExecutionContextImpl,
     inputTags?: Lite.TagInput,
@@ -3018,7 +3132,11 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
     }
   }
 
-  private createChildInvocation(options: ExecFlowRuntimeOptions): MaybePromise<{
+  private createChildInvocation(
+    options: ExecFlowRuntimeOptions,
+    detached = false,
+    abandonment?: StreamAbandonment,
+  ): MaybePromise<{
     flow: Lite.Flow<unknown, unknown, any, unknown>
     presetValue: unknown
     childCtx: ExecutionContextImpl
@@ -3028,17 +3146,19 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
     const { flow, input, rawInput, name: execName, tags: execTags, blockedTags } = options
     const presetValue = this.scope.getFlowPreset(flow)
     if (presetValue !== undefined && isFlow(presetValue)) {
-      return this.createChildInvocation({ ...options, flow: presetValue })
+      return this.createChildInvocation({ ...options, flow: presetValue }, detached, abandonment)
     }
 
     const finish = (parsedInput: unknown) => {
+      if (abandonment?.isAbandoned) throw abandonment.reason
       const childCtx = new ExecutionContextImpl(this.scope, {
         parent: this,
         input: parsedInput,
         execName,
         flowName: flow.name,
         boundary: false,
-        signal: options.signal
+        signal: options.signal,
+        detached,
       })
 
       this.seedTags(childCtx, execTags, flow.tags, blockedTags)
@@ -3082,14 +3202,18 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
     result: Promise<unknown>,
     settleResult: (value: unknown) => void,
     failResult: (error: unknown) => void,
-    start: () => void
+    start: () => void,
+    abandonment?: StreamAbandonment,
   ): AsyncGenerator<unknown, unknown, unknown> {
     start()
     let invocation: Awaited<ReturnType<ExecutionContextImpl["createChildInvocation"]>>
     try {
-      invocation = await this.createChildInvocation(options)
+      const created = this.createChildInvocation(options, abandonment !== undefined, abandonment)
+      invocation = abandonment
+        ? await Promise.race([created, abandonment.pending])
+        : await created
     } catch (error) {
-      failResult(error)
+      if (!abandonment?.isAbandoned) failResult(error)
       throw error
     }
 
@@ -3103,7 +3227,6 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
     })
     raw.catch(() => {})
     let iterator: AsyncGenerator<unknown, unknown, unknown> | undefined
-    let abortError: Error | undefined
     let resolveSetup!: (value: IteratorReturnResult<unknown> | undefined) => void
     let rejectSetup!: (error: unknown) => void
     const setup = new Promise<IteratorReturnResult<unknown> | undefined>((resolve, reject) => {
@@ -3135,24 +3258,46 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
       }
     })()
 
+    const abandon = abandonment
+      ? (error: unknown) => {
+          childCtx.abort(error)
+          childCtx.detachParent()
+          const active = iterator
+          iterator = undefined
+          failRaw!(error)
+          unregisterStreaming()
+          if (active) void active.return?.(undefined).catch(() => {})
+          void childCtx.close({ ok: false, error }).catch(() => {})
+        }
+      : undefined
+
     try {
-      const shortCircuit = await setup
+      const shortCircuit = abandonment
+        ? await Promise.race([setup, abandonment.pending])
+        : await setup
       if (shortCircuit) {
+        if (abandonment) return await Promise.race([result, abandonment.pending])
         await result
         return shortCircuit.value
       }
 
       for (;;) {
-        const step = await iterator!.next()
+        const step = abandonment
+          ? await Promise.race([iterator!.next(), abandonment.pending])
+          : await iterator!.next()
         if (step.done) {
           settleRaw!(step.value)
-          await result
+          const value = await result
           iterator = undefined
-          return step.value
+          return abandonment ? value : step.value
         }
         yield step.value
       }
     } catch (error) {
+      if (abandonment?.isAbandoned) {
+        abandon!(abandonment.reason)
+        throw abandonment.reason
+      }
       if (iterator) {
         iterator = undefined
         failRaw!(error)
@@ -3161,12 +3306,21 @@ class ExecutionContextImpl implements Lite.ExecutionContext {
       throw error
     } finally {
       if (iterator) {
-        abortError = new DOMException("Flow stream aborted", "AbortError")
-        childCtx.abort(abortError)
+        const error = abandonment?.isAbandoned
+          ? abandonment.reason
+          : new DOMException(
+              abandonment ? "Detached flow stream abandoned" : "Flow stream aborted",
+              "AbortError",
+            )
+        if (abandonment) {
+          abandon!(error)
+          return
+        }
+        childCtx.abort(error)
         try {
           await iterator.return?.(undefined)
         } catch {}
-        failRaw!(abortError)
+        failRaw!(error)
         await result.catch(() => {})
       }
     }

--- a/pkg/core/lite/src/streaming.ts
+++ b/pkg/core/lite/src/streaming.ts
@@ -56,6 +56,10 @@ export function streamResultBeforeStartError(): Error {
   return new Error("execStream()/runStream().result is unavailable before iteration begins; use exec() to drain from a context or run() from a scope.")
 }
 
+export function detachedStreamResultBeforeStartError(): Error {
+  return new Error("execDetachedStream().result is unavailable before iteration begins; start iteration before reading the result.")
+}
+
 const streamingExecSymbol = Symbol("pumped-fn.streamingExec")
 const streamingExecTargets = new WeakSet<object>()
 

--- a/pkg/core/lite/src/types.ts
+++ b/pkg/core/lite/src/types.ts
@@ -282,6 +282,11 @@ export namespace Lite {
       Result,
     >(options: ExecDepsOptions<D, Args, Result>): Promise<Awaited<Result>>
     execStream<Output, Yield, Input>(options: ExecFlowOptions<Output, Input, Yield>): FlowStream<Yield, Output>
+    /**
+     * Executes a streaming child with inherited context data without joining its eventual settlement.
+     * Abandonment aborts and closes the child while late yields and settlement are ignored.
+     */
+    execDetachedStream<Output, Yield, Input>(options: ExecFlowOptions<Output, Input, Yield>): FlowStream<Yield, Output>
     changes<T>(atom: Atom<T>): AsyncIterable<T>
     changes<T>(atom: Atom<T>, options: ChangesOptions): AsyncIterable<AtomChange<T>>
     changes<T>(handle: SelectHandle<T>): AsyncIterable<T>

--- a/pkg/core/lite/tests/exec-stream.test.ts
+++ b/pkg/core/lite/tests/exec-stream.test.ts
@@ -8,6 +8,20 @@ async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
   return values
 }
 
+async function promptly<T>(pending: Promise<T>, message: string): Promise<T> {
+  let timer!: ReturnType<typeof setTimeout>
+  try {
+    return await Promise.race([
+      pending,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(reject, 250, new Error(message))
+      }),
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
 describe("ctx.execStream()", () => {
   it("types generator flow streams", async () => {
     const read = flow({
@@ -20,13 +34,17 @@ describe("ctx.execStream()", () => {
     const scope = createScope()
     const ctx = scope.createContext()
     const stream = ctx.execStream({ flow: read, input: { id: "abc" } })
+    const detached = ctx.execDetachedStream({ flow: read, input: { id: "detached" } })
     const execResult = ctx.exec({ flow: read, input: { id: "abc" } })
 
     expectTypeOf(stream).toEqualTypeOf<Lite.FlowStream<number, { id: string }>>()
+    expectTypeOf(detached).toEqualTypeOf<Lite.FlowStream<number, { id: string }>>()
     expect(await collect(stream)).toEqual([3])
+    expect(await collect(detached)).toEqual([8])
     expectTypeOf(stream.result).toEqualTypeOf<Promise<{ id: string }>>()
     expectTypeOf(execResult).toEqualTypeOf<Promise<{ id: string }>>()
     await expect(stream.result).resolves.toEqual({ id: "abc" })
+    await expect(detached.result).resolves.toEqual({ id: "detached" })
     await expect(execResult).resolves.toEqual({ id: "abc" })
 
     await ctx.close()
@@ -176,6 +194,152 @@ describe("ctx.execStream()", () => {
     expect(starts).toBe(1)
     expect(closes[0]).toMatchObject({ ok: false, aborted: true })
     await ctx.close()
+    await scope.dispose()
+  })
+
+  it("abandons a detached child without joining its late settlement", async () => {
+    const events: string[] = []
+    const closes: Lite.CloseResult[] = []
+    const contextMarker = tag<string>({ label: "detached-marker" })
+    const late = resource({ factory: () => "late" })
+    let release!: () => void
+    let finishLate!: () => void
+    let finishCleanup!: () => void
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const lateFinished = new Promise<void>((resolve) => {
+      finishLate = resolve
+    })
+    const cleanupFinished = new Promise<void>((resolve) => {
+      finishCleanup = resolve
+    })
+    const lease = resource({
+      ownership: "current",
+      factory: (ctx) => {
+        ctx.cleanup(() => {
+          events.push("release")
+          finishCleanup()
+        })
+        return "lease"
+      },
+    })
+    let signal: AbortSignal | undefined
+    let lateMarker: string | undefined
+    let lateParent: Lite.ExecutionContext | undefined
+    const read = flow({
+      deps: { lease, marker: tags.required(contextMarker) },
+      factory: async function* (ctx, { lease, marker }) {
+        signal = ctx.signal
+        const timer = setTimeout(() => events.push("timer"), 10_000)
+        ctx.onClose((result, target) => {
+          clearTimeout(target)
+          closes.push(result)
+          events.push("close")
+        }, timer)
+        try {
+          yield `${marker}:${lease}`
+          await held
+          lateMarker = ctx.data.seekTag(contextMarker)
+          lateParent = ctx.parent
+          await ctx.resolve(late)
+          yield "late"
+          return "done"
+        } finally {
+          finishLate()
+        }
+      },
+    })
+    const scope = createScope()
+    const ctx = scope.createContext({ tags: [contextMarker("inherited")] })
+    const stream = ctx.execDetachedStream({ flow: read })
+    const iterator = stream[Symbol.asyncIterator]()
+
+    expectTypeOf(stream).toEqualTypeOf<Lite.FlowStream<string, string>>()
+    expect(await iterator.next()).toEqual({ done: false, value: "inherited:lease" })
+    const pending = iterator.next()
+    await expect(promptly(ctx.close(), "parent close waited")).resolves.toBeUndefined()
+    expect(signal?.aborted).toBe(true)
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" })
+    await expect(stream.result).rejects.toMatchObject({ name: "AbortError" })
+    await expect(promptly(cleanupFinished, "cleanup waited")).resolves.toBeUndefined()
+    expect(events).toEqual(["close", "release"])
+    expect(closes).toMatchObject([{ ok: false, aborted: true }])
+    await expect(promptly(scope.dispose(), "scope disposal waited")).resolves.toBeUndefined()
+
+    release()
+    await lateFinished
+    expect(lateMarker).toBeUndefined()
+    expect(lateParent).toBeUndefined()
+    expect(events).toEqual(["close", "release"])
+  })
+
+  it("returns promptly when a detached stream consumer abandons an uncooperative generator", async () => {
+    let release!: () => void
+    let finish!: () => void
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve
+    })
+    const read = flow({
+      factory: async function* () {
+        try {
+          yield "ready"
+          await held
+          yield "late"
+          return "done"
+        } finally {
+          finish()
+        }
+      },
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const stream = ctx.execDetachedStream({ flow: read })
+    const iterator = stream[Symbol.asyncIterator]()
+
+    expect(await iterator.next()).toEqual({ done: false, value: "ready" })
+    await expect(promptly(iterator.return!(undefined), "consumer return waited")).resolves.toEqual({ done: true, value: undefined })
+    await expect(stream.result).rejects.toMatchObject({ name: "AbortError" })
+    await expect(promptly(ctx.close(), "parent close waited")).resolves.toBeUndefined()
+    await expect(promptly(scope.dispose(), "scope disposal waited")).resolves.toBeUndefined()
+
+    release()
+    await finished
+  })
+
+  it("does not create a detached child after abandonment during async input parsing", async () => {
+    let finishParse!: () => void
+    const parsed = new Promise<void>((resolve) => {
+      finishParse = resolve
+    })
+    let factories = 0
+    const read = flow({
+      parse: async (raw: unknown) => {
+        await parsed
+        return String(raw)
+      },
+      factory: async function* () {
+        factories++
+        yield "late"
+        return "done"
+      },
+    })
+    const scope = createScope()
+    const ctx = scope.createContext()
+    const stream = ctx.execDetachedStream({ flow: read, rawInput: "input" })
+    const iterator = stream[Symbol.asyncIterator]()
+    const pending = iterator.next()
+
+    await expect(promptly(ctx.close(), "parent close waited for parsing")).resolves.toBeUndefined()
+    await expect(pending).rejects.toMatchObject({ name: "AbortError" })
+    await expect(stream.result).rejects.toMatchObject({ name: "AbortError" })
+    finishParse()
+    await parsed
+    await Promise.resolve()
+    expect(factories).toBe(0)
     await scope.dispose()
   })
 


### PR DESCRIPTION
## Why

A caller sometimes must stop waiting even when a streaming integration ignores cancellation. Normal execStream correctly uses structured lifetime and waits for settlement; this adds an explicit opt-in escape hatch without changing that default.

## What changed

- Adds ExecutionContext.execDetachedStream().
- Inherits tags and context data through the existing parent chain; there is no tag allow-list.
- Natural completion and failure keep normal stream behavior.
- Consumer return or parent close aborts and closes the child, severs the parent data link, rejects result with AbortError, and contains late settlement.
- Boundary-owned resources keep their normal parent lifetime; current-owned resources close with the child.
- Shares the existing stream engine instead of shipping a second copy.

## Release

- @pumped-fn/lite: minor (6.3.0)
- No SDK adoption or peer-floor change in this PR.

## Verification

- Lite: 256 tests
- Full workspace tests
- Full workspace typecheck and test typecheck
- Chromium: 70 tests
- Lightpanda: 1 test
- Packed Lite consumer check
- Lint
- Changeset and release policy

## Size

Lite ESM: 55.75 KB -> 57.82 KB raw; 15.23 KB -> 15.71 KB gzip. The shared engine removed about 0.85 KB raw from the preserved implementation.