### PR TITLE
ci: keep unrelated browser checks out of release gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,9 +66,6 @@ jobs:
           free -h
           ps -eo pid,ppid,stat,etime,%cpu,%mem,wchan:32,comm --sort=-%cpu
 
-      - name: Run comparison browser smoke
-        run: pnpm -F @pumped-fn/compare browser:smoke
-
       - name: Run Lightpanda browser tests
         run: pnpm -F @pumped-fn/lite-react test:browser:lightpanda
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,23 +115,32 @@ jobs:
 
       - name: Verify published registry metadata
         if: steps.changesets.outputs.published == 'true'
+        timeout-minutes: 5
         env:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           node --input-type=module <<'NODE'
-          import { spawnSync } from 'node:child_process'
+          import { execFile } from 'node:child_process'
+          import { promisify } from 'node:util'
           import { setTimeout as delay } from 'node:timers/promises'
 
+          const run = promisify(execFile)
           const packages = JSON.parse(process.env.PUBLISHED_PACKAGES)
           const waitForVersion = async ({ name, version }) => {
             const target = `${name}@${version}`
             const deadline = Date.now() + 120_000
+            let reason = 'no attempt completed'
             while (Date.now() < deadline) {
-              const result = spawnSync('npm', ['view', target, 'version', '--json'], { encoding: 'utf8' })
-              if (result.status === 0 && JSON.parse(result.stdout) === version) return
+              try {
+                const { stdout } = await run('npm', ['view', target, 'version', '--json'], { timeout: 20_000 })
+                if (JSON.parse(stdout) === version) return
+                reason = `registry reported ${stdout.trim()}`
+              } catch (error) {
+                reason = String(error.stderr || error.message).trim()
+              }
               await delay(2_000)
             }
-            throw new Error(`${target} is not visible in the npm registry`)
+            throw new Error(`${target} is not visible in the npm registry: ${reason}`)
           }
           await Promise.all(packages.map(waitForVersion))
           NODE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,6 @@ jobs:
           free -h
           ps -eo pid,ppid,stat,etime,%cpu,%mem,wchan:32,comm --sort=-%cpu
 
-      - name: Run comparison browser smoke
-        run: pnpm -F @pumped-fn/compare browser:smoke
-
       - name: Run Lightpanda browser tests
         run: pnpm -F @pumped-fn/lite-react test:browser:lightpanda
 
@@ -122,11 +119,19 @@ jobs:
           PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
         run: |
           node --input-type=module <<'NODE'
-          import { execFileSync } from 'node:child_process'
+          import { spawnSync } from 'node:child_process'
+          import { setTimeout as delay } from 'node:timers/promises'
 
           const packages = JSON.parse(process.env.PUBLISHED_PACKAGES)
-          for (const { name, version } of packages) {
-            const actual = JSON.parse(execFileSync('npm', ['view', `${name}@${version}`, 'version', '--json'], { encoding: 'utf8' }))
-            if (actual !== version) throw new Error(`${name}@${version} is not visible in the npm registry`)
+          const waitForVersion = async ({ name, version }) => {
+            const target = `${name}@${version}`
+            const deadline = Date.now() + 120_000
+            while (Date.now() < deadline) {
+              const result = spawnSync('npm', ['view', target, 'version', '--json'], { encoding: 'utf8' })
+              if (result.status === 0 && JSON.parse(result.stdout) === version) return
+              await delay(2_000)
+            }
+            throw new Error(`${target} is not visible in the npm registry`)
           }
+          await Promise.all(packages.map(waitForVersion))
           NODE


### PR DESCRIPTION
## Why

The comparison playground's browser smoke starts a Vite dev server and drives it with Playwright. On PR #365 it failed with `Failed to fetch` on Node 24 while Node 22 passed the same commit, blocking a release. A flaky browser check on a private playground should not be able to stop a package publish.

## Changes

**1. Remove the smoke step from the test and release gates** (`ci.yml`, `release.yml`).

Browser verification stays where it guards something real: `pages-dry-run.yml` runs `pages:stage → pages:verify → pages:browser:smoke`, and `pages-deploy.yml` verifies the published site.

Being precise about the tradeoff, because an adversarial review caught me overstating this earlier: coverage is **not** identical. `pages-dry-run` is path-filtered (`playground/compare/**`, `pkg/core/lite/**`, dependency files) and runs Node 24 only, against a built static site. So this drops Node 22 browser coverage for compare, the Vite dev-server path, and smoke on PRs outside those paths. That is an acceptable trade for a private playground — but it is a trade, not a free win.

**2. Fix the publish verification so it enforces the deadline it advertises.**

The first version of the retry loop used `spawnSync`. Because that blocks the event loop, `Promise.all` could not overlap the package checks and the 120s deadline could not be evaluated while a call was blocked — with npm's own 300s fetch timeout, one stuck request could run the step far past its stated bound *and* stall every other package's polling. This step runs **after** packages are on npm, so a false failure marks a good release as broken.

Now uses promisified `execFile` with a 20s per-attempt timeout plus a step-level `timeout-minutes: 5`. Two smaller defects from the same review: a status-0 response with empty or non-JSON output made `JSON.parse` throw out of the loop and spend the package's only attempt, and npm's stderr was discarded so every failure collapsed to a generic "not visible". Parse failures now retry, and the last npm error is reported.

## Verification

Exercised against a fake npm rather than reasoned about:

| Case | Result |
|---|---|
| status 0 + proxy HTML | retries, reports `Unexpected token '<'` |
| status 0 + empty stdout | retries, reports `Unexpected end of JSON input` |
| 3 packages each hanging 3s | **3.7s** total (serial `spawnSync` needed 9s+) |
| transient failures then success | recovers |

`pnpm actionlint` passes.

## Note

Workflow-only, no packages and no changeset, so merging publishes nothing — the release workflow will find no changesets and skip publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)